### PR TITLE
docs: use npx.cmd on Windows in client example

### DIFF
--- a/src/examples/client.ts
+++ b/src/examples/client.ts
@@ -102,8 +102,9 @@ async function main() {
   const __dirname = dirname(__filename);
   const agentPath = join(__dirname, "agent.ts");
 
-  // Spawn the agent as a subprocess using tsx
-  const agentProcess = spawn("npx", ["tsx", agentPath], {
+  // Spawn the agent as a subprocess via npx (npx.cmd on Windows) using tsx
+  const npxCmd = process.platform === "win32" ? "npx.cmd" : "npx";
+  const agentProcess = spawn(npxCmd, ["tsx", agentPath], {
     stdio: ["pipe", "pipe", "inherit"],
   });
 


### PR DESCRIPTION
When running `src/examples/client.ts` on Windows, meet with below error:
```bash
PS C:\code\typescript-sdk> npx tsx src/examples/client.ts
node:events:497
      throw er; // Unhandled 'error' event
      ^

Error: spawn npx ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:285:19)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
Emitted 'error' event on ChildProcess instance at:
    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {       
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn npx',
  path: 'npx',
  spawnargs: [ 'tsx', 'C:\\code\\typescript-sdk\\src\\examples\\agent.ts' ]
}

Node.js v22.19.0
```


On Windows, `npx` is installed as a batch script wrapper (`npx.cmd`), not a native executable. Node.js `spawn()` without a shell calls the OS directly, which only looks for exact filenames and won't try appending `.cmd` — causing an `ENOENT` error. Using `npx.cmd` explicitly resolves this without the side effects of `shell: true`.