### PR TITLE
fix: propagate input stream errors through ndJsonStream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,43 +31,6 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,43 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",

--- a/src/acp.test.ts
+++ b/src/acp.test.ts
@@ -1053,9 +1053,7 @@ describe("Connection", () => {
 
     errorController.error(new Error("process exited with code 1"));
 
-    await expect(requestPromise).rejects.toThrow(
-      "process exited with code 1",
-    );
+    await expect(requestPromise).rejects.toThrow("process exited with code 1");
   });
 
   it("rejects pending requests when the stream errors", async () => {

--- a/src/acp.test.ts
+++ b/src/acp.test.ts
@@ -1013,6 +1013,51 @@ describe("Connection", () => {
     }
   }
 
+  it("propagates input stream errors through ndJsonStream", async () => {
+    const inputStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        // Simulate a process crash after partial data
+        controller.error(new Error("process exited with code 1"));
+      },
+    });
+    const outputStream = new WritableStream<Uint8Array>();
+
+    const connection = new ClientSideConnection(
+      () => new MinimalTestClient(),
+      ndJsonStream(outputStream, inputStream),
+    );
+
+    await expect(connection.closed).resolves.toBeUndefined();
+    expect(connection.signal.aborted).toBe(true);
+  });
+
+  it("rejects pending requests when input stream errors via ndJsonStream", async () => {
+    let errorController!: ReadableStreamDefaultController<Uint8Array>;
+
+    const inputStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        errorController = controller;
+      },
+    });
+    const outputStream = new WritableStream<Uint8Array>();
+
+    const connection = new ClientSideConnection(
+      () => new MinimalTestClient(),
+      ndJsonStream(outputStream, inputStream),
+    );
+
+    const requestPromise = connection.newSession({
+      cwd: "/test",
+      mcpServers: [],
+    });
+
+    errorController.error(new Error("process exited with code 1"));
+
+    await expect(requestPromise).rejects.toThrow(
+      "process exited with code 1",
+    );
+  });
+
   it("rejects pending requests when the stream errors", async () => {
     let readableController!: ReadableStreamDefaultController<AnyMessage>;
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -63,10 +63,13 @@ export function ndJsonStream(
             }
           }
         }
+      } catch (err) {
+        controller.error(err);
+        return;
       } finally {
         reader.releaseLock();
-        controller.close();
       }
+      controller.close();
     },
   });
 


### PR DESCRIPTION
## Problem

`ndJsonStream` uses `try/finally` to read from the input byte stream. When the input stream errors (e.g. a child process crashes and the `ReadableStream` controller calls `controller.error()`), the `finally` block calls `controller.close()` on the output message stream, swallowing the error. This causes `Connection.#receive()` to see a clean EOF instead of the actual error.

As a result, when a process crashes mid-connection:
- Pending `sendRequest()` calls hang forever (before v0.18.0) or get a generic "ACP connection closed" error (v0.18.0+) instead of the actual crash error
- The `signal.reason` / `closed` promise don't carry the original error

## Fix

Replace `try/finally` with `try/catch/finally`:
- `catch`: calls `controller.error(err)` to propagate the error to the message-level `ReadableStream`, then returns early
- `finally`: always calls `reader.releaseLock()`
- `controller.close()` only runs on the success path (after the try block)

## Tests

Added two tests:
- **propagates input stream errors through ndJsonStream** — verifies the connection closes when the input stream errors immediately
- **rejects pending requests when input stream errors via ndJsonStream** — verifies in-flight requests are rejected with the original error message