### PR TITLE
Fix: return valid setSessionModel response object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.8 (2025-10-15)
+
+- Fix: return valid setSessionModel response object
+
 ## 0.4.7 (2025-10-11)
 
 - New repo: https://github.com/agentclientprotocol/typescript-sdk

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentclientprotocol/sdk",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentclientprotocol/sdk",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentclientprotocol/sdk",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "publishConfig": {
     "access": "public"
   },

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -87,7 +87,8 @@ export class AgentSideConnection {
           }
           const validatedParams =
             schema.setSessionModelRequestSchema.parse(params);
-          return agent.setSessionModel(validatedParams);
+          const result = await agent.setSessionModel(validatedParams);
+          return result ?? {};
         }
         default:
           if (method.startsWith("_")) {


### PR DESCRIPTION
We had a bug where we were returning `null` instead of an empty object,
since `meta` could be returned.
