### PR TITLE
Fix: Correct RPC method call in setSessionModel

### DIFF
--- a/src/acp.ts
+++ b/src/acp.ts
@@ -595,7 +595,7 @@ export class ClientSideConnection implements Agent {
   ): Promise<schema.SetSessionModelResponse> {
     return (
       (await this.#connection.sendRequest(
-        schema.AGENT_METHODS.session_set_mode,
+        schema.AGENT_METHODS.session_set_model,
         params,
       )) ?? {}
     );


### PR DESCRIPTION
  ## Description

  This PR fixes a bug in `ClientSideConnection.setSessionModel()` where it incorrectly calls `session/set_mode` instead of `session/set_model`.

  ### Problem

  The `setSessionModel()` method was calling the wrong RPC method (`session_set_mode`), which caused parameter validation failures because the server expected `modeId` instead of
  `modelId`.

  ### Solution

  Changed line 598 in `src/acp.ts` to call the correct RPC method: `schema.AGENT_METHODS.session_set_model`

  ## Changes

  - **File**: `src/acp.ts`
  - **Line**: 598
  - **Change**: `session_set_mode` → `session_set_model`

  ## Code Diff

  ```diff
    async setSessionModel(
      params: schema.SetSessionModelRequest
    ): Promise<schema.SetSessionModelResponse> {
      return (
        (await this.#connection.sendRequest(
  -       schema.AGENT_METHODS.session_set_mode,
  +       schema.AGENT_METHODS.session_set_model,
          params
        )) ?? {}
      );
    }