### PR TITLE
feat: Experimental Streamable HTTP & WebSocket Transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@eslint/js": "^10.0.1",
         "@hey-api/openapi-ts": "^0.98.0",
         "@types/node": "^25.5.0",
+        "@types/ws": "^8.5.13",
         "@typescript-eslint/eslint-plugin": "^8.57.1",
         "@typescript-eslint/parser": "^8.57.1",
         "concurrently": "^10.0.0",
@@ -25,6 +26,7 @@
         "typedoc-github-theme": "^0.4.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.0",
+        "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0"
       },
       "peerDependencies": {
@@ -1262,6 +1264,16 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.61.0",
@@ -4562,6 +4574,28 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/wsl-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1273,7 +1273,7 @@
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/ws/-/ws-8.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
@@ -4584,7 +4584,7 @@
     },
     "node_modules/ws": {
       "version": "8.20.1",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/ws/-/ws-8.20.1.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,13 @@
         "zod": "^3.25.0 || ^4.0.0"
       },
       "peerDependencies": {
+        "ws": ">=8.0.0",
         "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,13 +30,7 @@
         "zod": "^3.25.0 || ^4.0.0"
       },
       "peerDependencies": {
-        "ws": ">=8.0.0",
         "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        }
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
       "types": "./dist/http-stream.d.ts",
       "default": "./dist/http-stream.js"
     },
+    "./ws-client": {
+      "types": "./dist/ws-stream.d.ts",
+      "default": "./dist/ws-stream.js"
+    },
     "./server": {
       "types": "./dist/server.d.ts",
       "default": "./dist/server.js"
@@ -69,6 +73,7 @@
     "@eslint/js": "^10.0.1",
     "@hey-api/openapi-ts": "^0.98.0",
     "@types/node": "^25.5.0",
+    "@types/ws": "^8.5.13",
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.57.1",
     "concurrently": "^10.0.0",
@@ -82,6 +87,7 @@
     "typedoc-github-theme": "^0.4.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.0",
+    "ws": "^8.18.0",
     "zod": "^3.25.0 || ^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,22 +27,27 @@
   "exports": {
     ".": {
       "types": "./dist/acp.d.ts",
+      "import": "./dist/acp.js",
       "default": "./dist/acp.js"
     },
     "./http-client": {
       "types": "./dist/http-stream.d.ts",
+      "import": "./dist/http-stream.js",
       "default": "./dist/http-stream.js"
     },
     "./ws-client": {
       "types": "./dist/ws-stream.d.ts",
+      "import": "./dist/ws-stream.js",
       "default": "./dist/ws-stream.js"
     },
     "./server": {
       "types": "./dist/server.d.ts",
+      "import": "./dist/server.js",
       "default": "./dist/server.js"
     },
     "./node": {
       "types": "./dist/node-adapter.d.ts",
+      "import": "./dist/node-adapter.js",
       "default": "./dist/node-adapter.js"
     },
     "./schema/schema.json": "./schema/schema.json"
@@ -67,7 +72,13 @@
     "docs:ts:verify": "cd src && typedoc --emit none && echo 'TypeDoc verification passed'"
   },
   "peerDependencies": {
+    "ws": ">=8.0.0",
     "zod": "^3.25.0 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ws": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
       "types": "./dist/acp.d.ts",
       "default": "./dist/acp.js"
     },
+    "./http-client": {
+      "types": "./dist/http-stream.d.ts",
+      "default": "./dist/http-stream.js"
+    },
     "./server": {
       "types": "./dist/server.d.ts",
       "default": "./dist/server.js"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,21 @@
   "type": "module",
   "main": "dist/acp.js",
   "types": "dist/acp.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/acp.d.ts",
+      "default": "./dist/acp.js"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "default": "./dist/server.js"
+    },
+    "./node": {
+      "types": "./dist/node-adapter.d.ts",
+      "default": "./dist/node-adapter.js"
+    },
+    "./schema/schema.json": "./schema/schema.json"
+  },
   "directories": {
     "example": "examples"
   },

--- a/package.json
+++ b/package.json
@@ -72,13 +72,7 @@
     "docs:ts:verify": "cd src && typedoc --emit none && echo 'TypeDoc verification passed'"
   },
   "peerDependencies": {
-    "ws": ">=8.0.0",
     "zod": "^3.25.0 || ^4.0.0"
-  },
-  "peerDependenciesMeta": {
-    "ws": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -30,22 +30,22 @@
       "import": "./dist/acp.js",
       "default": "./dist/acp.js"
     },
-    "./http-client": {
+    "./experimental/http-client": {
       "types": "./dist/http-stream.d.ts",
       "import": "./dist/http-stream.js",
       "default": "./dist/http-stream.js"
     },
-    "./ws-client": {
+    "./experimental/ws-client": {
       "types": "./dist/ws-stream.d.ts",
       "import": "./dist/ws-stream.js",
       "default": "./dist/ws-stream.js"
     },
-    "./server": {
+    "./experimental/server": {
       "types": "./dist/server.d.ts",
       "import": "./dist/server.js",
       "default": "./dist/server.js"
     },
-    "./node": {
+    "./experimental/node": {
       "types": "./dist/node-adapter.d.ts",
       "import": "./dist/node-adapter.js",
       "default": "./dist/node-adapter.js"

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -7,7 +7,11 @@ import {
 import { messageIdKey } from "./protocol.js";
 import { TestAgent } from "./test-support/test-agent.js";
 
-import type { AgentSideConnection } from "./acp.js";
+import type {
+  AgentSideConnection,
+  InitializeRequest,
+  InitializeResponse,
+} from "./acp.js";
 import type { AnyMessage } from "./jsonrpc.js";
 
 const initializeRequest = {
@@ -97,6 +101,27 @@ describe("ConnectionRegistry", () => {
         },
       },
     });
+
+    registry.closeAll();
+  });
+
+  it("cancels a pending initialize reader during shutdown", async () => {
+    const initialize = createDeferred<InitializeResponse>();
+    const registry = new ConnectionRegistry();
+    const connection = registry.createConnection(
+      (conn: AgentSideConnection) =>
+        new DelayedInitializeAgent(conn, initialize.promise),
+    );
+
+    await writeInbound(connection.inboundTx, initializeRequest);
+    const initialResponse = connection.recvInitial(initializeRequest.id);
+    initialResponse.catch(() => undefined);
+
+    await connection.shutdown();
+
+    await expect(withTimeout(initialResponse)).rejects.toThrow(
+      "Expected initialize response from agent",
+    );
 
     registry.closeAll();
   });
@@ -339,6 +364,56 @@ async function readNextOrUndefined(
     ]);
   } finally {
     reader.releaseLock();
+  }
+}
+
+class DelayedInitializeAgent extends TestAgent {
+  constructor(
+    conn: AgentSideConnection,
+    private readonly initializeResponse: Promise<InitializeResponse>,
+  ) {
+    super(conn);
+  }
+
+  initialize(_params: InitializeRequest): Promise<InitializeResponse> {
+    return this.initializeResponse;
+  }
+}
+
+function createDeferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+  readonly reject: (error: unknown) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (error: unknown) => void = () => {};
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs = 100,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error("Timed out waiting for promise"));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
   }
 }
 

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { ConnectionRegistry } from "./connection.js";
+import { TestAgent } from "./test-support/test-agent.js";
+
+import type { AgentSideConnection } from "./acp.js";
+
+const initializeRequest = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: 1,
+    clientCapabilities: {},
+  },
+} as const;
+
+describe("ConnectionRegistry", () => {
+  it("creates retrievable connections with unique UUID connection IDs", () => {
+    const registry = new ConnectionRegistry();
+    const first = registry.createConnection(
+      (conn: AgentSideConnection) => new TestAgent(conn),
+    );
+    const second = registry.createConnection(
+      (conn: AgentSideConnection) => new TestAgent(conn),
+    );
+
+    expect(first.connectionId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(second.connectionId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(first.connectionId).not.toBe(second.connectionId);
+    expect(registry.get(first.connectionId)).toBe(first);
+    expect(registry.get(second.connectionId)).toBe(second);
+
+    registry.closeAll();
+  });
+
+  it("removes connections", () => {
+    const registry = new ConnectionRegistry();
+    const connection = registry.createConnection(
+      (conn: AgentSideConnection) => new TestAgent(conn),
+    );
+
+    expect(registry.remove(connection.connectionId)).toBe(connection);
+    expect(registry.get(connection.connectionId)).toBeUndefined();
+    expect(registry.remove(connection.connectionId)).toBeUndefined();
+  });
+
+  it("receives the initialize response directly from the agent", async () => {
+    const registry = new ConnectionRegistry();
+    const connection = registry.createConnection(
+      (conn: AgentSideConnection) => new TestAgent(conn),
+    );
+    const writer = connection.inboundTx.getWriter();
+
+    try {
+      await writer.write(initializeRequest);
+    } finally {
+      writer.releaseLock();
+    }
+
+    const response = await connection.recvInitial(initializeRequest.id);
+
+    expect(response).toMatchObject({
+      jsonrpc: "2.0",
+      id: initializeRequest.id,
+      result: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: false,
+        },
+      },
+    });
+
+    registry.closeAll();
+  });
+});

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { ConnectionRegistry } from "./connection.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ConnectionRegistry,
+  OutboundStream,
+  type ResponseRoute,
+} from "./connection.js";
+import { messageIdKey } from "./protocol.js";
 import { TestAgent } from "./test-support/test-agent.js";
 
 import type { AgentSideConnection } from "./acp.js";
+import type { AnyMessage } from "./jsonrpc.js";
 
 const initializeRequest = {
   jsonrpc: "2.0",
@@ -13,6 +19,21 @@ const initializeRequest = {
     clientCapabilities: {},
   },
 } as const;
+
+const sessionNewRequest = {
+  jsonrpc: "2.0",
+  id: 2,
+  method: "session/new",
+  params: {
+    cwd: "/tmp",
+    mcpServers: [],
+  },
+} as const;
+
+const messageOne = { jsonrpc: "2.0", id: 1, result: "one" } as const;
+const messageTwo = { jsonrpc: "2.0", id: 2, result: "two" } as const;
+const messageThree = { jsonrpc: "2.0", id: 3, result: "three" } as const;
+const messageFour = { jsonrpc: "2.0", id: 4, result: "four" } as const;
 
 describe("ConnectionRegistry", () => {
   it("creates retrievable connections with unique UUID connection IDs", () => {
@@ -49,13 +70,8 @@ describe("ConnectionRegistry", () => {
     const connection = registry.createConnection(
       (conn: AgentSideConnection) => new TestAgent(conn),
     );
-    const writer = connection.inboundTx.getWriter();
 
-    try {
-      await writer.write(initializeRequest);
-    } finally {
-      writer.releaseLock();
-    }
+    await writeInbound(connection.inboundTx, initializeRequest);
 
     const response = await connection.recvInitial(initializeRequest.id);
 
@@ -72,4 +88,168 @@ describe("ConnectionRegistry", () => {
 
     registry.closeAll();
   });
+
+  it("routes pending responses to the connection stream and all outbound stream", async () => {
+    const registry = new ConnectionRegistry();
+    const connection = registry.createConnection(
+      (conn: AgentSideConnection) => new TestAgent(conn),
+    );
+
+    await initializeConnection(connection);
+
+    const connectionSubscription = connection.connectionStream.subscribe();
+    const allOutboundSubscription = connection.allOutbound.subscribe();
+    const key = messageIdKey(sessionNewRequest.id);
+
+    expect(key).toBe("number:2");
+    connection.pendingRoutes.set(key ?? "", "connection");
+
+    await writeInbound(connection.inboundTx, sessionNewRequest);
+
+    const connectionMessage = await readNext(connectionSubscription.stream);
+    const allOutboundMessage = await readNext(allOutboundSubscription.stream);
+
+    expect(connectionMessage).toMatchObject({
+      jsonrpc: "2.0",
+      id: sessionNewRequest.id,
+      result: {
+        sessionId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      },
+    });
+    expect(allOutboundMessage).toMatchObject(connectionMessage);
+    expect(connection.pendingRoutes.has(key ?? "")).toBe(false);
+
+    registry.closeAll();
+  });
+
+  it("falls back to the connection stream for responses without a pending route", async () => {
+    const registry = new ConnectionRegistry();
+    const connection = registry.createConnection(
+      (conn: AgentSideConnection) => new TestAgent(conn),
+    );
+
+    await initializeConnection(connection);
+
+    const subscription = connection.connectionStream.subscribe();
+
+    await writeInbound(connection.inboundTx, sessionNewRequest);
+
+    expect(await readNext(subscription.stream)).toMatchObject({
+      jsonrpc: "2.0",
+      id: sessionNewRequest.id,
+      result: {
+        sessionId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      },
+    });
+
+    registry.closeAll();
+  });
 });
+
+describe("OutboundStream", () => {
+  it("replays buffered messages to the first subscriber", () => {
+    const stream = new OutboundStream();
+
+    stream.push(messageOne);
+    stream.push(messageTwo);
+
+    expect(stream.subscribe().replay).toEqual([messageOne, messageTwo]);
+  });
+
+  it("does not replay buffered messages to later subscribers", async () => {
+    const stream = new OutboundStream();
+
+    stream.push(messageOne);
+
+    const first = stream.subscribe();
+    const second = stream.subscribe();
+
+    expect(first.replay).toEqual([messageOne]);
+    expect(second.replay).toEqual([]);
+
+    stream.push(messageTwo);
+
+    expect(await readNext(first.stream)).toEqual(messageTwo);
+    expect(await readNext(second.stream)).toEqual(messageTwo);
+  });
+
+  it("evicts oldest replay messages when capacity is exceeded", () => {
+    const stream = new OutboundStream(2);
+
+    stream.push(messageOne);
+    stream.push(messageTwo);
+    stream.push(messageThree);
+
+    expect(stream.subscribe().replay).toEqual([messageTwo, messageThree]);
+  });
+
+  it("drops oldest queued live messages for lagging subscribers", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const stream = new OutboundStream(2);
+    const subscription = stream.subscribe();
+
+    stream.push(messageOne);
+    stream.push(messageTwo);
+    stream.push(messageThree);
+    stream.push(messageFour);
+
+    expect(await readNext(subscription.stream)).toEqual(messageOne);
+    expect(await readNext(subscription.stream)).toEqual(messageThree);
+    expect(await readNext(subscription.stream)).toEqual(messageFour);
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockRestore();
+  });
+
+  it("closes subscriber streams", async () => {
+    const stream = new OutboundStream();
+    const reader = stream.subscribe().stream.getReader();
+
+    stream.close();
+
+    expect(await reader.read()).toEqual({ done: true, value: undefined });
+    reader.releaseLock();
+  });
+});
+
+type TestConnection = ReturnType<ConnectionRegistry["createConnection"]>;
+
+async function initializeConnection(connection: TestConnection): Promise<void> {
+  await writeInbound(connection.inboundTx, initializeRequest);
+  await connection.recvInitial(initializeRequest.id);
+  connection.startRouter();
+}
+
+async function writeInbound(
+  stream: WritableStream<AnyMessage>,
+  message: AnyMessage,
+): Promise<void> {
+  const writer = stream.getWriter();
+
+  try {
+    await writer.write(message);
+  } finally {
+    writer.releaseLock();
+  }
+}
+
+async function readNext(
+  stream: ReadableStream<AnyMessage>,
+): Promise<AnyMessage> {
+  const reader = stream.getReader();
+
+  try {
+    const result = await reader.read();
+
+    if (result.done) {
+      throw new Error("Expected stream message");
+    }
+
+    return result.value;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+const routeShapeCheck = "connection" satisfies ResponseRoute;
+void routeShapeCheck;

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -52,7 +52,7 @@ const messageThree = { jsonrpc: "2.0", id: 3, result: "three" } as const;
 const messageFour = { jsonrpc: "2.0", id: 4, result: "four" } as const;
 
 describe("ConnectionRegistry", () => {
-  it("creates retrievable connections with unique UUID connection IDs", () => {
+  it("creates retrievable connections with unique UUID connection IDs", async () => {
     const registry = new ConnectionRegistry();
     const first = registry.createConnection(
       (conn: AgentSideConnection) => new TestAgent(conn),
@@ -67,7 +67,7 @@ describe("ConnectionRegistry", () => {
     expect(registry.get(first.connectionId)).toBe(first);
     expect(registry.get(second.connectionId)).toBe(second);
 
-    registry.closeAll();
+    await registry.closeAll();
   });
 
   it("removes connections", () => {
@@ -102,7 +102,7 @@ describe("ConnectionRegistry", () => {
       },
     });
 
-    registry.closeAll();
+    await registry.closeAll();
   });
 
   it("cancels a pending initialize reader during shutdown", async () => {
@@ -123,7 +123,53 @@ describe("ConnectionRegistry", () => {
       "Expected initialize response from agent",
     );
 
-    registry.closeAll();
+    await registry.closeAll();
+  });
+
+  it("waits for active and pending connection shutdowns before closeAll resolves", async () => {
+    const registry = new ConnectionRegistry();
+    const active = registry.createConnection(
+      (conn: AgentSideConnection) => new TestAgent(conn),
+    );
+    const pending = registry.createPendingConnection(
+      (conn: AgentSideConnection) => new TestAgent(conn),
+    );
+    const activeShutdownStarted = createDeferred<void>();
+    const pendingShutdownStarted = createDeferred<void>();
+    const allowActiveShutdown = createDeferred<void>();
+    const allowPendingShutdown = createDeferred<void>();
+    const originalActiveShutdown = active.shutdown.bind(active);
+    const originalPendingShutdown = pending.shutdown.bind(pending);
+    vi.spyOn(active, "shutdown").mockImplementation(async () => {
+      activeShutdownStarted.resolve();
+      await allowActiveShutdown.promise;
+      await originalActiveShutdown();
+    });
+    vi.spyOn(pending, "shutdown").mockImplementation(async () => {
+      pendingShutdownStarted.resolve();
+      await allowPendingShutdown.promise;
+      await originalPendingShutdown();
+    });
+    let closeResolved = false;
+
+    const close = registry.closeAll().then(() => {
+      closeResolved = true;
+    });
+
+    await activeShutdownStarted.promise;
+    await pendingShutdownStarted.promise;
+    await flushMicrotasks();
+
+    expect(registry.get(active.connectionId)).toBeUndefined();
+    expect(closeResolved).toBe(false);
+
+    allowActiveShutdown.resolve();
+    await flushMicrotasks();
+    expect(closeResolved).toBe(false);
+
+    allowPendingShutdown.resolve();
+    await close;
+    expect(closeResolved).toBe(true);
   });
 
   it("routes pending responses to the connection stream and all outbound stream", async () => {
@@ -156,7 +202,7 @@ describe("ConnectionRegistry", () => {
     expect(allOutboundMessage).toMatchObject(connectionMessage);
     expect(connection.pendingRoutes.has(key ?? "")).toBe(false);
 
-    registry.closeAll();
+    await registry.closeAll();
   });
 
   it("falls back to the connection stream for responses without a pending route", async () => {
@@ -179,10 +225,10 @@ describe("ConnectionRegistry", () => {
       },
     });
 
-    registry.closeAll();
+    await registry.closeAll();
   });
 
-  it("returns the same session stream for repeated ensureSession calls", () => {
+  it("returns the same session stream for repeated ensureSession calls", async () => {
     const registry = new ConnectionRegistry();
     const connection = registry.createConnection(
       (conn: AgentSideConnection) => new TestAgent(conn),
@@ -196,7 +242,7 @@ describe("ConnectionRegistry", () => {
       connection.ensureSession(sessionId),
     );
 
-    registry.closeAll();
+    await registry.closeAll();
   });
 
   it("routes session responses and notifications to the session stream", async () => {
@@ -243,7 +289,7 @@ describe("ConnectionRegistry", () => {
       await readNextOrUndefined(connectionSubscription.stream),
     ).toBeUndefined();
 
-    registry.closeAll();
+    await registry.closeAll();
   });
 });
 
@@ -421,6 +467,11 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 const routeShapeCheck = "connection" satisfies ResponseRoute;

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -30,6 +30,18 @@ const sessionNewRequest = {
   },
 } as const;
 
+function createPromptRequest(id: number, sessionId: string) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "session/prompt",
+    params: {
+      sessionId,
+      prompt: [{ type: "text", text: "Hello" }],
+    },
+  } as const;
+}
+
 const messageOne = { jsonrpc: "2.0", id: 1, result: "one" } as const;
 const messageTwo = { jsonrpc: "2.0", id: 2, result: "two" } as const;
 const messageThree = { jsonrpc: "2.0", id: 3, result: "three" } as const;
@@ -144,6 +156,70 @@ describe("ConnectionRegistry", () => {
 
     registry.closeAll();
   });
+
+  it("returns the same session stream for repeated ensureSession calls", () => {
+    const registry = new ConnectionRegistry();
+    const connection = registry.createConnection(
+      (conn: AgentSideConnection) => new TestAgent(conn),
+    );
+    const sessionId = globalThis.crypto.randomUUID();
+
+    expect(connection.ensureSession(sessionId)).toBe(
+      connection.ensureSession(sessionId),
+    );
+    expect(connection.sessionStreams.get(sessionId)).toBe(
+      connection.ensureSession(sessionId),
+    );
+
+    registry.closeAll();
+  });
+
+  it("routes session responses and notifications to the session stream", async () => {
+    const registry = new ConnectionRegistry();
+    const connection = registry.createConnection(
+      (conn: AgentSideConnection) => new TestAgent(conn, { chunkCount: 1 }),
+    );
+    const sessionId = globalThis.crypto.randomUUID();
+    const promptRequest = createPromptRequest(3, sessionId);
+
+    await initializeConnection(connection);
+
+    const sessionSubscription = connection.ensureSession(sessionId).subscribe();
+    const connectionSubscription = connection.connectionStream.subscribe();
+    const key = messageIdKey(promptRequest.id);
+
+    expect(key).toBe("number:3");
+    connection.pendingRoutes.set(key ?? "", { session: sessionId });
+
+    await writeInbound(connection.inboundTx, promptRequest);
+
+    expect(await readNext(sessionSubscription.stream)).toMatchObject({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            text: "chunk-1",
+          },
+        },
+      },
+    });
+    expect(await readNext(sessionSubscription.stream)).toMatchObject({
+      jsonrpc: "2.0",
+      id: promptRequest.id,
+      result: {
+        stopReason: "end_turn",
+      },
+    });
+    expect(connection.pendingRoutes.has(key ?? "")).toBe(false);
+    expect(
+      await readNextOrUndefined(connectionSubscription.stream),
+    ).toBeUndefined();
+
+    registry.closeAll();
+  });
 });
 
 describe("OutboundStream", () => {
@@ -249,6 +325,27 @@ async function readNext(
   } finally {
     reader.releaseLock();
   }
+}
+
+async function readNextOrUndefined(
+  stream: ReadableStream<AnyMessage>,
+): Promise<AnyMessage | undefined> {
+  const reader = stream.getReader();
+
+  try {
+    return await Promise.race([
+      reader.read().then((result) => (result.done ? undefined : result.value)),
+      delay(50).then(() => undefined),
+    ]);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 const routeShapeCheck = "connection" satisfies ResponseRoute;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,5 +1,10 @@
 import { AgentSideConnection } from "./acp.js";
-import { messageIdKey, sessionIdFromParams } from "./protocol.js";
+import { isResponseMessage } from "./jsonrpc.js";
+import {
+  messageIdKey,
+  sessionIdFromMessageParams,
+  sessionIdFromResponseResult,
+} from "./protocol.js";
 
 import type { Agent } from "./acp.js";
 import type { AnyMessage, AnyResponse } from "./jsonrpc.js";
@@ -199,7 +204,7 @@ export class ConnectionState {
   private routeOutbound(message: AnyMessage): void {
     this.allOutbound.push(message);
 
-    if (isResponse(message)) {
+    if (isResponseMessage(message)) {
       this.routeOutboundResponse(message);
       return;
     }
@@ -210,9 +215,7 @@ export class ConnectionState {
   private routeOutboundResponse(message: AnyResponse): void {
     const key = messageIdKey(message.id);
     const route = key ? this.pendingRoutes.get(key) : undefined;
-    const sessionId = sessionIdFromResult(
-      "result" in message ? message.result : undefined,
-    );
+    const sessionId = sessionIdFromResponseResult(message);
 
     if (sessionId) {
       this.ensureSession(sessionId);
@@ -226,12 +229,10 @@ export class ConnectionState {
   }
 
   private routeOutboundRequestOrNotification(message: AnyMessage): void {
-    if ("method" in message) {
-      const sessionId = sessionIdFromParams(message.params);
-      if (sessionId) {
-        this.ensureSession(sessionId).push(message);
-        return;
-      }
+    const sessionId = sessionIdFromMessageParams(message);
+    if (sessionId) {
+      this.ensureSession(sessionId).push(message);
+      return;
     }
 
     this.connectionStream.push(message);
@@ -374,21 +375,4 @@ function isMatchingResponse(
   id: string | number,
 ): msg is AnyResponse {
   return "id" in msg && !("method" in msg) && msg.id === id;
-}
-
-function isResponse(msg: AnyMessage): msg is AnyResponse {
-  return "id" in msg && !("method" in msg);
-}
-
-function sessionIdFromResult(result: unknown): string | undefined {
-  if (!isRecord(result)) {
-    return undefined;
-  }
-
-  const sessionId = result["sessionId"];
-  return typeof sessionId === "string" ? sessionId : undefined;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -95,7 +95,9 @@ export class ConnectionState {
 
   private hasStartedRouter = false;
   private inboundWriteChain: Promise<void> = Promise.resolve();
+  private initialReader: ReadableStreamDefaultReader<AnyMessage> | undefined;
   private outboundReader: ReadableStreamDefaultReader<AnyMessage> | undefined;
+  private shutdownPromise: Promise<void> | undefined;
 
   constructor(agentFactory: (conn: AgentSideConnection) => Agent) {
     this.connectionId = globalThis.crypto.randomUUID();
@@ -115,6 +117,7 @@ export class ConnectionState {
 
   async recvInitial(initializeId: string | number): Promise<AnyResponse> {
     const reader = this.outboundRx.getReader();
+    this.initialReader = reader;
 
     try {
       const result = await reader.read();
@@ -124,12 +127,19 @@ export class ConnectionState {
         !result.value ||
         !isMatchingResponse(result.value, initializeId)
       ) {
-        await this.shutdown();
+        if (!this.shutdownPromise) {
+          await this.shutdown();
+        }
+
         throw new Error("Expected initialize response from agent");
       }
 
       return result.value;
     } finally {
+      if (this.initialReader === reader) {
+        this.initialReader = undefined;
+      }
+
       reader.releaseLock();
     }
   }
@@ -164,6 +174,14 @@ export class ConnectionState {
   }
 
   async shutdown(): Promise<void> {
+    if (!this.shutdownPromise) {
+      this.shutdownPromise = this.runShutdown();
+    }
+
+    return this.shutdownPromise;
+  }
+
+  private async runShutdown(): Promise<void> {
     this.connectionStream.close();
     this.allOutbound.close();
 
@@ -177,8 +195,17 @@ export class ConnectionState {
 
     await Promise.allSettled([
       this.inboundTx.close(),
-      this.outboundReader?.cancel() ?? this.outboundRx.cancel(),
+      this.cancelOutboundReader(),
     ]);
+  }
+
+  private cancelOutboundReader(): Promise<void> {
+    const reader = this.initialReader ?? this.outboundReader;
+    if (reader) {
+      return reader.cancel();
+    }
+
+    return this.outboundRx.cancel();
   }
 
   private async writeInboundMessage(message: AnyMessage): Promise<void> {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,0 +1,99 @@
+import { AgentSideConnection } from "./acp.js";
+
+import type { Agent } from "./acp.js";
+import type { AnyMessage, AnyResponse } from "./jsonrpc.js";
+import type { Stream } from "./stream.js";
+
+export class ConnectionState {
+  readonly connectionId: string;
+  readonly inboundTx: WritableStream<AnyMessage>;
+  readonly outboundRx: ReadableStream<AnyMessage>;
+  readonly agentConnection: AgentSideConnection;
+
+  constructor(agentFactory: (conn: AgentSideConnection) => Agent) {
+    this.connectionId = globalThis.crypto.randomUUID();
+    const inbound = new TransformStream<AnyMessage, AnyMessage>();
+    const outbound = new TransformStream<AnyMessage, AnyMessage>();
+
+    this.inboundTx = inbound.writable;
+    this.outboundRx = outbound.readable;
+
+    const stream: Stream = {
+      readable: inbound.readable,
+      writable: outbound.writable,
+    };
+
+    this.agentConnection = new AgentSideConnection(agentFactory, stream);
+  }
+
+  async recvInitial(initializeId: string | number): Promise<AnyResponse> {
+    const reader = this.outboundRx.getReader();
+
+    try {
+      const result = await reader.read();
+
+      if (
+        result.done ||
+        !result.value ||
+        !isMatchingResponse(result.value, initializeId)
+      ) {
+        await this.shutdown();
+        throw new Error("Expected initialize response from agent");
+      }
+
+      return result.value;
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  async shutdown() {
+    await Promise.allSettled([
+      this.inboundTx.close(),
+      this.outboundRx.cancel(),
+    ]);
+  }
+}
+
+export class ConnectionRegistry {
+  private readonly connections = new Map<string, ConnectionState>();
+
+  createConnection(
+    agentFactory: (conn: AgentSideConnection) => Agent,
+  ): ConnectionState {
+    const connection = new ConnectionState(agentFactory);
+    this.connections.set(connection.connectionId, connection);
+    return connection;
+  }
+
+  get(connectionId: string): ConnectionState | undefined {
+    return this.connections.get(connectionId);
+  }
+
+  remove(connectionId: string): ConnectionState | undefined {
+    const connection = this.get(connectionId);
+
+    if (!connection) {
+      return undefined;
+    }
+
+    this.connections.delete(connectionId);
+    void connection.shutdown();
+    return connection;
+  }
+
+  closeAll(): void {
+    for (const connection of this.connections.values()) {
+      void connection.shutdown();
+    }
+
+    this.connections.clear();
+  }
+}
+
+function isMatchingResponse(
+  msg: AnyMessage,
+  id: string | number,
+): msg is AnyResponse {
+  return "id" in msg && !("method" in msg) && msg.id === id;
+}

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -91,6 +91,7 @@ export class ConnectionState {
   readonly allOutbound = new OutboundStream();
   readonly sessionStreams = new Map<string, OutboundStream>();
   readonly pendingRoutes = new Map<string, ResponseRoute>();
+  readonly clientResponseRoutes = new Map<string, ResponseRoute>();
 
   private hasStartedRouter = false;
   private outboundReader: ReadableStreamDefaultReader<AnyMessage> | undefined;
@@ -163,6 +164,7 @@ export class ConnectionState {
 
     this.sessionStreams.clear();
     this.pendingRoutes.clear();
+    this.clientResponseRoutes.clear();
 
     await Promise.allSettled([
       this.inboundTx.close(),
@@ -231,11 +233,27 @@ export class ConnectionState {
   private routeOutboundRequestOrNotification(message: AnyMessage): void {
     const sessionId = sessionIdFromMessageParams(message);
     if (sessionId) {
+      this.trackClientResponseRoute(message, { session: sessionId });
       this.ensureSession(sessionId).push(message);
       return;
     }
 
+    this.trackClientResponseRoute(message, "connection");
     this.connectionStream.push(message);
+  }
+
+  private trackClientResponseRoute(
+    message: AnyMessage,
+    route: ResponseRoute,
+  ): void {
+    if (!("id" in message) || !("method" in message)) {
+      return;
+    }
+
+    const key = messageIdKey(message.id);
+    if (key) {
+      this.clientResponseRoutes.set(key, route);
+    }
   }
 
   private pushToRoute(route: ResponseRoute, message: AnyMessage): void {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -200,24 +200,32 @@ export class ConnectionState {
     this.allOutbound.push(message);
 
     if (isResponse(message)) {
-      const key = messageIdKey(message.id);
-      const route = key ? this.pendingRoutes.get(key) : undefined;
-      const sessionId = sessionIdFromResult(
-        "result" in message ? message.result : undefined,
-      );
-
-      if (sessionId) {
-        this.ensureSession(sessionId);
-      }
-
-      if (key) {
-        this.pendingRoutes.delete(key);
-      }
-
-      this.pushToRoute(route ?? "connection", message);
+      this.routeOutboundResponse(message);
       return;
     }
 
+    this.routeOutboundRequestOrNotification(message);
+  }
+
+  private routeOutboundResponse(message: AnyResponse): void {
+    const key = messageIdKey(message.id);
+    const route = key ? this.pendingRoutes.get(key) : undefined;
+    const sessionId = sessionIdFromResult(
+      "result" in message ? message.result : undefined,
+    );
+
+    if (sessionId) {
+      this.ensureSession(sessionId);
+    }
+
+    if (key) {
+      this.pendingRoutes.delete(key);
+    }
+
+    this.pushToRoute(route ?? "connection", message);
+  }
+
+  private routeOutboundRequestOrNotification(message: AnyMessage): void {
     if ("method" in message) {
       const sessionId = sessionIdFromParams(message.params);
       if (sessionId) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -287,6 +287,7 @@ export class ConnectionState {
 
 export class ConnectionRegistry {
   private readonly connections = new Map<string, ConnectionState>();
+  private readonly pendingConnections = new Map<string, ConnectionState>();
 
   createConnection(
     agentFactory: (conn: AgentSideConnection) => Agent,
@@ -294,6 +295,19 @@ export class ConnectionRegistry {
     const connection = new ConnectionState(agentFactory);
     this.connections.set(connection.connectionId, connection);
     return connection;
+  }
+
+  createPendingConnection(
+    agentFactory: (conn: AgentSideConnection) => Agent,
+  ): ConnectionState {
+    const connection = new ConnectionState(agentFactory);
+    this.pendingConnections.set(connection.connectionId, connection);
+    return connection;
+  }
+
+  register(connection: ConnectionState): void {
+    this.pendingConnections.delete(connection.connectionId);
+    this.connections.set(connection.connectionId, connection);
   }
 
   get(connectionId: string): ConnectionState | undefined {
@@ -312,12 +326,32 @@ export class ConnectionRegistry {
     return connection;
   }
 
+  discard(connectionId: string): ConnectionState | undefined {
+    const connection =
+      this.connections.get(connectionId) ??
+      this.pendingConnections.get(connectionId);
+
+    if (!connection) {
+      return undefined;
+    }
+
+    this.connections.delete(connectionId);
+    this.pendingConnections.delete(connectionId);
+    void connection.shutdown();
+    return connection;
+  }
+
   closeAll(): void {
     for (const connection of this.connections.values()) {
       void connection.shutdown();
     }
 
+    for (const connection of this.pendingConnections.values()) {
+      void connection.shutdown();
+    }
+
     this.connections.clear();
+    this.pendingConnections.clear();
   }
 }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,5 +1,5 @@
 import { AgentSideConnection } from "./acp.js";
-import { messageIdKey } from "./protocol.js";
+import { messageIdKey, sessionIdFromParams } from "./protocol.js";
 
 import type { Agent } from "./acp.js";
 import type { AnyMessage, AnyResponse } from "./jsonrpc.js";
@@ -84,6 +84,7 @@ export class ConnectionState {
   readonly agentConnection: AgentSideConnection;
   readonly connectionStream = new OutboundStream();
   readonly allOutbound = new OutboundStream();
+  readonly sessionStreams = new Map<string, OutboundStream>();
   readonly pendingRoutes = new Map<string, ResponseRoute>();
 
   private hasStartedRouter = false;
@@ -135,9 +136,27 @@ export class ConnectionState {
     void this.runRouter();
   }
 
+  ensureSession(sessionId: string): OutboundStream {
+    const existing = this.sessionStreams.get(sessionId);
+    if (existing) {
+      return existing;
+    }
+
+    const stream = new OutboundStream();
+    this.sessionStreams.set(sessionId, stream);
+
+    return stream;
+  }
+
   async shutdown(): Promise<void> {
     this.connectionStream.close();
     this.allOutbound.close();
+
+    for (const stream of this.sessionStreams.values()) {
+      stream.close();
+    }
+
+    this.sessionStreams.clear();
     this.pendingRoutes.clear();
 
     await Promise.allSettled([
@@ -170,6 +189,10 @@ export class ConnectionState {
       reader.releaseLock();
       this.connectionStream.close();
       this.allOutbound.close();
+
+      for (const stream of this.sessionStreams.values()) {
+        stream.close();
+      }
     }
   }
 
@@ -179,6 +202,13 @@ export class ConnectionState {
     if (isResponse(message)) {
       const key = messageIdKey(message.id);
       const route = key ? this.pendingRoutes.get(key) : undefined;
+      const sessionId = sessionIdFromResult(
+        "result" in message ? message.result : undefined,
+      );
+
+      if (sessionId) {
+        this.ensureSession(sessionId);
+      }
 
       if (key) {
         this.pendingRoutes.delete(key);
@@ -186,6 +216,14 @@ export class ConnectionState {
 
       this.pushToRoute(route ?? "connection", message);
       return;
+    }
+
+    if ("method" in message) {
+      const sessionId = sessionIdFromParams(message.params);
+      if (sessionId) {
+        this.ensureSession(sessionId).push(message);
+        return;
+      }
     }
 
     this.connectionStream.push(message);
@@ -197,7 +235,7 @@ export class ConnectionState {
       return;
     }
 
-    this.connectionStream.push(message);
+    this.ensureSession(route.session).push(message);
   }
 }
 
@@ -332,4 +370,17 @@ function isMatchingResponse(
 
 function isResponse(msg: AnyMessage): msg is AnyResponse {
   return "id" in msg && !("method" in msg);
+}
+
+function sessionIdFromResult(result: unknown): string | undefined {
+  if (!isRecord(result)) {
+    return undefined;
+  }
+
+  const sessionId = result["sessionId"];
+  return typeof sessionId === "string" ? sessionId : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -94,6 +94,7 @@ export class ConnectionState {
   readonly clientResponseRoutes = new Map<string, ResponseRoute>();
 
   private hasStartedRouter = false;
+  private inboundWriteChain: Promise<void> = Promise.resolve();
   private outboundReader: ReadableStreamDefaultReader<AnyMessage> | undefined;
 
   constructor(agentFactory: (conn: AgentSideConnection) => Agent) {
@@ -133,6 +134,14 @@ export class ConnectionState {
     }
   }
 
+  async writeInbound(message: AnyMessage): Promise<void> {
+    const write = this.inboundWriteChain.then(() =>
+      this.writeInboundMessage(message),
+    );
+    this.inboundWriteChain = write.catch(() => undefined);
+    await write;
+  }
+
   startRouter(): void {
     if (this.hasStartedRouter) {
       return;
@@ -170,6 +179,16 @@ export class ConnectionState {
       this.inboundTx.close(),
       this.outboundReader?.cancel() ?? this.outboundRx.cancel(),
     ]);
+  }
+
+  private async writeInboundMessage(message: AnyMessage): Promise<void> {
+    const writer = this.inboundTx.getWriter();
+
+    try {
+      await writer.write(message);
+    } finally {
+      writer.releaseLock();
+    }
   }
 
   private async runRouter(): Promise<void> {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,14 +1,93 @@
 import { AgentSideConnection } from "./acp.js";
+import { messageIdKey } from "./protocol.js";
 
 import type { Agent } from "./acp.js";
 import type { AnyMessage, AnyResponse } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
+
+export type ResponseRoute = "connection" | { readonly session: string };
+
+export interface OutboundSubscription {
+  readonly replay: readonly AnyMessage[];
+  readonly stream: ReadableStream<AnyMessage>;
+}
+
+export class OutboundStream {
+  private readonly subscribers = new Set<OutboundSubscriber>();
+  private replayBuffer: AnyMessage[] = [];
+  private hasSubscriber = false;
+  private isClosed = false;
+
+  constructor(private readonly capacity = 1024) {}
+
+  push(message: AnyMessage): void {
+    if (this.isClosed) {
+      return;
+    }
+
+    if (!this.hasSubscriber) {
+      this.replayBuffer.push(message);
+
+      if (this.replayBuffer.length > this.capacity) {
+        this.replayBuffer.shift();
+      }
+
+      return;
+    }
+
+    for (const subscriber of this.subscribers) {
+      subscriber.push(message);
+    }
+  }
+
+  subscribe(): OutboundSubscription {
+    const replay = this.hasSubscriber ? [] : [...this.replayBuffer];
+    this.replayBuffer = [];
+    this.hasSubscriber = true;
+
+    const subscriber = new OutboundSubscriber(this.capacity, (item) => {
+      this.subscribers.delete(item);
+    });
+
+    this.subscribers.add(subscriber);
+
+    if (this.isClosed) {
+      subscriber.close();
+    }
+
+    return {
+      replay,
+      stream: subscriber.stream,
+    };
+  }
+
+  close(): void {
+    if (this.isClosed) {
+      return;
+    }
+
+    this.isClosed = true;
+    this.replayBuffer = [];
+
+    for (const subscriber of this.subscribers) {
+      subscriber.close();
+    }
+
+    this.subscribers.clear();
+  }
+}
 
 export class ConnectionState {
   readonly connectionId: string;
   readonly inboundTx: WritableStream<AnyMessage>;
   readonly outboundRx: ReadableStream<AnyMessage>;
   readonly agentConnection: AgentSideConnection;
+  readonly connectionStream = new OutboundStream();
+  readonly allOutbound = new OutboundStream();
+  readonly pendingRoutes = new Map<string, ResponseRoute>();
+
+  private hasStartedRouter = false;
+  private outboundReader: ReadableStreamDefaultReader<AnyMessage> | undefined;
 
   constructor(agentFactory: (conn: AgentSideConnection) => Agent) {
     this.connectionId = globalThis.crypto.randomUUID();
@@ -47,11 +126,78 @@ export class ConnectionState {
     }
   }
 
-  async shutdown() {
+  startRouter(): void {
+    if (this.hasStartedRouter) {
+      return;
+    }
+
+    this.hasStartedRouter = true;
+    void this.runRouter();
+  }
+
+  async shutdown(): Promise<void> {
+    this.connectionStream.close();
+    this.allOutbound.close();
+    this.pendingRoutes.clear();
+
     await Promise.allSettled([
       this.inboundTx.close(),
-      this.outboundRx.cancel(),
+      this.outboundReader?.cancel() ?? this.outboundRx.cancel(),
     ]);
+  }
+
+  private async runRouter(): Promise<void> {
+    const reader = this.outboundRx.getReader();
+    this.outboundReader = reader;
+
+    try {
+      while (true) {
+        const result = await reader.read();
+
+        if (result.done) {
+          return;
+        }
+
+        this.routeOutbound(result.value);
+      }
+    } catch (error) {
+      console.error("ACP connection router stopped unexpectedly:", error);
+    } finally {
+      if (this.outboundReader === reader) {
+        this.outboundReader = undefined;
+      }
+
+      reader.releaseLock();
+      this.connectionStream.close();
+      this.allOutbound.close();
+    }
+  }
+
+  private routeOutbound(message: AnyMessage): void {
+    this.allOutbound.push(message);
+
+    if (isResponse(message)) {
+      const key = messageIdKey(message.id);
+      const route = key ? this.pendingRoutes.get(key) : undefined;
+
+      if (key) {
+        this.pendingRoutes.delete(key);
+      }
+
+      this.pushToRoute(route ?? "connection", message);
+      return;
+    }
+
+    this.connectionStream.push(message);
+  }
+
+  private pushToRoute(route: ResponseRoute, message: AnyMessage): void {
+    if (route === "connection") {
+      this.connectionStream.push(message);
+      return;
+    }
+
+    this.connectionStream.push(message);
   }
 }
 
@@ -91,9 +237,99 @@ export class ConnectionRegistry {
   }
 }
 
+class OutboundSubscriber {
+  readonly stream: ReadableStream<AnyMessage>;
+
+  private controller: ReadableStreamDefaultController<AnyMessage> | undefined;
+  private queue: AnyMessage[] = [];
+  private isClosed = false;
+  private hasWarnedAboutOverflow = false;
+
+  constructor(
+    private readonly capacity: number,
+    private readonly onCancel: (subscriber: OutboundSubscriber) => void,
+  ) {
+    this.stream = new ReadableStream<AnyMessage>({
+      start: (controller) => {
+        this.controller = controller;
+        this.flush();
+      },
+      pull: () => {
+        this.flush();
+      },
+      cancel: () => {
+        this.cancel();
+      },
+    });
+  }
+
+  push(message: AnyMessage): void {
+    if (this.isClosed) {
+      return;
+    }
+
+    this.queue.push(message);
+
+    if (this.queue.length > this.capacity) {
+      this.queue.shift();
+
+      if (!this.hasWarnedAboutOverflow) {
+        console.warn("ACP outbound subscriber lagged; dropping oldest message");
+        this.hasWarnedAboutOverflow = true;
+      }
+    }
+
+    this.flush();
+  }
+
+  close(): void {
+    if (this.isClosed) {
+      return;
+    }
+
+    this.isClosed = true;
+    this.queue = [];
+    this.controller?.close();
+  }
+
+  private cancel(): void {
+    this.isClosed = true;
+    this.queue = [];
+    this.onCancel(this);
+  }
+
+  private flush(): void {
+    if (!this.controller) {
+      return;
+    }
+
+    while (
+      this.queue.length > 0 &&
+      this.controller.desiredSize !== null &&
+      this.controller.desiredSize > 0
+    ) {
+      const message = this.queue.shift();
+
+      if (!message) {
+        return;
+      }
+
+      this.controller.enqueue(message);
+    }
+
+    if (this.queue.length === 0) {
+      this.hasWarnedAboutOverflow = false;
+    }
+  }
+}
+
 function isMatchingResponse(
   msg: AnyMessage,
   id: string | number,
 ): msg is AnyResponse {
   return "id" in msg && !("method" in msg) && msg.id === id;
+}
+
+function isResponse(msg: AnyMessage): msg is AnyResponse {
+  return "id" in msg && !("method" in msg);
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -368,17 +368,17 @@ export class ConnectionRegistry {
     return connection;
   }
 
-  closeAll(): void {
-    for (const connection of this.connections.values()) {
-      void connection.shutdown();
-    }
-
-    for (const connection of this.pendingConnections.values()) {
-      void connection.shutdown();
-    }
-
+  async closeAll(): Promise<void> {
+    const connections = new Set([
+      ...this.connections.values(),
+      ...this.pendingConnections.values(),
+    ]);
     this.connections.clear();
     this.pendingConnections.clear();
+
+    await Promise.all(
+      Array.from(connections, (connection) => connection.shutdown()),
+    );
   }
 }
 

--- a/src/cookie-store.test.ts
+++ b/src/cookie-store.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { MemoryAcpCookieStore } from "./cookie-store.js";
+
+describe("MemoryAcpCookieStore", () => {
+  it("stores single and multiple Set-Cookie values", () => {
+    const store = new MemoryAcpCookieStore();
+    store.store(headersWithSetCookie(["transport=alpha; Path=/"]));
+    store.store(
+      headersWithSetCookie(["route=bravo; Path=/", "affinity=charlie"]),
+    );
+
+    const headers = new Headers();
+    store.apply(headers);
+
+    expect(headers.get("Cookie")).toBe(
+      "transport=alpha; route=bravo; affinity=charlie",
+    );
+  });
+
+  it("splits combined Set-Cookie headers with Expires commas", () => {
+    const store = new MemoryAcpCookieStore();
+    store.store(
+      new Headers({
+        "Set-Cookie":
+          "transport=alpha; Expires=Wed, 21 Oct 2030 07:28:00 GMT, route=bravo; Path=/",
+      }),
+    );
+
+    const headers = new Headers();
+    store.apply(headers);
+
+    expect(headers.get("Cookie")).toBe("transport=alpha; route=bravo");
+  });
+
+  it("ignores malformed cookie headers", () => {
+    const store = new MemoryAcpCookieStore();
+    store.store(
+      headersWithSetCookie([
+        "missing-separator",
+        "=empty-name",
+        " =blank",
+        "ok=value",
+      ]),
+    );
+
+    const headers = new Headers();
+    store.apply(headers);
+
+    expect(headers.get("Cookie")).toBe("ok=value");
+  });
+
+  it("lets later cookies overwrite earlier cookies with the same name", () => {
+    const store = new MemoryAcpCookieStore();
+    store.store(headersWithSetCookie(["route=alpha", "route=bravo"]));
+
+    const headers = new Headers();
+    store.apply(headers);
+
+    expect(headers.get("Cookie")).toBe("route=bravo");
+  });
+
+  it("writes a Cookie header when managed cookies exist", () => {
+    const store = new MemoryAcpCookieStore();
+    store.store(headersWithSetCookie(["transport=alpha"]));
+
+    const headers = new Headers();
+    store.apply(headers);
+
+    expect(headers.get("Cookie")).toBe("transport=alpha");
+  });
+
+  it("merges managed cookies with caller-provided Cookie headers", () => {
+    const store = new MemoryAcpCookieStore();
+    store.store(headersWithSetCookie(["transport=alpha", "route=bravo"]));
+
+    const headers = new Headers({ Cookie: "caller=custom" });
+    store.apply(headers);
+
+    expect(headers.get("Cookie")).toBe(
+      "transport=alpha; route=bravo; caller=custom",
+    );
+  });
+
+  it("lets caller-provided cookie values override managed duplicate names", () => {
+    const store = new MemoryAcpCookieStore();
+    store.store(headersWithSetCookie(["transport=alpha", "route=bravo"]));
+
+    const headers = new Headers({ Cookie: "route=caller; caller=custom" });
+    store.apply(headers);
+
+    expect(headers.get("Cookie")).toBe(
+      "transport=alpha; route=caller; caller=custom",
+    );
+  });
+
+  it("clears managed cookies", () => {
+    const store = new MemoryAcpCookieStore();
+    store.store(headersWithSetCookie(["transport=alpha"]));
+    store.clear();
+
+    const headers = new Headers();
+    store.apply(headers);
+
+    expect(headers.get("Cookie")).toBeNull();
+  });
+});
+
+function headersWithSetCookie(values: readonly string[]): Headers {
+  const headers = new Headers();
+
+  Object.defineProperty(headers, "getSetCookie", {
+    value: () => values,
+  });
+
+  return headers;
+}

--- a/src/cookie-store.ts
+++ b/src/cookie-store.ts
@@ -1,0 +1,147 @@
+/**
+ * Minimal ACP affinity cookie store.
+ *
+ * This helper stores cookie name/value pairs from `Set-Cookie` response
+ * headers and applies them to outgoing `Cookie` request headers. It is meant
+ * for ACP routing affinity across reconnects, not authentication or
+ * authorization, and not as a general-purpose browser cookie jar: it
+ * intentionally does not implement domain/path matching,
+ * expiry, `Secure`, `HttpOnly`, or `SameSite` handling.
+ */
+export interface AcpCookieStore {
+  /** Stores cookies from response headers. */
+  store(headers: Headers): void;
+  /** Applies stored cookies to outgoing request headers. */
+  apply(headers: Headers): void;
+  /** Clears all stored cookies. */
+  clear(): void;
+}
+
+/** In-memory implementation of {@link AcpCookieStore}. */
+export class MemoryAcpCookieStore implements AcpCookieStore {
+  private readonly cookies = new Map<string, string>();
+
+  store(headers: Headers): void {
+    for (const value of setCookieHeaders(headers)) {
+      const cookie = parseSetCookie(value);
+      if (!cookie) {
+        continue;
+      }
+
+      this.cookies.set(cookie.name, cookie.value);
+    }
+  }
+
+  apply(headers: Headers): void {
+    const merged = mergeCookieHeaders(
+      this.cookieHeader(),
+      headers.get("Cookie"),
+    );
+    if (merged) {
+      headers.set("Cookie", merged);
+    }
+  }
+
+  clear(): void {
+    this.cookies.clear();
+  }
+
+  private cookieHeader(): string | undefined {
+    return this.cookies.size === 0
+      ? undefined
+      : Array.from(this.cookies)
+          .map(([name, value]) => `${name}=${value}`)
+          .join("; ");
+  }
+}
+
+interface CookiePair {
+  readonly name: string;
+  readonly value: string;
+}
+
+function setCookieHeaders(headers: Headers): string[] {
+  const getSetCookie = headers.getSetCookie;
+  if (typeof getSetCookie === "function") {
+    return getSetCookie.call(headers).flatMap(splitSetCookieHeader);
+  }
+
+  const setCookie = headers.get("Set-Cookie");
+  return setCookie ? splitSetCookieHeader(setCookie) : [];
+}
+
+function splitSetCookieHeader(header: string): string[] {
+  return header
+    .split(/,(?=\s*[^;,\s]+=)/)
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+function parseSetCookie(header: string): CookiePair | undefined {
+  const pair = header.split(";", 1)[0];
+  const separator = pair.indexOf("=");
+
+  if (separator <= 0) {
+    return undefined;
+  }
+
+  const name = pair.slice(0, separator).trim();
+  if (!name) {
+    return undefined;
+  }
+
+  return {
+    name,
+    value: pair.slice(separator + 1).trim(),
+  };
+}
+
+function mergeCookieHeaders(
+  managedCookieHeader: string | undefined,
+  callerCookieHeader: string | null,
+): string | undefined {
+  const cookies = new Map<string, string>();
+
+  for (const cookie of parseCookieHeader(managedCookieHeader)) {
+    cookies.set(cookie.name, cookie.value);
+  }
+
+  for (const cookie of parseCookieHeader(callerCookieHeader ?? undefined)) {
+    cookies.set(cookie.name, cookie.value);
+  }
+
+  return cookies.size === 0
+    ? undefined
+    : Array.from(cookies)
+        .map(([name, value]) => `${name}=${value}`)
+        .join("; ");
+}
+
+function parseCookieHeader(header: string | undefined): CookiePair[] {
+  if (!header) {
+    return [];
+  }
+
+  return header
+    .split(";")
+    .map(parseCookiePair)
+    .filter((cookie): cookie is CookiePair => cookie !== undefined);
+}
+
+function parseCookiePair(value: string): CookiePair | undefined {
+  const separator = value.indexOf("=");
+
+  if (separator <= 0) {
+    return undefined;
+  }
+
+  const name = value.slice(0, separator).trim();
+  if (!name) {
+    return undefined;
+  }
+
+  return {
+    name,
+    value: value.slice(separator + 1).trim(),
+  };
+}

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -4,6 +4,9 @@ This directory contains examples using the [ACP](https://agentclientprotocol.com
 
 - [`agent.ts`](./agent.ts) - A minimal agent implementation that simulates LLM interaction
 - [`client.ts`](./client.ts) - A minimal client implementation that spawns the [`agent.ts`](./agent.ts) as a subprocess
+- [`http-server.ts`](./http-server.ts) - A minimal ACP Streamable HTTP server with WebSocket upgrade support
+- [`http-client.ts`](./http-client.ts) - A minimal client using `createHttpStream`
+- [`ws-client.ts`](./ws-client.ts) - A minimal client using `createWebSocketStream`
 
 ## Running the Agent
 
@@ -75,3 +78,25 @@ npx tsx src/examples/client.ts
 ```
 
 This client will spawn the example agent as a subprocess, send a message, and print the content it receives from it.
+
+## Running the HTTP and WebSocket Examples
+
+Start the Streamable HTTP server with WebSocket upgrade support:
+
+```bash
+npx tsx src/examples/http-server.ts
+```
+
+In another terminal, run the HTTP client:
+
+```bash
+npx tsx src/examples/http-client.ts
+```
+
+Or run the WebSocket client:
+
+```bash
+npx tsx src/examples/ws-client.ts
+```
+
+The HTTP example sends a bearer token through custom request headers. The WebSocket example passes the Node `ws` constructor so custom headers can be sent during the WebSocket handshake. Browser WebSocket clients can use `createWebSocketStream` too, but browsers do not allow custom WebSocket headers.

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -99,4 +99,10 @@ Or run the WebSocket client:
 npx tsx src/examples/ws-client.ts
 ```
 
-The HTTP example sends a bearer token through custom request headers. The WebSocket example passes the Node `ws` constructor so custom headers can be sent during the WebSocket handshake. Browser WebSocket clients can use `createWebSocketStream` too, but browsers do not allow custom WebSocket headers.
+The HTTP example sends a bearer token through custom request headers. `createHttpStream` includes cookies by default for the lifetime of one stream: it sends credentials on fetch requests, captures exposed `Set-Cookie` headers, merges them with caller-provided `Cookie` headers, and reuses them for connection SSE, session SSE, POST, and DELETE requests. Pass `cookies: "omit"` to disable this behavior for stateless transports.
+
+The WebSocket server example uses `createNodeWebSocketUpgradeHandler`, which creates the ACP connection before the upgrade completes and adds `Acp-Connection-Id` to the `101 Switching Protocols` response. Frameworks that only expose an already-upgraded WebSocket socket cannot add that response header, so prefer an upgrade hook when building compliant servers.
+
+The WebSocket client example passes the Node `ws` constructor so custom headers can be sent during the WebSocket handshake. Browser WebSocket clients can use `createWebSocketStream` too, but browsers do not allow custom WebSocket headers. Use cookies or URL-level authentication for browser WebSocket authentication instead of relying on custom handshake headers.
+
+The included Node HTTP server is an HTTP/1.1 compatibility adapter. HTTP/2 deployment guidance is still tracked separately in the transport hardening plan.

--- a/src/examples/http-client.ts
+++ b/src/examples/http-client.ts
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 
-import * as acp from "@agentclientprotocol/sdk";
-import {
-  MemoryAcpCookieStore,
-  createHttpStream,
-} from "@agentclientprotocol/sdk/experimental/http-client";
+import * as acp from "../acp.js";
+import { MemoryAcpCookieStore, createHttpStream } from "../http-stream.js";
 
 class HttpExampleClient implements acp.Client {
   async requestPermission(

--- a/src/examples/http-client.ts
+++ b/src/examples/http-client.ts
@@ -4,7 +4,7 @@ import * as acp from "@agentclientprotocol/sdk";
 import {
   MemoryAcpCookieStore,
   createHttpStream,
-} from "@agentclientprotocol/sdk/http-client";
+} from "@agentclientprotocol/sdk/experimental/http-client";
 
 class HttpExampleClient implements acp.Client {
   async requestPermission(

--- a/src/examples/http-client.ts
+++ b/src/examples/http-client.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import * as acp from "@agentclientprotocol/sdk";
+import { createHttpStream } from "@agentclientprotocol/sdk/http-client";
+
+class HttpExampleClient implements acp.Client {
+  async requestPermission(
+    params: acp.RequestPermissionRequest,
+  ): Promise<acp.RequestPermissionResponse> {
+    return {
+      outcome: {
+        outcome: "selected",
+        optionId: params.options[0]?.optionId ?? "allow",
+      },
+    };
+  }
+
+  async sessionUpdate(params: acp.SessionNotification): Promise<void> {
+    const update = params.update;
+
+    if (update.sessionUpdate === "agent_message_chunk") {
+      process.stdout.write(
+        update.content.type === "text" ? update.content.text : "",
+      );
+      return;
+    }
+
+    console.log(`[${update.sessionUpdate}]`);
+  }
+}
+
+const serverUrl = process.env.ACP_HTTP_URL ?? "http://127.0.0.1:7331/acp";
+const stream = createHttpStream(serverUrl, {
+  headers: {
+    Authorization: "Bearer example-token",
+  },
+  // To use cookies, pass a cookie-aware fetch implementation here instead of relying on a built-in cookie jar.
+  // fetch: cookieAwareFetch,
+});
+const connection = new acp.ClientSideConnection(
+  (_agent) => new HttpExampleClient(),
+  stream,
+);
+
+try {
+  await connection.initialize({
+    protocolVersion: acp.PROTOCOL_VERSION,
+    clientCapabilities: {},
+  });
+
+  const session = await connection.newSession({
+    cwd: process.cwd(),
+    mcpServers: [],
+  });
+
+  const result = await connection.prompt({
+    sessionId: session.sessionId,
+    prompt: [
+      {
+        type: "text",
+        text: "Hello over Streamable HTTP",
+      },
+    ],
+  });
+
+  console.log(`\nDone: ${result.stopReason}`);
+} finally {
+  await stream.writable.close();
+}

--- a/src/examples/http-client.ts
+++ b/src/examples/http-client.ts
@@ -34,8 +34,7 @@ const stream = createHttpStream(serverUrl, {
   headers: {
     Authorization: "Bearer example-token",
   },
-  // To use cookies, pass a cookie-aware fetch implementation here instead of relying on a built-in cookie jar.
-  // fetch: cookieAwareFetch,
+  // Cookies are included by default and scoped to this stream. Use `cookies: "omit"` for stateless requests.
 });
 const connection = new acp.ClientSideConnection(
   (_agent) => new HttpExampleClient(),

--- a/src/examples/http-client.ts
+++ b/src/examples/http-client.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
 import * as acp from "@agentclientprotocol/sdk";
-import { createHttpStream } from "@agentclientprotocol/sdk/http-client";
+import {
+  MemoryAcpCookieStore,
+  createHttpStream,
+} from "@agentclientprotocol/sdk/http-client";
 
 class HttpExampleClient implements acp.Client {
   async requestPermission(
@@ -30,19 +33,36 @@ class HttpExampleClient implements acp.Client {
 }
 
 const serverUrl = process.env.ACP_HTTP_URL ?? "http://127.0.0.1:7331/acp";
-const stream = createHttpStream(serverUrl, {
-  headers: {
-    Authorization: "Bearer example-token",
-  },
-  // Cookies are included by default and scoped to this stream. Use `cookies: "omit"` for stateless requests.
-});
-const connection = new acp.ClientSideConnection(
-  (_agent) => new HttpExampleClient(),
-  stream,
-);
+const authHeaders = {
+  Authorization: "Bearer example-token",
+};
+
+// Keep reconnect state outside individual stream instances. Reuse this store
+// across fresh streams so an external affinity layer can route reconnects.
+const cookieStore = new MemoryAcpCookieStore();
+let savedSessionId: string | undefined;
+
+function connect(): {
+  readonly stream: acp.Stream;
+  readonly connection: acp.ClientSideConnection;
+} {
+  const stream = createHttpStream(serverUrl, {
+    headers: authHeaders,
+    cookieStore,
+    // Cookies are included by default. Use `cookies: "omit"` for stateless requests.
+  });
+  const connection = new acp.ClientSideConnection(
+    (_agent) => new HttpExampleClient(),
+    stream,
+  );
+
+  return { stream, connection };
+}
+
+const { stream, connection } = connect();
 
 try {
-  await connection.initialize({
+  const initialized = await connection.initialize({
     protocolVersion: acp.PROTOCOL_VERSION,
     clientCapabilities: {},
   });
@@ -51,6 +71,7 @@ try {
     cwd: process.cwd(),
     mcpServers: [],
   });
+  savedSessionId = session.sessionId;
 
   const result = await connection.prompt({
     sessionId: session.sessionId,
@@ -63,6 +84,22 @@ try {
   });
 
   console.log(`\nDone: ${result.stopReason}`);
+
+  console.log(
+    `Saved session ${savedSessionId}; loadSession=${initialized.agentCapabilities?.loadSession === true}`,
+  );
+
+  // Reconnect flow sketch:
+  // 1. Save `sessionId`, auth headers, cwd, MCP servers, and `cookieStore`.
+  // 2. Create a fresh stream with the same auth headers and cookie store.
+  // 3. Call initialize and require `agentCapabilities.loadSession`.
+  // 4. Call session/load for the saved session ID.
+  // Production agents must authorize session/load for the authenticated user.
+  // ACP v1 does not replay in-flight transport messages emitted while disconnected.
+  // Example:
+  // const next = connect();
+  // await next.connection.initialize({ protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+  // await next.connection.loadSession({ sessionId: savedSessionId, cwd: process.cwd(), mcpServers: [] });
 } finally {
   await stream.writable.close();
 }

--- a/src/examples/http-server.ts
+++ b/src/examples/http-server.ts
@@ -5,7 +5,10 @@ import { createServer } from "node:http";
 import { WebSocketServer } from "ws";
 
 import * as acp from "@agentclientprotocol/sdk";
-import { createNodeHttpHandler } from "@agentclientprotocol/sdk/node";
+import {
+  createNodeHttpHandler,
+  createNodeWebSocketUpgradeHandler,
+} from "@agentclientprotocol/sdk/node";
 import { AcpServer } from "@agentclientprotocol/sdk/server";
 
 class HttpExampleAgent implements acp.Agent {
@@ -68,6 +71,10 @@ const acpServer = new AcpServer({
 });
 const acpHttpHandler = createNodeHttpHandler(acpServer);
 const webSocketServer = new WebSocketServer({ noServer: true });
+const acpWebSocketUpgradeHandler = createNodeWebSocketUpgradeHandler(
+  acpServer,
+  webSocketServer,
+);
 const port = Number.parseInt(process.env.PORT ?? "7331", 10);
 
 const httpServer = createServer((req, res) => {
@@ -94,9 +101,7 @@ httpServer.on("upgrade", (req, socket, head) => {
     return;
   }
 
-  webSocketServer.handleUpgrade(req, socket, head, (ws) => {
-    acpServer.handleWebSocket(ws);
-  });
+  acpWebSocketUpgradeHandler(req, socket, head);
 });
 
 httpServer.listen(port, () => {

--- a/src/examples/http-server.ts
+++ b/src/examples/http-server.ts
@@ -71,6 +71,7 @@ const acpServer = new AcpServer({
 });
 const acpHttpHandler = createNodeHttpHandler(acpServer);
 const webSocketServer = new WebSocketServer({ noServer: true });
+// Use the ACP upgrade helper so the 101 response includes Acp-Connection-Id.
 const acpWebSocketUpgradeHandler = createNodeWebSocketUpgradeHandler(
   acpServer,
   webSocketServer,

--- a/src/examples/http-server.ts
+++ b/src/examples/http-server.ts
@@ -11,9 +11,18 @@ import {
 } from "@agentclientprotocol/sdk/node";
 import { AcpServer } from "@agentclientprotocol/sdk/server";
 
+interface DurableSessionState {
+  readonly cwd: string;
+  readonly history: acp.SessionNotification[];
+}
+
+// Illustrative durable state outside per-connection agent instances. For
+// production multi-node deployments, replace this with Redis, Postgres, shared
+// storage, or rely on sticky sessions with clear restart/drain semantics.
+const durableSessions = new Map<string, DurableSessionState>();
+
 class HttpExampleAgent implements acp.Agent {
   private readonly connection: acp.AgentSideConnection;
-  private readonly sessions = new Set<string>();
 
   constructor(connection: acp.AgentSideConnection) {
     this.connection = connection;
@@ -25,17 +34,38 @@ class HttpExampleAgent implements acp.Agent {
     return {
       protocolVersion: acp.PROTOCOL_VERSION,
       agentCapabilities: {
-        loadSession: false,
+        loadSession: true,
       },
     };
   }
 
   async newSession(
-    _params: acp.NewSessionRequest,
+    params: acp.NewSessionRequest,
   ): Promise<acp.NewSessionResponse> {
     const sessionId = crypto.randomUUID();
-    this.sessions.add(sessionId);
+    durableSessions.set(sessionId, {
+      cwd: params.cwd,
+      history: [],
+    });
     return { sessionId };
+  }
+
+  async loadSession(
+    params: acp.LoadSessionRequest,
+  ): Promise<acp.LoadSessionResponse> {
+    const session = durableSessions.get(params.sessionId);
+    if (!session) {
+      throw new Error(`Session ${params.sessionId} not found`);
+    }
+
+    // Production agents must authorize session/load against the authenticated
+    // principal before replaying durable state. This example's auth check lives
+    // in HTTP middleware and is intentionally minimal.
+    for (const update of session.history) {
+      await this.connection.sessionUpdate(update);
+    }
+
+    return {};
   }
 
   async authenticate(
@@ -45,20 +75,23 @@ class HttpExampleAgent implements acp.Agent {
   }
 
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
-    if (!this.sessions.has(params.sessionId)) {
+    const session = durableSessions.get(params.sessionId);
+    if (!session) {
       throw new Error(`Session ${params.sessionId} not found`);
     }
 
-    await this.connection.sessionUpdate({
+    const update: acp.SessionNotification = {
       sessionId: params.sessionId,
       update: {
         sessionUpdate: "agent_message_chunk",
         content: {
           type: "text",
-          text: "Hello from the ACP HTTP/WebSocket example server.",
+          text: `Hello from the ACP HTTP/WebSocket example server at ${session.cwd}.`,
         },
       },
-    });
+    };
+    session.history.push(update);
+    await this.connection.sessionUpdate(update);
 
     return { stopReason: "end_turn" };
   }

--- a/src/examples/http-server.ts
+++ b/src/examples/http-server.ts
@@ -4,12 +4,12 @@ import { createServer } from "node:http";
 
 import { WebSocketServer } from "ws";
 
-import * as acp from "@agentclientprotocol/sdk";
+import * as acp from "../acp.js";
 import {
   createNodeHttpHandler,
   createNodeWebSocketUpgradeHandler,
-} from "@agentclientprotocol/sdk/experimental/node";
-import { AcpServer } from "@agentclientprotocol/sdk/experimental/server";
+} from "../node-adapter.js";
+import { AcpServer } from "../server.js";
 
 interface DurableSessionState {
   readonly cwd: string;

--- a/src/examples/http-server.ts
+++ b/src/examples/http-server.ts
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+import { createServer } from "node:http";
+
+import { WebSocketServer } from "ws";
+
+import * as acp from "@agentclientprotocol/sdk";
+import { createNodeHttpHandler } from "@agentclientprotocol/sdk/node";
+import { AcpServer } from "@agentclientprotocol/sdk/server";
+
+class HttpExampleAgent implements acp.Agent {
+  private readonly connection: acp.AgentSideConnection;
+  private readonly sessions = new Set<string>();
+
+  constructor(connection: acp.AgentSideConnection) {
+    this.connection = connection;
+  }
+
+  async initialize(
+    _params: acp.InitializeRequest,
+  ): Promise<acp.InitializeResponse> {
+    return {
+      protocolVersion: acp.PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: false,
+      },
+    };
+  }
+
+  async newSession(
+    _params: acp.NewSessionRequest,
+  ): Promise<acp.NewSessionResponse> {
+    const sessionId = crypto.randomUUID();
+    this.sessions.add(sessionId);
+    return { sessionId };
+  }
+
+  async authenticate(
+    _params: acp.AuthenticateRequest,
+  ): Promise<acp.AuthenticateResponse> {
+    return {};
+  }
+
+  async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
+    if (!this.sessions.has(params.sessionId)) {
+      throw new Error(`Session ${params.sessionId} not found`);
+    }
+
+    await this.connection.sessionUpdate({
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "Hello from the ACP HTTP/WebSocket example server.",
+        },
+      },
+    });
+
+    return { stopReason: "end_turn" };
+  }
+
+  async cancel(_params: acp.CancelNotification): Promise<void> {}
+}
+
+const acpServer = new AcpServer({
+  createAgent: (connection) => new HttpExampleAgent(connection),
+});
+const acpHttpHandler = createNodeHttpHandler(acpServer);
+const webSocketServer = new WebSocketServer({ noServer: true });
+const port = Number.parseInt(process.env.PORT ?? "7331", 10);
+
+const httpServer = createServer((req, res) => {
+  if (!isAcpPath(req.url)) {
+    res.writeHead(404, { "Content-Type": "text/plain" });
+    res.end("Not Found");
+    return;
+  }
+
+  // Put authentication or tenant-selection middleware here before routing to AcpServer.
+  // For example, validate `req.headers.authorization` and reject unauthorized requests.
+  if (!isAuthorized(req.headers.authorization)) {
+    res.writeHead(401, { "Content-Type": "text/plain" });
+    res.end("Unauthorized");
+    return;
+  }
+
+  acpHttpHandler(req, res);
+});
+
+httpServer.on("upgrade", (req, socket, head) => {
+  if (!isAcpPath(req.url) || !isAuthorized(req.headers.authorization)) {
+    socket.destroy();
+    return;
+  }
+
+  webSocketServer.handleUpgrade(req, socket, head, (ws) => {
+    acpServer.handleWebSocket(ws);
+  });
+});
+
+httpServer.listen(port, () => {
+  console.log(`ACP HTTP endpoint listening at http://127.0.0.1:${port}/acp`);
+  console.log(`ACP WebSocket endpoint listening at ws://127.0.0.1:${port}/acp`);
+});
+
+function isAcpPath(url: string | undefined): boolean {
+  return new URL(url ?? "/", "http://127.0.0.1").pathname === "/acp";
+}
+
+function isAuthorized(authorization: string | undefined): boolean {
+  return (
+    authorization === undefined || authorization === "Bearer example-token"
+  );
+}

--- a/src/examples/http-server.ts
+++ b/src/examples/http-server.ts
@@ -8,8 +8,8 @@ import * as acp from "@agentclientprotocol/sdk";
 import {
   createNodeHttpHandler,
   createNodeWebSocketUpgradeHandler,
-} from "@agentclientprotocol/sdk/node";
-import { AcpServer } from "@agentclientprotocol/sdk/server";
+} from "@agentclientprotocol/sdk/experimental/node";
+import { AcpServer } from "@agentclientprotocol/sdk/experimental/server";
 
 interface DurableSessionState {
   readonly cwd: string;

--- a/src/examples/ws-client.ts
+++ b/src/examples/ws-client.ts
@@ -2,12 +2,9 @@
 
 import { WebSocket } from "ws";
 
-import * as acp from "@agentclientprotocol/sdk";
-import {
-  MemoryAcpCookieStore,
-  createWebSocketStream,
-} from "@agentclientprotocol/sdk/experimental/ws-client";
-import type { WebSocketConstructor } from "@agentclientprotocol/sdk/experimental/ws-client";
+import * as acp from "../acp.js";
+import { MemoryAcpCookieStore, createWebSocketStream } from "../ws-stream.js";
+import type { WebSocketConstructor } from "../ws-stream.js";
 
 class WebSocketExampleClient implements acp.Client {
   async requestPermission(

--- a/src/examples/ws-client.ts
+++ b/src/examples/ws-client.ts
@@ -6,8 +6,8 @@ import * as acp from "@agentclientprotocol/sdk";
 import {
   MemoryAcpCookieStore,
   createWebSocketStream,
-} from "@agentclientprotocol/sdk/ws-client";
-import type { WebSocketConstructor } from "@agentclientprotocol/sdk/ws-client";
+} from "@agentclientprotocol/sdk/experimental/ws-client";
+import type { WebSocketConstructor } from "@agentclientprotocol/sdk/experimental/ws-client";
 
 class WebSocketExampleClient implements acp.Client {
   async requestPermission(

--- a/src/examples/ws-client.ts
+++ b/src/examples/ws-client.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+import { WebSocket } from "ws";
+
+import * as acp from "@agentclientprotocol/sdk";
+import { createWebSocketStream } from "@agentclientprotocol/sdk/ws-client";
+import type { WebSocketConstructor } from "@agentclientprotocol/sdk/ws-client";
+
+class WebSocketExampleClient implements acp.Client {
+  async requestPermission(
+    params: acp.RequestPermissionRequest,
+  ): Promise<acp.RequestPermissionResponse> {
+    return {
+      outcome: {
+        outcome: "selected",
+        optionId: params.options[0]?.optionId ?? "allow",
+      },
+    };
+  }
+
+  async sessionUpdate(params: acp.SessionNotification): Promise<void> {
+    const update = params.update;
+
+    if (update.sessionUpdate === "agent_message_chunk") {
+      process.stdout.write(
+        update.content.type === "text" ? update.content.text : "",
+      );
+      return;
+    }
+
+    console.log(`[${update.sessionUpdate}]`);
+  }
+}
+
+const serverUrl = process.env.ACP_WS_URL ?? "ws://127.0.0.1:7331/acp";
+const stream = createWebSocketStream(serverUrl, {
+  WebSocket: WebSocket satisfies WebSocketConstructor,
+  // Custom headers work with Node's `ws` constructor. Browser WebSocket does not support custom headers.
+  headers: {
+    Authorization: "Bearer example-token",
+  },
+});
+const connection = new acp.ClientSideConnection(
+  (_agent) => new WebSocketExampleClient(),
+  stream,
+);
+
+try {
+  await connection.initialize({
+    protocolVersion: acp.PROTOCOL_VERSION,
+    clientCapabilities: {},
+  });
+
+  const session = await connection.newSession({
+    cwd: process.cwd(),
+    mcpServers: [],
+  });
+
+  const result = await connection.prompt({
+    sessionId: session.sessionId,
+    prompt: [
+      {
+        type: "text",
+        text: "Hello over WebSocket",
+      },
+    ],
+  });
+
+  console.log(`\nDone: ${result.stopReason}`);
+} finally {
+  await stream.writable.close();
+}

--- a/src/examples/ws-client.ts
+++ b/src/examples/ws-client.ts
@@ -3,7 +3,10 @@
 import { WebSocket } from "ws";
 
 import * as acp from "@agentclientprotocol/sdk";
-import { createWebSocketStream } from "@agentclientprotocol/sdk/ws-client";
+import {
+  MemoryAcpCookieStore,
+  createWebSocketStream,
+} from "@agentclientprotocol/sdk/ws-client";
 import type { WebSocketConstructor } from "@agentclientprotocol/sdk/ws-client";
 
 class WebSocketExampleClient implements acp.Client {
@@ -33,20 +36,37 @@ class WebSocketExampleClient implements acp.Client {
 }
 
 const serverUrl = process.env.ACP_WS_URL ?? "ws://127.0.0.1:7331/acp";
-const stream = createWebSocketStream(serverUrl, {
-  WebSocket: WebSocket satisfies WebSocketConstructor,
-  // Custom headers work with Node's `ws` constructor. Browser WebSocket does not support custom headers.
-  headers: {
-    Authorization: "Bearer example-token",
-  },
-});
-const connection = new acp.ClientSideConnection(
-  (_agent) => new WebSocketExampleClient(),
-  stream,
-);
+const authHeaders = {
+  Authorization: "Bearer example-token",
+};
+
+// Keep reconnect state outside individual stream instances. Browser WebSocket
+// uses the platform cookie jar; Node's `ws` uses constructor headers populated
+// from this store.
+const cookieStore = new MemoryAcpCookieStore();
+let savedSessionId: string | undefined;
+
+function connect(): {
+  readonly stream: acp.Stream;
+  readonly connection: acp.ClientSideConnection;
+} {
+  const stream = createWebSocketStream(serverUrl, {
+    WebSocket: WebSocket satisfies WebSocketConstructor,
+    headers: authHeaders,
+    cookieStore,
+  });
+  const connection = new acp.ClientSideConnection(
+    (_agent) => new WebSocketExampleClient(),
+    stream,
+  );
+
+  return { stream, connection };
+}
+
+const { stream, connection } = connect();
 
 try {
-  await connection.initialize({
+  const initialized = await connection.initialize({
     protocolVersion: acp.PROTOCOL_VERSION,
     clientCapabilities: {},
   });
@@ -55,6 +75,7 @@ try {
     cwd: process.cwd(),
     mcpServers: [],
   });
+  savedSessionId = session.sessionId;
 
   const result = await connection.prompt({
     sessionId: session.sessionId,
@@ -67,6 +88,21 @@ try {
   });
 
   console.log(`\nDone: ${result.stopReason}`);
+  console.log(
+    `Saved session ${savedSessionId}; loadSession=${initialized.agentCapabilities?.loadSession === true}`,
+  );
+
+  // Reconnect flow sketch:
+  // 1. Save `sessionId`, auth headers, cwd, MCP servers, and `cookieStore`.
+  // 2. Create a fresh WebSocket stream with the same auth headers and cookie store.
+  // 3. Call initialize and require `agentCapabilities.loadSession`.
+  // 4. Call session/load for the saved session ID.
+  // Production agents must authorize session/load for the authenticated user.
+  // ACP v1 does not replay in-flight transport messages emitted while disconnected.
+  // Example:
+  // const next = connect();
+  // await next.connection.initialize({ protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+  // await next.connection.loadSession({ sessionId: savedSessionId, cwd: process.cwd(), mcpServers: [] });
 } finally {
   await stream.writable.close();
 }

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -188,6 +188,91 @@ describe("createHttpStream", () => {
     }
   });
 
+  it("errors the stream when the connection SSE closes cleanly", async () => {
+    const controlledFetch = createControlledFetch();
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+      await controlledFetch.closeSse(0);
+
+      await expect(reader.read()).rejects.toThrow(
+        "ACP connection SSE stream closed",
+      );
+    } finally {
+      reader.releaseLock();
+      writer.releaseLock();
+      await closeStream(stream);
+    }
+  });
+
+  it("reopens session SSE after it closes cleanly without pending requests", async () => {
+    const controlledFetch = createControlledFetch();
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+      await controlledFetch.sendSse(0, sessionNewResponse);
+      await readMessage(reader);
+      await controlledFetch.closeSse(1);
+      await flushMicrotasks();
+      await writer.write(promptRequest);
+
+      const reopenedSessionGet = requestAt(controlledFetch.requests, 3);
+      const promptPost = requestAt(controlledFetch.requests, 4);
+
+      expect(reopenedSessionGet.method).toBe("GET");
+      expect(reopenedSessionGet.headers.get(HEADER_CONNECTION_ID)).toBe(
+        "connection-1",
+      );
+      expect(reopenedSessionGet.headers.get(HEADER_SESSION_ID)).toBe(
+        "session-1",
+      );
+      expect(promptPost.method).toBe("POST");
+      expect(promptPost.headers.get(HEADER_SESSION_ID)).toBe("session-1");
+    } finally {
+      reader.releaseLock();
+      writer.releaseLock();
+      await closeStream(stream);
+    }
+  });
+
+  it("errors the stream when a session SSE closes with a pending request", async () => {
+    const controlledFetch = createControlledFetch();
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+      await controlledFetch.sendSse(0, sessionNewResponse);
+      await readMessage(reader);
+      await writer.write(promptRequest);
+      await controlledFetch.closeSse(1);
+
+      await expect(reader.read()).rejects.toThrow(
+        "ACP session SSE stream closed",
+      );
+    } finally {
+      reader.releaseLock();
+      writer.releaseLock();
+      await closeStream(stream);
+    }
+  });
+
   it("opens session SSE before posting session/load for an existing session", async () => {
     const controlledFetch = createControlledFetch();
     const stream = createHttpStream("https://agent.example/acp", {
@@ -861,6 +946,7 @@ interface ControlledFetch {
   readonly requests: RecordedRequest[];
   readonly sseRequests: RecordedSseRequest[];
   readonly sendSse: (index: number, message: AnyMessage) => Promise<void>;
+  readonly closeSse: (index: number) => Promise<void>;
 }
 
 interface TestClientState {
@@ -939,7 +1025,7 @@ function createControlledFetch(
 
         if (signal) {
           signal.addEventListener("abort", () => {
-            void writer.close();
+            void writer.close().catch(() => undefined);
           });
         }
 
@@ -963,6 +1049,9 @@ function createControlledFetch(
       await sseAt(sseRequests, index).writer.write(
         encoder.encode(serializeSseEvent(message)),
       );
+    },
+    closeSse: async (index) => {
+      await sseAt(sseRequests, index).writer.close();
     },
   };
 }
@@ -989,6 +1078,11 @@ async function closeStream(stream: {
   writable: WritableStream<AnyMessage>;
 }): Promise<void> {
   await stream.writable.close().catch(() => undefined);
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 async function readMessage(

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -199,6 +199,69 @@ describe("createHttpStream", () => {
     }
   });
 
+  it("aborts and deletes late initialize connections when canceled during initialize POST", async () => {
+    const clearSpy = vi.spyOn(MemoryAcpCookieStore.prototype, "clear");
+    const initializeResponseDeferred = createDeferred<Response>();
+    const requests: Array<{
+      readonly method: string;
+      readonly headers: Headers;
+      readonly signal: AbortSignal | null | undefined;
+    }> = [];
+    const fetch: typeof globalThis.fetch = async (_input, init) => {
+      const method = init?.method ?? "GET";
+      const headers = new Headers(init?.headers);
+      requests.push({
+        method,
+        headers,
+        signal: init?.signal,
+      });
+
+      if (method === "POST" && !headers.has(HEADER_CONNECTION_ID)) {
+        return await initializeResponseDeferred.promise;
+      }
+
+      if (method === "DELETE") {
+        return new Response(null, { status: 202 });
+      }
+
+      throw new Error(`Unexpected ${method} request`);
+    };
+    const stream = createHttpStream("https://agent.example/acp", { fetch });
+    const writer = stream.writable.getWriter();
+
+    try {
+      const write = writer.write(initializeRequest);
+      await flushMicrotasks();
+      expect(requests).toHaveLength(1);
+      expect(requests[0].signal?.aborted).toBe(false);
+
+      stream.readable.cancel().catch(() => undefined);
+      await flushMicrotasks();
+
+      expect(requests[0].signal?.aborted).toBe(true);
+      initializeResponseDeferred.resolve(
+        jsonResponse(initializeResponse, 200, {
+          [HEADER_CONNECTION_ID]: "connection-1",
+          ...setCookieResponseHeaders(["transport=alpha; Path=/"]),
+        }),
+      );
+
+      await expect(write).rejects.toThrow("ACP HTTP stream is closed");
+
+      expect(requests).toHaveLength(2);
+      expect(requests[1].method).toBe("DELETE");
+      expect(requests[1].headers.get(HEADER_CONNECTION_ID)).toBe(
+        "connection-1",
+      );
+      expect(requests[1].headers.get("Cookie")).toBe("transport=alpha");
+      expect(clearSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      clearSpy.mockRestore();
+      writer.releaseLock();
+      await closeStream(stream);
+    }
+  });
+
   it("deletes the initialized connection when the initialize body is not a response", async () => {
     const clearSpy = vi.spyOn(MemoryAcpCookieStore.prototype, "clear");
     const controlledFetch = createControlledFetch({

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -110,6 +110,13 @@ const permissionResponse = {
   },
 } satisfies AnyMessage;
 
+const connectionScopedServerRequest = {
+  jsonrpc: "2.0",
+  id: 99,
+  method: "connection/example",
+  params: {},
+} satisfies AnyMessage;
+
 describe("createHttpStream", () => {
   it("posts initialize with custom headers, opens connection SSE, and emits the initialize response", async () => {
     const controlledFetch = createControlledFetch();
@@ -304,7 +311,7 @@ describe("createHttpStream", () => {
     }
   });
 
-  it("includes the session header on responses to session-scoped server requests", async () => {
+  it("includes the session header only on responses to session-scoped server requests", async () => {
     const controlledFetch = createControlledFetch();
     const stream = createHttpStream("https://agent.example/acp", {
       fetch: controlledFetch.fetch,
@@ -328,6 +335,20 @@ describe("createHttpStream", () => {
       );
       expect(responsePost.headers.get(HEADER_SESSION_ID)).toBe("session-1");
       expect(JSON.parse(responsePost.body)).toEqual(permissionResponse);
+
+      await controlledFetch.sendSse(0, connectionScopedServerRequest);
+      await readMessage(reader);
+      await writer.write(permissionResponse);
+
+      const connectionResponsePost = requestAt(controlledFetch.requests, 4);
+      expect(connectionResponsePost.method).toBe("POST");
+      expect(connectionResponsePost.headers.get(HEADER_CONNECTION_ID)).toBe(
+        "connection-1",
+      );
+      expect(connectionResponsePost.headers.get(HEADER_SESSION_ID)).toBeNull();
+      expect(JSON.parse(connectionResponsePost.body)).toEqual(
+        permissionResponse,
+      );
     } finally {
       reader.releaseLock();
       writer.releaseLock();

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -218,8 +218,11 @@ describe("createHttpStream", () => {
     }
   });
 
-  it("reopens session SSE after it closes cleanly without pending requests", async () => {
-    const controlledFetch = createControlledFetch();
+  it("waits for a reopened session SSE before posting session-scoped messages", async () => {
+    const reopenedSessionSseResponse = createDeferred<void>();
+    const controlledFetch = createControlledFetch({
+      sseResponseDelays: new Map([[2, reopenedSessionSseResponse.promise]]),
+    });
     const stream = createHttpStream("https://agent.example/acp", {
       fetch: controlledFetch.fetch,
     });
@@ -233,11 +236,10 @@ describe("createHttpStream", () => {
       await readMessage(reader);
       await controlledFetch.closeSse(1);
       await flushMicrotasks();
-      await writer.write(promptRequest);
+      const promptWrite = writer.write(promptRequest);
+      await flushMicrotasks();
 
       const reopenedSessionGet = requestAt(controlledFetch.requests, 3);
-      const promptPost = requestAt(controlledFetch.requests, 4);
-
       expect(reopenedSessionGet.method).toBe("GET");
       expect(reopenedSessionGet.headers.get(HEADER_CONNECTION_ID)).toBe(
         "connection-1",
@@ -245,6 +247,12 @@ describe("createHttpStream", () => {
       expect(reopenedSessionGet.headers.get(HEADER_SESSION_ID)).toBe(
         "session-1",
       );
+      expect(controlledFetch.requests).toHaveLength(4);
+
+      reopenedSessionSseResponse.resolve();
+      await promptWrite;
+
+      const promptPost = requestAt(controlledFetch.requests, 4);
       expect(promptPost.method).toBe("POST");
       expect(promptPost.headers.get(HEADER_SESSION_ID)).toBe("session-1");
     } finally {
@@ -1008,6 +1016,7 @@ interface ControlledFetchOptions {
   readonly getCookies?: readonly string[];
   readonly getStatus?: number;
   readonly deleteError?: Error;
+  readonly sseResponseDelays?: ReadonlyMap<number, Promise<void>>;
 }
 
 function recordInitializeConnectionIds(
@@ -1073,6 +1082,9 @@ function createControlledFetch(
           });
         }
 
+        const sseIndex = sseRequests.length;
+        await options.sseResponseDelays?.get(sseIndex);
+
         const stream = new TransformStream<Uint8Array, Uint8Array>();
         const writer = stream.writable.getWriter();
         const signal = init?.signal;
@@ -1137,6 +1149,21 @@ async function closeStream(stream: {
 async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
+}
+
+function createDeferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+  readonly reject: (error: unknown) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (error: unknown) => void = () => {};
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
 }
 
 async function readMessage(

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -1,0 +1,487 @@
+import { describe, expect, it } from "vitest";
+import { ClientSideConnection, PROTOCOL_VERSION } from "./acp.js";
+import { createHttpStream } from "./http-stream.js";
+import {
+  EVENT_STREAM_MIME_TYPE,
+  HEADER_CONNECTION_ID,
+  HEADER_SESSION_ID,
+  JSON_MIME_TYPE,
+} from "./protocol.js";
+import { serializeSseEvent } from "./sse.js";
+import { TestAgent } from "./test-support/test-agent.js";
+import { startTestServer } from "./test-support/test-http-server.js";
+
+import type {
+  AgentSideConnection,
+  Client,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+  SessionNotification,
+} from "./acp.js";
+import type { AnyMessage } from "./jsonrpc.js";
+
+const initializeRequest = {
+  jsonrpc: "2.0",
+  id: 0,
+  method: "initialize",
+  params: {
+    protocolVersion: PROTOCOL_VERSION,
+    clientCapabilities: {},
+  },
+} satisfies AnyMessage;
+
+const initializeResponse = {
+  jsonrpc: "2.0",
+  id: 0,
+  result: {
+    protocolVersion: PROTOCOL_VERSION,
+    agentCapabilities: {
+      loadSession: false,
+    },
+  },
+} satisfies AnyMessage;
+
+const sessionNewResponse = {
+  jsonrpc: "2.0",
+  id: 1,
+  result: {
+    sessionId: "session-1",
+  },
+} satisfies AnyMessage;
+
+const promptRequest = {
+  jsonrpc: "2.0",
+  id: 2,
+  method: "session/prompt",
+  params: {
+    sessionId: "session-1",
+    prompt: [{ type: "text", text: "Hello" }],
+  },
+} satisfies AnyMessage;
+
+describe("createHttpStream", () => {
+  it("posts initialize with custom headers, opens connection SSE, and emits the initialize response", async () => {
+    const controlledFetch = createControlledFetch();
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+      headers: {
+        Authorization: "Bearer token",
+        "X-Test-Header": "phase-5",
+      },
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+
+      expect(await readMessage(reader)).toEqual(initializeResponse);
+      expect(controlledFetch.requests).toHaveLength(2);
+
+      const initializePost = requestAt(controlledFetch.requests, 0);
+      expect(initializePost.url).toBe("https://agent.example/acp");
+      expect(initializePost.method).toBe("POST");
+      expect(initializePost.headers.get("Authorization")).toBe("Bearer token");
+      expect(initializePost.headers.get("X-Test-Header")).toBe("phase-5");
+      expect(initializePost.headers.get("Content-Type")).toBe(JSON_MIME_TYPE);
+      expect(initializePost.headers.get(HEADER_CONNECTION_ID)).toBeNull();
+      expect(JSON.parse(initializePost.body)).toEqual(initializeRequest);
+
+      const connectionGet = requestAt(controlledFetch.requests, 1);
+      expect(connectionGet.method).toBe("GET");
+      expect(connectionGet.headers.get("Authorization")).toBe("Bearer token");
+      expect(connectionGet.headers.get("Accept")).toBe(EVENT_STREAM_MIME_TYPE);
+      expect(connectionGet.headers.get(HEADER_CONNECTION_ID)).toBe(
+        "connection-1",
+      );
+      expect(connectionGet.headers.get(HEADER_SESSION_ID)).toBeNull();
+    } finally {
+      reader.releaseLock();
+      writer.releaseLock();
+      await stream.writable.close();
+    }
+  });
+
+  it("opens session SSE after session creation and includes the session header on session-scoped POSTs", async () => {
+    const controlledFetch = createControlledFetch();
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+      await controlledFetch.sendSse(0, sessionNewResponse);
+
+      expect(await readMessage(reader)).toEqual(sessionNewResponse);
+      expect(controlledFetch.requests).toHaveLength(3);
+
+      const sessionGet = requestAt(controlledFetch.requests, 2);
+      expect(sessionGet.method).toBe("GET");
+      expect(sessionGet.headers.get(HEADER_CONNECTION_ID)).toBe("connection-1");
+      expect(sessionGet.headers.get(HEADER_SESSION_ID)).toBe("session-1");
+
+      await writer.write(promptRequest);
+
+      const promptPost = requestAt(controlledFetch.requests, 3);
+      expect(promptPost.method).toBe("POST");
+      expect(promptPost.headers.get(HEADER_CONNECTION_ID)).toBe("connection-1");
+      expect(promptPost.headers.get(HEADER_SESSION_ID)).toBe("session-1");
+      expect(JSON.parse(promptPost.body)).toEqual(promptRequest);
+    } finally {
+      reader.releaseLock();
+      writer.releaseLock();
+      await stream.writable.close();
+    }
+  });
+
+  it("sends DELETE and aborts SSE requests when closed", async () => {
+    const controlledFetch = createControlledFetch();
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+      await writer.close();
+
+      const deleteRequest = requestAt(controlledFetch.requests, 2);
+      expect(deleteRequest.method).toBe("DELETE");
+      expect(deleteRequest.headers.get(HEADER_CONNECTION_ID)).toBe(
+        "connection-1",
+      );
+      expect(sseAt(controlledFetch.sseRequests, 0).signal.aborted).toBe(true);
+    } finally {
+      reader.releaseLock();
+      writer.releaseLock();
+    }
+  });
+
+  it("runs initialize, newSession, and prompt through ClientSideConnection", async () => {
+    const updates: SessionNotification[] = [];
+    const server = await startTestServer(
+      (conn: AgentSideConnection) => new TestAgent(conn, { chunkCount: 2 }),
+    );
+    const stream = createHttpStream(server.url);
+    const conn = new ClientSideConnection(
+      () => createTestClient({ updates }),
+      stream,
+    );
+
+    try {
+      expect(
+        await conn.initialize({
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {},
+        }),
+      ).toMatchObject({
+        protocolVersion: PROTOCOL_VERSION,
+        agentCapabilities: { loadSession: false },
+      });
+
+      const session = await conn.newSession({ cwd: "/tmp", mcpServers: [] });
+      expect(session.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+
+      await expect(
+        conn.prompt({
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "Hello" }],
+        }),
+      ).resolves.toEqual({ stopReason: "end_turn" });
+      expect(updates).toHaveLength(2);
+      expect(updates).toMatchObject([
+        {
+          sessionId: session.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { text: "chunk-1" },
+          },
+        },
+        {
+          sessionId: session.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { text: "chunk-2" },
+          },
+        },
+      ]);
+    } finally {
+      await closeStream(stream);
+      await server.close();
+    }
+  });
+
+  it("round-trips permission requests through ClientSideConnection", async () => {
+    const updates: SessionNotification[] = [];
+    const permissionRequests: RequestPermissionRequest[] = [];
+    const server = await startTestServer(
+      (conn: AgentSideConnection) =>
+        new TestAgent(conn, { enablePermission: true }),
+    );
+    const stream = createHttpStream(server.url);
+    const conn = new ClientSideConnection(
+      () => createTestClient({ updates, permissionRequests }),
+      stream,
+    );
+
+    try {
+      await conn.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      });
+      const session = await conn.newSession({ cwd: "/tmp", mcpServers: [] });
+
+      await expect(
+        conn.prompt({
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "Hello" }],
+        }),
+      ).resolves.toEqual({ stopReason: "end_turn" });
+
+      expect(permissionRequests).toHaveLength(1);
+      expect(permissionRequests[0]).toMatchObject({
+        sessionId: session.sessionId,
+        toolCall: {
+          toolCallId: "permission-tool",
+          title: "Permission tool",
+        },
+      });
+      expect(updates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            sessionId: session.sessionId,
+            update: expect.objectContaining({
+              sessionUpdate: "agent_message_chunk",
+              content: expect.objectContaining({
+                text: "permission-selected-allow",
+              }),
+            }),
+          }),
+        ]),
+      );
+    } finally {
+      await closeStream(stream);
+      await server.close();
+    }
+  });
+
+  it("keeps multiple sessions isolated through the SDK client abstraction", async () => {
+    const updates: SessionNotification[] = [];
+    const server = await startTestServer();
+    const stream = createHttpStream(server.url);
+    const conn = new ClientSideConnection(
+      () => createTestClient({ updates }),
+      stream,
+    );
+
+    try {
+      await conn.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      });
+      const firstSession = await conn.newSession({
+        cwd: "/tmp",
+        mcpServers: [],
+      });
+      const secondSession = await conn.newSession({
+        cwd: "/tmp/other",
+        mcpServers: [],
+      });
+
+      await Promise.all([
+        conn.prompt({
+          sessionId: firstSession.sessionId,
+          prompt: [{ type: "text", text: "First" }],
+        }),
+        conn.prompt({
+          sessionId: secondSession.sessionId,
+          prompt: [{ type: "text", text: "Second" }],
+        }),
+      ]);
+
+      expect(updates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ sessionId: firstSession.sessionId }),
+          expect.objectContaining({ sessionId: secondSession.sessionId }),
+        ]),
+      );
+      expect(
+        updates.filter((update) => update.sessionId === firstSession.sessionId),
+      ).toHaveLength(1);
+      expect(
+        updates.filter(
+          (update) => update.sessionId === secondSession.sessionId,
+        ),
+      ).toHaveLength(1);
+    } finally {
+      await closeStream(stream);
+      await server.close();
+    }
+  });
+});
+
+interface RecordedRequest {
+  readonly url: string;
+  readonly method: string;
+  readonly headers: Headers;
+  readonly body: string;
+}
+
+interface RecordedSseRequest {
+  readonly signal: AbortSignal;
+  readonly writer: WritableStreamDefaultWriter<Uint8Array>;
+}
+
+interface ControlledFetch {
+  readonly fetch: typeof globalThis.fetch;
+  readonly requests: RecordedRequest[];
+  readonly sseRequests: RecordedSseRequest[];
+  readonly sendSse: (index: number, message: AnyMessage) => Promise<void>;
+}
+
+interface TestClientState {
+  readonly updates: SessionNotification[];
+  readonly permissionRequests?: RequestPermissionRequest[];
+}
+
+function createControlledFetch(): ControlledFetch {
+  const requests: RecordedRequest[] = [];
+  const sseRequests: RecordedSseRequest[] = [];
+  const encoder = new TextEncoder();
+
+  return {
+    requests,
+    sseRequests,
+    fetch: async (input, init) => {
+      const method = init?.method ?? "GET";
+      const headers = new Headers(init?.headers);
+      requests.push({
+        url: String(input),
+        method,
+        headers,
+        body: bodyToString(init?.body),
+      });
+
+      if (method === "POST" && !headers.has(HEADER_CONNECTION_ID)) {
+        return jsonResponse(initializeResponse, 200, {
+          [HEADER_CONNECTION_ID]: "connection-1",
+        });
+      }
+
+      if (method === "POST" || method === "DELETE") {
+        return new Response(null, { status: 202 });
+      }
+
+      if (method === "GET") {
+        const stream = new TransformStream<Uint8Array, Uint8Array>();
+        const writer = stream.writable.getWriter();
+        const signal = init?.signal;
+
+        if (signal) {
+          signal.addEventListener("abort", () => {
+            void writer.close();
+          });
+        }
+
+        sseRequests.push({
+          signal: signal ?? new AbortController().signal,
+          writer,
+        });
+
+        return new Response(stream.readable, {
+          status: 200,
+          headers: { "Content-Type": EVENT_STREAM_MIME_TYPE },
+        });
+      }
+
+      return new Response("Unexpected method", { status: 405 });
+    },
+    sendSse: async (index, message) => {
+      await sseAt(sseRequests, index).writer.write(
+        encoder.encode(serializeSseEvent(message)),
+      );
+    },
+  };
+}
+
+function createTestClient(state: TestClientState): Client {
+  return {
+    requestPermission: (params): Promise<RequestPermissionResponse> => {
+      state.permissionRequests?.push(params);
+      return Promise.resolve({
+        outcome: {
+          outcome: "selected",
+          optionId: "allow",
+        },
+      });
+    },
+    sessionUpdate: (params): Promise<void> => {
+      state.updates.push(params);
+      return Promise.resolve();
+    },
+  };
+}
+
+async function closeStream(stream: {
+  writable: WritableStream<AnyMessage>;
+}): Promise<void> {
+  await stream.writable.close().catch(() => undefined);
+}
+
+async function readMessage(
+  reader: ReadableStreamDefaultReader<AnyMessage>,
+): Promise<AnyMessage> {
+  const result = await reader.read();
+  if (result.done) {
+    throw new Error("Expected a message");
+  }
+
+  return result.value;
+}
+
+function requestAt(
+  requests: readonly RecordedRequest[],
+  index: number,
+): RecordedRequest {
+  const request = requests[index];
+  if (!request) {
+    throw new Error(`Expected request at index ${index}`);
+  }
+
+  return request;
+}
+
+function sseAt(
+  requests: readonly RecordedSseRequest[],
+  index: number,
+): RecordedSseRequest {
+  const request = requests[index];
+  if (!request) {
+    throw new Error(`Expected SSE request at index ${index}`);
+  }
+
+  return request;
+}
+
+function bodyToString(body: BodyInit | null | undefined): string {
+  return typeof body === "string" ? body : "";
+}
+
+function jsonResponse(
+  body: AnyMessage,
+  status: number,
+  headers: Record<string, string>,
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": JSON_MIME_TYPE,
+      ...headers,
+    },
+  });
+}

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -170,6 +170,71 @@ describe("createHttpStream", () => {
     }
   });
 
+  it("errors and clears local resources when initialize POST fails", async () => {
+    const clearSpy = vi.spyOn(MemoryAcpCookieStore.prototype, "clear");
+    const controlledFetch = createControlledFetch({
+      initializeCookies: ["transport=alpha; Path=/"],
+      initializeStatus: 401,
+      initializeBody: "expired",
+    });
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await expect(writer.write(initializeRequest)).rejects.toThrow(
+        "ACP initialize failed: 401",
+      );
+      expect(controlledFetch.requests).toHaveLength(1);
+      await flushMicrotasks();
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      await expect(reader.read()).rejects.toThrow("ACP initialize failed");
+    } finally {
+      clearSpy.mockRestore();
+      reader.releaseLock();
+      writer.releaseLock();
+      await closeStream(stream);
+    }
+  });
+
+  it("deletes the initialized connection when the initialize response is malformed", async () => {
+    const clearSpy = vi.spyOn(MemoryAcpCookieStore.prototype, "clear");
+    const controlledFetch = createControlledFetch({
+      initializeCookies: ["transport=alpha; Path=/"],
+      initializeResponse: { notJsonRpc: true },
+    });
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await expect(writer.write(initializeRequest)).rejects.toThrow(
+        "ACP initialize response was not a JSON-RPC message",
+      );
+      const deleteRequest = requestAt(controlledFetch.requests, 1);
+      expect(deleteRequest.method).toBe("DELETE");
+      expect(deleteRequest.headers.get(HEADER_CONNECTION_ID)).toBe(
+        "connection-1",
+      );
+      expect(deleteRequest.headers.get("Cookie")).toBe("transport=alpha");
+      expect(controlledFetch.sseRequests).toHaveLength(0);
+      await flushMicrotasks();
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      await expect(reader.read()).rejects.toThrow(
+        "ACP initialize response was not a JSON-RPC message",
+      );
+    } finally {
+      clearSpy.mockRestore();
+      reader.releaseLock();
+      writer.releaseLock();
+      await closeStream(stream);
+    }
+  });
+
   it("opens session SSE after session creation and includes the session header on session-scoped POSTs", async () => {
     const controlledFetch = createControlledFetch();
     const stream = createHttpStream("https://agent.example/acp", {
@@ -1084,6 +1149,9 @@ interface TestClientState {
 
 interface ControlledFetchOptions {
   readonly initializeCookies?: readonly string[];
+  readonly initializeStatus?: number;
+  readonly initializeBody?: string;
+  readonly initializeResponse?: unknown;
   readonly getCookies?: readonly string[];
   readonly getStatus?: number;
   readonly postStatus?: number;
@@ -1132,10 +1200,22 @@ function createControlledFetch(
       });
 
       if (method === "POST" && !headers.has(HEADER_CONNECTION_ID)) {
-        return jsonResponse(initializeResponse, 200, {
-          [HEADER_CONNECTION_ID]: "connection-1",
-          ...setCookieResponseHeaders(options.initializeCookies),
-        });
+        const status = options.initializeStatus ?? 200;
+        if (status !== 200) {
+          return new Response(options.initializeBody ?? null, {
+            status,
+            headers: setCookieResponseHeaders(options.initializeCookies),
+          });
+        }
+
+        return jsonResponse(
+          options.initializeResponse ?? initializeResponse,
+          200,
+          {
+            [HEADER_CONNECTION_ID]: "connection-1",
+            ...setCookieResponseHeaders(options.initializeCookies),
+          },
+        );
       }
 
       if (method === "DELETE" && options.deleteError) {
@@ -1303,7 +1383,7 @@ function bodyToString(body: BodyInit | null | undefined): string {
 }
 
 function jsonResponse(
-  body: AnyMessage,
+  body: unknown,
   status: number,
   headers: Record<string, string>,
 ): Response {

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -682,6 +682,13 @@ describe("createHttpStream", () => {
       await expect(writer.write(sessionNewRequest)).rejects.toThrow(
         "ACP POST failed: 401",
       );
+      const deleteRequest = requestAt(controlledFetch.requests, 3);
+      expect(deleteRequest.method).toBe("DELETE");
+      expect(deleteRequest.headers.get(HEADER_CONNECTION_ID)).toBe(
+        "connection-1",
+      );
+      expect(deleteRequest.headers.get("Cookie")).toBe("transport=alpha");
+      await flushMicrotasks();
       expect(sseAt(controlledFetch.sseRequests, 0).signal.aborted).toBe(true);
       expect(clearSpy).toHaveBeenCalledTimes(1);
       await expect(reader.read()).rejects.toThrow("ACP POST failed");

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -58,6 +58,16 @@ const sessionNewResponse = {
   },
 } satisfies AnyMessage;
 
+const sessionNewRequest = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "session/new",
+  params: {
+    cwd: "/tmp",
+    mcpServers: [],
+  },
+} satisfies AnyMessage;
+
 const promptRequest = {
   jsonrpc: "2.0",
   id: 2,
@@ -652,6 +662,37 @@ describe("createHttpStream", () => {
     }
   });
 
+  it("errors and tears down local resources when connected POST fails", async () => {
+    const clearSpy = vi.spyOn(MemoryAcpCookieStore.prototype, "clear");
+    const controlledFetch = createControlledFetch({
+      initializeCookies: ["transport=alpha; Path=/"],
+      postStatus: 401,
+      postBody: "expired",
+    });
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+
+      await expect(writer.write(sessionNewRequest)).rejects.toThrow(
+        "ACP POST failed: 401",
+      );
+      expect(sseAt(controlledFetch.sseRequests, 0).signal.aborted).toBe(true);
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      await expect(reader.read()).rejects.toThrow("ACP POST failed");
+    } finally {
+      clearSpy.mockRestore();
+      reader.releaseLock();
+      writer.releaseLock();
+      await closeStream(stream);
+    }
+  });
+
   it("cleans up local resources when DELETE rejects during close", async () => {
     const clearSpy = vi.spyOn(MemoryAcpCookieStore.prototype, "clear");
     const controlledFetch = createControlledFetch({
@@ -1038,6 +1079,8 @@ interface ControlledFetchOptions {
   readonly initializeCookies?: readonly string[];
   readonly getCookies?: readonly string[];
   readonly getStatus?: number;
+  readonly postStatus?: number;
+  readonly postBody?: string;
   readonly deleteError?: Error;
   readonly sseResponseDelays?: ReadonlyMap<number, Promise<void>>;
 }
@@ -1090,6 +1133,16 @@ function createControlledFetch(
 
       if (method === "DELETE" && options.deleteError) {
         throw options.deleteError;
+      }
+
+      if (
+        method === "POST" &&
+        headers.has(HEADER_CONNECTION_ID) &&
+        options.postStatus !== undefined
+      ) {
+        return new Response(options.postBody ?? null, {
+          status: options.postStatus,
+        });
       }
 
       if (method === "POST" || method === "DELETE") {

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -199,11 +199,16 @@ describe("createHttpStream", () => {
     }
   });
 
-  it("deletes the initialized connection when the initialize response is malformed", async () => {
+  it("deletes the initialized connection when the initialize body is not a response", async () => {
     const clearSpy = vi.spyOn(MemoryAcpCookieStore.prototype, "clear");
     const controlledFetch = createControlledFetch({
       initializeCookies: ["transport=alpha; Path=/"],
-      initializeResponse: { notJsonRpc: true },
+      initializeResponse: {
+        jsonrpc: "2.0",
+        id: 0,
+        method: "session/new",
+        params: {},
+      },
     });
     const stream = createHttpStream("https://agent.example/acp", {
       fetch: controlledFetch.fetch,
@@ -213,7 +218,7 @@ describe("createHttpStream", () => {
 
     try {
       await expect(writer.write(initializeRequest)).rejects.toThrow(
-        "ACP initialize response was not a JSON-RPC message",
+        "ACP initialize response was not a JSON-RPC response",
       );
       const deleteRequest = requestAt(controlledFetch.requests, 1);
       expect(deleteRequest.method).toBe("DELETE");
@@ -225,7 +230,46 @@ describe("createHttpStream", () => {
       await flushMicrotasks();
       expect(clearSpy).toHaveBeenCalledTimes(1);
       await expect(reader.read()).rejects.toThrow(
-        "ACP initialize response was not a JSON-RPC message",
+        "ACP initialize response was not a JSON-RPC response",
+      );
+    } finally {
+      clearSpy.mockRestore();
+      reader.releaseLock();
+      writer.releaseLock();
+      await closeStream(stream);
+    }
+  });
+
+  it("deletes the initialized connection when the initialize response id does not match", async () => {
+    const clearSpy = vi.spyOn(MemoryAcpCookieStore.prototype, "clear");
+    const controlledFetch = createControlledFetch({
+      initializeCookies: ["transport=alpha; Path=/"],
+      initializeResponse: {
+        ...initializeResponse,
+        id: 999,
+      },
+    });
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await expect(writer.write(initializeRequest)).rejects.toThrow(
+        "ACP initialize response id did not match initialize request",
+      );
+      const deleteRequest = requestAt(controlledFetch.requests, 1);
+      expect(deleteRequest.method).toBe("DELETE");
+      expect(deleteRequest.headers.get(HEADER_CONNECTION_ID)).toBe(
+        "connection-1",
+      );
+      expect(deleteRequest.headers.get("Cookie")).toBe("transport=alpha");
+      expect(controlledFetch.sseRequests).toHaveLength(0);
+      await flushMicrotasks();
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      await expect(reader.read()).rejects.toThrow(
+        "ACP initialize response id did not match initialize request",
       );
     } finally {
       clearSpy.mockRestore();

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -680,6 +680,29 @@ describe("createHttpStream", () => {
     }
   });
 
+  it("propagates DELETE failures from readable cancel", async () => {
+    const controlledFetch = createControlledFetch({
+      deleteError: new Error("Network dropped"),
+    });
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+
+      await expect(reader.cancel()).rejects.toThrow("Network dropped");
+      expect(sseAt(controlledFetch.sseRequests, 0).signal.aborted).toBe(true);
+    } finally {
+      reader.releaseLock();
+      writer.releaseLock();
+      await closeStream(stream);
+    }
+  });
+
   it("runs initialize, newSession, and prompt through ClientSideConnection", async () => {
     const updates: SessionNotification[] = [];
     const server = await startTestServer(

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -834,6 +834,87 @@ describe("createHttpStream", () => {
     }
   });
 
+  it("aborts in-flight connected POSTs when closed", async () => {
+    const connectedPostAborted = createDeferred<void>();
+    const requests: RecordedRequest[] = [];
+    const fetch: typeof globalThis.fetch = async (input, init) => {
+      const method = init?.method ?? "GET";
+      const headers = new Headers(init?.headers);
+      const signal = init?.signal;
+      requests.push({
+        url: String(input),
+        method,
+        headers,
+        body: bodyToString(init?.body),
+        credentials: init?.credentials,
+        signal,
+      });
+
+      if (method === "POST" && !headers.has(HEADER_CONNECTION_ID)) {
+        return jsonResponse(initializeResponse, 200, {
+          [HEADER_CONNECTION_ID]: "connection-1",
+        });
+      }
+
+      if (method === "GET") {
+        return sseResponse(signal);
+      }
+
+      if (method === "POST" && headers.has(HEADER_CONNECTION_ID)) {
+        return await new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => {
+              connectedPostAborted.resolve();
+              reject(new Error("connected POST aborted"));
+            },
+            { once: true },
+          );
+        });
+      }
+
+      if (method === "DELETE") {
+        return new Response(null, { status: 202 });
+      }
+
+      throw new Error(`Unexpected ${method} request`);
+    };
+    const stream = createHttpStream("https://agent.example/acp", { fetch });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+
+      const write = writer.write(sessionNewRequest);
+      await flushMicrotasks();
+
+      const postRequest = requestAt(requests, 2);
+      expect(postRequest.method).toBe("POST");
+      expect(postRequest.headers.get(HEADER_CONNECTION_ID)).toBe(
+        "connection-1",
+      );
+      expect(postRequest.signal?.aborted).toBe(false);
+
+      const cancel = reader.cancel();
+      await connectedPostAborted.promise;
+
+      expect(postRequest.signal?.aborted).toBe(true);
+      await expect(write).rejects.toThrow("connected POST aborted");
+      await cancel;
+
+      const deleteRequest = requestAt(requests, 3);
+      expect(deleteRequest.method).toBe("DELETE");
+      expect(deleteRequest.headers.get(HEADER_CONNECTION_ID)).toBe(
+        "connection-1",
+      );
+    } finally {
+      writer.releaseLock();
+      await closeStream(stream);
+    }
+  });
+
   it("errors and tears down local resources when connected POST fails", async () => {
     const clearSpy = vi.spyOn(MemoryAcpCookieStore.prototype, "clear");
     const controlledFetch = createControlledFetch({
@@ -1234,6 +1315,7 @@ interface RecordedRequest {
   readonly headers: Headers;
   readonly body: string;
   readonly credentials: RequestCredentials | undefined;
+  readonly signal: AbortSignal | null | undefined;
 }
 
 interface RecordedSseRequest {
@@ -1304,6 +1386,7 @@ function createControlledFetch(
         headers,
         body: bodyToString(init?.body),
         credentials: init?.credentials,
+        signal: init?.signal,
       });
 
       if (method === "POST" && !headers.has(HEADER_CONNECTION_ID)) {
@@ -1499,6 +1582,22 @@ function jsonResponse(
     headers: {
       "Content-Type": JSON_MIME_TYPE,
       ...headers,
+    },
+  });
+}
+
+function sseResponse(signal: AbortSignal | null | undefined): Response {
+  const stream = new TransformStream<Uint8Array, Uint8Array>();
+  const writer = stream.writable.getWriter();
+
+  signal?.addEventListener("abort", () => {
+    void writer.close().catch(() => undefined);
+  });
+
+  return new Response(stream.readable, {
+    status: 200,
+    headers: {
+      "Content-Type": EVENT_STREAM_MIME_TYPE,
     },
   });
 }

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -137,6 +137,82 @@ describe("createHttpStream", () => {
     }
   });
 
+  it("propagates cookies across initialize, SSE, session POST, and DELETE", async () => {
+    const controlledFetch = createControlledFetch({
+      initializeCookies: ["transport=alpha; Path=/"],
+      getCookies: ["route=bravo; Path=/"],
+    });
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+      headers: {
+        Cookie: "caller=custom; transport=caller",
+      },
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+      await controlledFetch.sendSse(0, sessionNewResponse);
+      await readMessage(reader);
+      await writer.write(promptRequest);
+      await writer.close();
+
+      expect(requestAt(controlledFetch.requests, 0).credentials).toBe(
+        "include",
+      );
+      expect(requestAt(controlledFetch.requests, 0).headers.get("Cookie")).toBe(
+        "caller=custom; transport=caller",
+      );
+      expect(requestAt(controlledFetch.requests, 1).headers.get("Cookie")).toBe(
+        "transport=caller; caller=custom",
+      );
+      expect(requestAt(controlledFetch.requests, 2).headers.get("Cookie")).toBe(
+        "transport=caller; route=bravo; caller=custom",
+      );
+      expect(requestAt(controlledFetch.requests, 3).headers.get("Cookie")).toBe(
+        "transport=caller; route=bravo; caller=custom",
+      );
+      expect(requestAt(controlledFetch.requests, 4).headers.get("Cookie")).toBe(
+        "transport=caller; route=bravo; caller=custom",
+      );
+      expect(
+        controlledFetch.requests.map((request) => request.credentials),
+      ).toEqual(["include", "include", "include", "include", "include"]);
+    } finally {
+      reader.releaseLock();
+      writer.releaseLock();
+    }
+  });
+
+  it("omits managed cookies when cookie handling is disabled", async () => {
+    const controlledFetch = createControlledFetch({
+      initializeCookies: ["transport=alpha; Path=/"],
+    });
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+      cookies: "omit",
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+
+      expect(requestAt(controlledFetch.requests, 0).credentials).toBe("omit");
+      expect(requestAt(controlledFetch.requests, 1).credentials).toBe("omit");
+      expect(
+        requestAt(controlledFetch.requests, 1).headers.get("Cookie"),
+      ).toBeNull();
+    } finally {
+      reader.releaseLock();
+      writer.releaseLock();
+      await stream.writable.close();
+    }
+  });
+
   it("sends DELETE and aborts SSE requests when closed", async () => {
     const controlledFetch = createControlledFetch();
     const stream = createHttpStream("https://agent.example/acp", {
@@ -330,6 +406,7 @@ interface RecordedRequest {
   readonly method: string;
   readonly headers: Headers;
   readonly body: string;
+  readonly credentials: RequestCredentials | undefined;
 }
 
 interface RecordedSseRequest {
@@ -349,7 +426,14 @@ interface TestClientState {
   readonly permissionRequests?: RequestPermissionRequest[];
 }
 
-function createControlledFetch(): ControlledFetch {
+interface ControlledFetchOptions {
+  readonly initializeCookies?: readonly string[];
+  readonly getCookies?: readonly string[];
+}
+
+function createControlledFetch(
+  options: ControlledFetchOptions = {},
+): ControlledFetch {
   const requests: RecordedRequest[] = [];
   const sseRequests: RecordedSseRequest[] = [];
   const encoder = new TextEncoder();
@@ -365,11 +449,13 @@ function createControlledFetch(): ControlledFetch {
         method,
         headers,
         body: bodyToString(init?.body),
+        credentials: init?.credentials,
       });
 
       if (method === "POST" && !headers.has(HEADER_CONNECTION_ID)) {
         return jsonResponse(initializeResponse, 200, {
           [HEADER_CONNECTION_ID]: "connection-1",
+          ...setCookieResponseHeaders(options.initializeCookies),
         });
       }
 
@@ -395,7 +481,10 @@ function createControlledFetch(): ControlledFetch {
 
         return new Response(stream.readable, {
           status: 200,
-          headers: { "Content-Type": EVENT_STREAM_MIME_TYPE },
+          headers: {
+            "Content-Type": EVENT_STREAM_MIME_TYPE,
+            ...setCookieResponseHeaders(options.getCookies),
+          },
         });
       }
 
@@ -484,4 +573,10 @@ function jsonResponse(
       ...headers,
     },
   });
+}
+
+function setCookieResponseHeaders(
+  cookies: readonly string[] | undefined,
+): Record<string, string> {
+  return cookies ? { "Set-Cookie": cookies.join(", ") } : {};
 }

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ClientSideConnection, PROTOCOL_VERSION } from "./acp.js";
-import { createHttpStream } from "./http-stream.js";
+import { MemoryAcpCookieStore, createHttpStream } from "./http-stream.js";
 import {
   EVENT_STREAM_MIME_TYPE,
   HEADER_CONNECTION_ID,
@@ -12,8 +12,17 @@ import { TestAgent } from "./test-support/test-agent.js";
 import { startTestServer } from "./test-support/test-http-server.js";
 
 import type {
+  Agent,
   AgentSideConnection,
   Client,
+  InitializeRequest,
+  InitializeResponse,
+  LoadSessionRequest,
+  LoadSessionResponse,
+  NewSessionRequest,
+  NewSessionResponse,
+  PromptRequest,
+  PromptResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
   SessionNotification,
@@ -317,6 +326,193 @@ describe("createHttpStream", () => {
     }
   });
 
+  it("clears SDK-owned ephemeral cookies when the stream errors", async () => {
+    const clearSpy = vi.spyOn(MemoryAcpCookieStore.prototype, "clear");
+    const controlledFetch = createControlledFetch({
+      initializeCookies: ["transport=alpha; Path=/"],
+      getStatus: 500,
+    });
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      expect(await readMessage(reader)).toEqual(initializeResponse);
+
+      await expect(reader.read()).rejects.toThrow("ACP SSE connection failed");
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      clearSpy.mockRestore();
+      reader.releaseLock();
+      writer.releaseLock();
+      await stream.writable.close();
+    }
+  });
+
+  it("preserves caller-owned cookies when the stream errors", async () => {
+    const cookieStore = new MemoryAcpCookieStore();
+    const clearSpy = vi.spyOn(cookieStore, "clear");
+    const firstFetch = createControlledFetch({
+      initializeCookies: ["transport=alpha; Path=/"],
+      getStatus: 500,
+    });
+    const firstStream = createHttpStream("https://agent.example/acp", {
+      fetch: firstFetch.fetch,
+      cookieStore,
+    });
+    const firstWriter = firstStream.writable.getWriter();
+    const firstReader = firstStream.readable.getReader();
+
+    try {
+      await firstWriter.write(initializeRequest);
+      expect(await readMessage(firstReader)).toEqual(initializeResponse);
+      await expect(firstReader.read()).rejects.toThrow(
+        "ACP SSE connection failed",
+      );
+      expect(clearSpy).not.toHaveBeenCalled();
+    } finally {
+      clearSpy.mockRestore();
+      firstReader.releaseLock();
+      firstWriter.releaseLock();
+      await firstStream.writable.close();
+    }
+
+    const secondFetch = createControlledFetch();
+    const secondStream = createHttpStream("https://agent.example/acp", {
+      fetch: secondFetch.fetch,
+      cookieStore,
+    });
+    const secondWriter = secondStream.writable.getWriter();
+    const secondReader = secondStream.readable.getReader();
+
+    try {
+      await secondWriter.write(initializeRequest);
+      await readMessage(secondReader);
+
+      expect(requestAt(secondFetch.requests, 0).headers.get("Cookie")).toBe(
+        "transport=alpha",
+      );
+    } finally {
+      secondReader.releaseLock();
+      secondWriter.releaseLock();
+      await secondStream.writable.close();
+    }
+  });
+
+  it("preserves caller-owned cookies across separate stream instances", async () => {
+    const cookieStore = new MemoryAcpCookieStore();
+    const firstFetch = createControlledFetch({
+      initializeCookies: ["transport=alpha; Path=/"],
+    });
+    const firstStream = createHttpStream("https://agent.example/acp", {
+      fetch: firstFetch.fetch,
+      cookieStore,
+    });
+    const firstWriter = firstStream.writable.getWriter();
+    const firstReader = firstStream.readable.getReader();
+
+    try {
+      await firstWriter.write(initializeRequest);
+      await readMessage(firstReader);
+      await firstWriter.close();
+    } finally {
+      firstReader.releaseLock();
+      firstWriter.releaseLock();
+    }
+
+    const secondFetch = createControlledFetch();
+    const secondStream = createHttpStream("https://agent.example/acp", {
+      fetch: secondFetch.fetch,
+      cookieStore,
+    });
+    const secondWriter = secondStream.writable.getWriter();
+    const secondReader = secondStream.readable.getReader();
+
+    try {
+      await secondWriter.write(initializeRequest);
+      await readMessage(secondReader);
+
+      expect(requestAt(secondFetch.requests, 0).headers.get("Cookie")).toBe(
+        "transport=alpha",
+      );
+    } finally {
+      secondReader.releaseLock();
+      secondWriter.releaseLock();
+      await secondStream.writable.close();
+    }
+  });
+
+  it("clears SDK-owned ephemeral cookies when the stream closes", async () => {
+    const firstFetch = createControlledFetch({
+      initializeCookies: ["transport=alpha; Path=/"],
+    });
+    const firstStream = createHttpStream("https://agent.example/acp", {
+      fetch: firstFetch.fetch,
+    });
+    const firstWriter = firstStream.writable.getWriter();
+    const firstReader = firstStream.readable.getReader();
+
+    try {
+      await firstWriter.write(initializeRequest);
+      await readMessage(firstReader);
+      await firstWriter.close();
+    } finally {
+      firstReader.releaseLock();
+      firstWriter.releaseLock();
+    }
+
+    const secondFetch = createControlledFetch();
+    const secondStream = createHttpStream("https://agent.example/acp", {
+      fetch: secondFetch.fetch,
+    });
+    const secondWriter = secondStream.writable.getWriter();
+    const secondReader = secondStream.readable.getReader();
+
+    try {
+      await secondWriter.write(initializeRequest);
+      await readMessage(secondReader);
+
+      expect(
+        requestAt(secondFetch.requests, 0).headers.get("Cookie"),
+      ).toBeNull();
+    } finally {
+      secondReader.releaseLock();
+      secondWriter.releaseLock();
+      await secondStream.writable.close();
+    }
+  });
+
+  it("lets caller Cookie headers override caller-owned store values", async () => {
+    const cookieStore = new MemoryAcpCookieStore();
+    cookieStore.store(headersWithSetCookie(["transport=alpha", "route=bravo"]));
+    const controlledFetch = createControlledFetch();
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+      cookieStore,
+      headers: {
+        Cookie: "route=caller; caller=custom",
+      },
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+
+      expect(requestAt(controlledFetch.requests, 0).headers.get("Cookie")).toBe(
+        "transport=alpha; route=caller; caller=custom",
+      );
+    } finally {
+      reader.releaseLock();
+      writer.releaseLock();
+      await stream.writable.close();
+    }
+  });
+
   it("sends DELETE and aborts SSE requests when closed", async () => {
     const controlledFetch = createControlledFetch();
     const stream = createHttpStream("https://agent.example/acp", {
@@ -450,6 +646,75 @@ describe("createHttpStream", () => {
     }
   });
 
+  it("loads durable sessions after an HTTP reconnect", async () => {
+    const durableSessions = new Map<string, DurableSessionState>();
+    const connectionIds: string[] = [];
+    const fetch = recordInitializeConnectionIds(connectionIds);
+    const server = await startTestServer(
+      (conn: AgentSideConnection) =>
+        new DurableSessionAgent(conn, durableSessions),
+    );
+
+    try {
+      const firstUpdates: SessionNotification[] = [];
+      const firstStream = createHttpStream(server.url, { fetch });
+      const firstConn = new ClientSideConnection(
+        () => createTestClient({ updates: firstUpdates }),
+        firstStream,
+      );
+      const initialized = await firstConn.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      });
+      expect(initialized.agentCapabilities?.loadSession).toBe(true);
+      const session = await firstConn.newSession({
+        cwd: "/tmp",
+        mcpServers: [],
+      });
+      await expect(
+        firstConn.prompt({
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "Remember this" }],
+        }),
+      ).resolves.toEqual({ stopReason: "end_turn" });
+      await waitForUpdates(firstUpdates, 1);
+      await closeStream(firstStream);
+
+      expect(durableSessions.has(session.sessionId)).toBe(true);
+
+      const secondUpdates: SessionNotification[] = [];
+      const secondStream = createHttpStream(server.url, { fetch });
+      const secondConn = new ClientSideConnection(
+        () => createTestClient({ updates: secondUpdates }),
+        secondStream,
+      );
+      const reinitialized = await secondConn.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      });
+      expect(reinitialized.agentCapabilities?.loadSession).toBe(true);
+
+      // Production agents must authorize session/load against the authenticated
+      // principal. This SDK transport test omits auth because there is no
+      // generic auth layer in the SDK.
+      await expect(
+        secondConn.loadSession({
+          sessionId: session.sessionId,
+          cwd: "/tmp",
+          mcpServers: [],
+        }),
+      ).resolves.toEqual({});
+      await waitForUpdates(secondUpdates, firstUpdates.length);
+      await closeStream(secondStream);
+
+      expect(connectionIds).toHaveLength(2);
+      expect(connectionIds[0]).not.toBe(connectionIds[1]);
+      expect(secondUpdates).toEqual(firstUpdates);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("keeps multiple sessions isolated through the SDK client abstraction", async () => {
     const updates: SessionNotification[] = [];
     const server = await startTestServer();
@@ -505,6 +770,79 @@ describe("createHttpStream", () => {
   });
 });
 
+interface DurableSessionState {
+  readonly cwd: string;
+  readonly history: SessionNotification[];
+}
+
+class DurableSessionAgent implements Agent {
+  constructor(
+    private readonly connection: AgentSideConnection,
+    private readonly sessions: Map<string, DurableSessionState>,
+  ) {}
+
+  initialize(_params: InitializeRequest): Promise<InitializeResponse> {
+    return Promise.resolve({
+      protocolVersion: PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: true,
+      },
+    });
+  }
+
+  newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
+    const sessionId = globalThis.crypto.randomUUID();
+    this.sessions.set(sessionId, {
+      cwd: params.cwd,
+      history: [],
+    });
+    return Promise.resolve({ sessionId });
+  }
+
+  async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
+    const session = this.sessions.get(params.sessionId);
+    if (!session) {
+      throw new Error(`Unknown durable session: ${params.sessionId}`);
+    }
+
+    for (const update of session.history) {
+      await this.connection.sessionUpdate(update);
+    }
+
+    return {};
+  }
+
+  async prompt(params: PromptRequest): Promise<PromptResponse> {
+    const session = this.sessions.get(params.sessionId);
+    if (!session) {
+      throw new Error(`Unknown durable session: ${params.sessionId}`);
+    }
+
+    const update: SessionNotification = {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: `durable-history:${session.cwd}`,
+        },
+      },
+    };
+    session.history.push(update);
+    await this.connection.sessionUpdate(update);
+
+    return { stopReason: "end_turn" };
+  }
+
+  cancel(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  authenticate(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
 interface RecordedRequest {
   readonly url: string;
   readonly method: string;
@@ -533,6 +871,25 @@ interface TestClientState {
 interface ControlledFetchOptions {
   readonly initializeCookies?: readonly string[];
   readonly getCookies?: readonly string[];
+  readonly getStatus?: number;
+}
+
+function recordInitializeConnectionIds(
+  connectionIds: string[],
+): typeof globalThis.fetch {
+  return async (input, init) => {
+    const response = await globalThis.fetch(input, init);
+    const headers = new Headers(init?.headers);
+
+    if (init?.method === "POST" && !headers.has(HEADER_CONNECTION_ID)) {
+      const connectionId = response.headers.get(HEADER_CONNECTION_ID);
+      if (connectionId) {
+        connectionIds.push(connectionId);
+      }
+    }
+
+    return response;
+  };
 }
 
 function createControlledFetch(
@@ -568,6 +925,14 @@ function createControlledFetch(
       }
 
       if (method === "GET") {
+        const status = options.getStatus ?? 200;
+        if (status !== 200) {
+          return new Response("SSE failed", {
+            status,
+            headers: setCookieResponseHeaders(options.getCookies),
+          });
+        }
+
         const stream = new TransformStream<Uint8Array, Uint8Array>();
         const writer = stream.writable.getWriter();
         const signal = init?.signal;
@@ -637,6 +1002,20 @@ async function readMessage(
   return result.value;
 }
 
+async function waitForUpdates(
+  updates: readonly SessionNotification[],
+  count: number,
+): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (updates.length < count) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${count} session updates`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+
 function requestAt(
   requests: readonly RecordedRequest[],
   index: number,
@@ -677,6 +1056,16 @@ function jsonResponse(
       ...headers,
     },
   });
+}
+
+function headersWithSetCookie(values: readonly string[]): Headers {
+  const headers = new Headers();
+
+  Object.defineProperty(headers, "getSetCookie", {
+    value: () => values,
+  });
+
+  return headers;
 }
 
 function setCookieResponseHeaders(

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -623,6 +623,34 @@ describe("createHttpStream", () => {
     }
   });
 
+  it("cleans up local resources when DELETE rejects during close", async () => {
+    const clearSpy = vi.spyOn(MemoryAcpCookieStore.prototype, "clear");
+    const controlledFetch = createControlledFetch({
+      initializeCookies: ["transport=alpha; Path=/"],
+      deleteError: new Error("Network dropped"),
+    });
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+
+      await expect(writer.close()).rejects.toThrow("Network dropped");
+      expect(sseAt(controlledFetch.sseRequests, 0).signal.aborted).toBe(true);
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      expect((await reader.read()).done).toBe(true);
+    } finally {
+      clearSpy.mockRestore();
+      reader.releaseLock();
+      writer.releaseLock();
+      await closeStream(stream);
+    }
+  });
+
   it("runs initialize, newSession, and prompt through ClientSideConnection", async () => {
     const updates: SessionNotification[] = [];
     const server = await startTestServer(
@@ -958,6 +986,7 @@ interface ControlledFetchOptions {
   readonly initializeCookies?: readonly string[];
   readonly getCookies?: readonly string[];
   readonly getStatus?: number;
+  readonly deleteError?: Error;
 }
 
 function recordInitializeConnectionIds(
@@ -1004,6 +1033,10 @@ function createControlledFetch(
           [HEADER_CONNECTION_ID]: "connection-1",
           ...setCookieResponseHeaders(options.initializeCookies),
         });
+      }
+
+      if (method === "DELETE" && options.deleteError) {
+        throw options.deleteError;
       }
 
       if (method === "POST" || method === "DELETE") {

--- a/src/http-stream.test.ts
+++ b/src/http-stream.test.ts
@@ -59,6 +59,48 @@ const promptRequest = {
   },
 } satisfies AnyMessage;
 
+const loadSessionRequest = {
+  jsonrpc: "2.0",
+  id: 3,
+  method: "session/load",
+  params: {
+    cwd: "/tmp",
+    mcpServers: [],
+    sessionId: "existing-session",
+  },
+} satisfies AnyMessage;
+
+const permissionRequest = {
+  jsonrpc: "2.0",
+  id: 99,
+  method: "session/request_permission",
+  params: {
+    sessionId: "session-1",
+    toolCall: {
+      toolCallId: "permission-tool",
+      title: "Permission tool",
+    },
+    options: [
+      {
+        kind: "allow_once",
+        name: "Allow once",
+        optionId: "allow",
+      },
+    ],
+  },
+} satisfies AnyMessage;
+
+const permissionResponse = {
+  jsonrpc: "2.0",
+  id: 99,
+  result: {
+    outcome: {
+      outcome: "selected",
+      optionId: "allow",
+    },
+  },
+} satisfies AnyMessage;
+
 describe("createHttpStream", () => {
   it("posts initialize with custom headers, opens connection SSE, and emits the initialize response", async () => {
     const controlledFetch = createControlledFetch();
@@ -130,6 +172,68 @@ describe("createHttpStream", () => {
       expect(promptPost.headers.get(HEADER_CONNECTION_ID)).toBe("connection-1");
       expect(promptPost.headers.get(HEADER_SESSION_ID)).toBe("session-1");
       expect(JSON.parse(promptPost.body)).toEqual(promptRequest);
+    } finally {
+      reader.releaseLock();
+      writer.releaseLock();
+      await stream.writable.close();
+    }
+  });
+
+  it("opens session SSE before posting session/load for an existing session", async () => {
+    const controlledFetch = createControlledFetch();
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+      await writer.write(loadSessionRequest);
+
+      const sessionGet = requestAt(controlledFetch.requests, 2);
+      const loadPost = requestAt(controlledFetch.requests, 3);
+
+      expect(sessionGet.method).toBe("GET");
+      expect(sessionGet.headers.get(HEADER_CONNECTION_ID)).toBe("connection-1");
+      expect(sessionGet.headers.get(HEADER_SESSION_ID)).toBe(
+        "existing-session",
+      );
+      expect(loadPost.method).toBe("POST");
+      expect(loadPost.headers.get(HEADER_CONNECTION_ID)).toBe("connection-1");
+      expect(loadPost.headers.get(HEADER_SESSION_ID)).toBe("existing-session");
+    } finally {
+      reader.releaseLock();
+      writer.releaseLock();
+      await stream.writable.close();
+    }
+  });
+
+  it("includes the session header on responses to session-scoped server requests", async () => {
+    const controlledFetch = createControlledFetch();
+    const stream = createHttpStream("https://agent.example/acp", {
+      fetch: controlledFetch.fetch,
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      await writer.write(initializeRequest);
+      await readMessage(reader);
+      await controlledFetch.sendSse(0, sessionNewResponse);
+      await readMessage(reader);
+      await controlledFetch.sendSse(1, permissionRequest);
+      await readMessage(reader);
+      await writer.write(permissionResponse);
+
+      const responsePost = requestAt(controlledFetch.requests, 3);
+      expect(responsePost.method).toBe("POST");
+      expect(responsePost.headers.get(HEADER_CONNECTION_ID)).toBe(
+        "connection-1",
+      );
+      expect(responsePost.headers.get(HEADER_SESSION_ID)).toBe("session-1");
+      expect(JSON.parse(responsePost.body)).toEqual(permissionResponse);
     } finally {
       reader.releaseLock();
       writer.releaseLock();

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -1,4 +1,4 @@
-import { isJsonRpcMessage } from "./jsonrpc.js";
+import { isJsonRpcMessage, isResponseMessage } from "./jsonrpc.js";
 import {
   EVENT_STREAM_MIME_TYPE,
   HEADER_CONNECTION_ID,
@@ -66,6 +66,7 @@ class HttpStreamTransport {
   private readonly abortController = new AbortController();
   private readonly knownSessions = new Set<string>();
   private readonly pendingResponseSessions = new Map<string, string>();
+  private readonly pendingSessionRequests = new Map<string, string>();
 
   private readableController:
     | ReadableStreamDefaultController<AnyMessage>
@@ -162,18 +163,35 @@ class HttpStreamTransport {
       this.openSessionSse(sessionId);
     }
 
-    const response = await this.fetchRequest({
-      method: "POST",
-      headers: {
-        "Content-Type": JSON_MIME_TYPE,
-        [HEADER_CONNECTION_ID]: connectionId,
-        ...(sessionId ? { [HEADER_SESSION_ID]: sessionId } : {}),
-      },
-      body: JSON.stringify(message),
-    });
+    const pendingSessionRequestKey =
+      sessionId && "method" in message && "id" in message
+        ? messageIdKey(message.id)
+        : undefined;
 
-    if (!response.ok) {
-      throw await httpError("ACP POST failed", response);
+    if (sessionId && pendingSessionRequestKey) {
+      this.pendingSessionRequests.set(pendingSessionRequestKey, sessionId);
+    }
+
+    try {
+      const response = await this.fetchRequest({
+        method: "POST",
+        headers: {
+          "Content-Type": JSON_MIME_TYPE,
+          [HEADER_CONNECTION_ID]: connectionId,
+          ...(sessionId ? { [HEADER_SESSION_ID]: sessionId } : {}),
+        },
+        body: JSON.stringify(message),
+      });
+
+      if (!response.ok) {
+        throw await httpError("ACP POST failed", response);
+      }
+    } catch (error) {
+      if (pendingSessionRequestKey) {
+        this.pendingSessionRequests.delete(pendingSessionRequestKey);
+      }
+
+      throw error;
     }
   }
 
@@ -221,6 +239,8 @@ class HttpStreamTransport {
   }
 
   private async openSse(headers: Record<string, string>): Promise<void> {
+    const streamSessionId = headers[HEADER_SESSION_ID];
+
     try {
       const response = await this.fetchRequest({
         method: "GET",
@@ -250,14 +270,34 @@ class HttpStreamTransport {
         }
 
         this.trackServerRequestRoute(message, headers[HEADER_SESSION_ID]);
+        this.trackInboundResponse(message);
         this.enqueue(message);
       }
+
+      this.handleSseEof(streamSessionId);
     } catch (error) {
       if (this.isClosed || this.abortController.signal.aborted) {
         return;
       }
 
       this.errorReadable(error);
+    }
+  }
+
+  private handleSseEof(streamSessionId: string | undefined): void {
+    if (this.isClosed || this.abortController.signal.aborted) {
+      return;
+    }
+
+    if (!streamSessionId) {
+      this.errorReadable(new Error("ACP connection SSE stream closed"));
+      return;
+    }
+
+    this.knownSessions.delete(streamSessionId);
+
+    if (this.hasPendingSessionRequest(streamSessionId)) {
+      this.errorReadable(new Error("ACP session SSE stream closed"));
     }
   }
 
@@ -273,6 +313,27 @@ class HttpStreamTransport {
     if (key) {
       this.pendingResponseSessions.set(key, streamSessionId);
     }
+  }
+
+  private trackInboundResponse(message: AnyMessage): void {
+    if (!isResponseMessage(message)) {
+      return;
+    }
+
+    const key = messageIdKey(message.id);
+    if (key) {
+      this.pendingSessionRequests.delete(key);
+    }
+  }
+
+  private hasPendingSessionRequest(sessionId: string): boolean {
+    for (const pendingSessionId of this.pendingSessionRequests.values()) {
+      if (pendingSessionId === sessionId) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private async fetchRequest(init: RequestInit): Promise<Response> {

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -186,6 +186,13 @@ class HttpStreamTransport {
       if (!response.ok) {
         throw await httpError("ACP POST failed", response);
       }
+
+      if (!("method" in message) && "id" in message) {
+        const key = messageIdKey(message.id);
+        if (key) {
+          this.pendingResponseSessions.delete(key);
+        }
+      }
     } catch (error) {
       if (pendingSessionRequestKey) {
         this.pendingSessionRequests.delete(pendingSessionRequestKey);

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -220,6 +220,7 @@ class HttpStreamTransport {
           ...(sessionId ? { [HEADER_SESSION_ID]: sessionId } : {}),
         },
         body: JSON.stringify(message),
+        signal: this.abortController.signal,
       });
 
       if (!response.ok) {

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -97,9 +97,7 @@ class HttpStreamTransport {
         start: (controller) => {
           this.readableController = controller;
         },
-        cancel: () => {
-          void this.close();
-        },
+        cancel: () => this.close(),
       }),
       writable: new WritableStream<AnyMessage>({
         write: (message) => {

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -5,6 +5,7 @@ import {
   HEADER_SESSION_ID,
   JSON_MIME_TYPE,
   isInitializeRequest,
+  messageIdKey,
   sessionIdFromMessageParams,
   sessionIdFromResponseResult,
 } from "./protocol.js";
@@ -44,6 +45,7 @@ class HttpStreamTransport {
   private readonly cookieJar = new ConnectionCookieJar();
   private readonly abortController = new AbortController();
   private readonly knownSessions = new Set<string>();
+  private readonly pendingResponseSessions = new Map<string, string>();
 
   private readableController:
     | ReadableStreamDefaultController<AnyMessage>
@@ -133,7 +135,11 @@ class HttpStreamTransport {
       throw new Error("ACP HTTP stream is not initialized");
     }
 
-    const sessionId = sessionIdFromMessageParams(message);
+    const sessionId = this.sessionIdForOutboundMessage(message);
+    if (sessionId) {
+      this.openSessionSse(sessionId);
+    }
+
     const response = await this.fetchRequest({
       method: "POST",
       headers: {
@@ -147,6 +153,20 @@ class HttpStreamTransport {
     if (!response.ok) {
       throw await httpError("ACP POST failed", response);
     }
+  }
+
+  private sessionIdForOutboundMessage(message: AnyMessage): string | undefined {
+    const paramsSessionId = sessionIdFromMessageParams(message);
+    if (paramsSessionId) {
+      return paramsSessionId;
+    }
+
+    if (!("id" in message) || "method" in message) {
+      return undefined;
+    }
+
+    const key = messageIdKey(message.id);
+    return key ? this.pendingResponseSessions.get(key) : undefined;
   }
 
   private openConnectionSse(): void {
@@ -207,6 +227,7 @@ class HttpStreamTransport {
           this.openSessionSse(sessionId);
         }
 
+        this.trackServerRequestRoute(message, headers[HEADER_SESSION_ID]);
         this.enqueue(message);
       }
     } catch (error) {
@@ -215,6 +236,20 @@ class HttpStreamTransport {
       }
 
       this.errorReadable(error);
+    }
+  }
+
+  private trackServerRequestRoute(
+    message: AnyMessage,
+    streamSessionId: string | undefined,
+  ): void {
+    if (!streamSessionId || !("method" in message) || !("id" in message)) {
+      return;
+    }
+
+    const key = messageIdKey(message.id);
+    if (key) {
+      this.pendingResponseSessions.set(key, streamSessionId);
     }
   }
 

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -1,4 +1,4 @@
-import { isJsonRpcMessage, isResponseMessage } from "./jsonrpc.js";
+import { isResponseMessage } from "./jsonrpc.js";
 import {
   EVENT_STREAM_MIME_TYPE,
   HEADER_CONNECTION_ID,
@@ -126,6 +126,8 @@ class HttpStreamTransport {
   }
 
   private async postInitialize(message: AnyMessage): Promise<void> {
+    let cleanupConnectionId: string | undefined;
+
     try {
       if (!isInitializeRequest(message)) {
         throw new Error("ACP HTTP stream first message must be initialize");
@@ -148,17 +150,27 @@ class HttpStreamTransport {
         throw new Error("ACP initialize response missing Acp-Connection-Id");
       }
 
-      this.connectionId = connectionId;
+      cleanupConnectionId = connectionId;
 
       const body: unknown = await response.json();
-      if (!isJsonRpcMessage(body)) {
-        throw new Error("ACP initialize response was not a JSON-RPC message");
+      if (!isResponseMessage(body)) {
+        throw new Error("ACP initialize response was not a JSON-RPC response");
       }
 
+      const responseIdKey = messageIdKey(body.id);
+      const requestIdKey =
+        "id" in message ? messageIdKey(message.id) : undefined;
+      if (responseIdKey !== requestIdKey) {
+        throw new Error(
+          "ACP initialize response id did not match initialize request",
+        );
+      }
+
+      this.connectionId = connectionId;
       this.openConnectionSse();
       this.enqueue(body);
     } catch (error) {
-      this.errorReadable(error);
+      this.errorReadable(error, cleanupConnectionId);
       throw error;
     }
   }
@@ -454,8 +466,9 @@ class HttpStreamTransport {
     }
   }
 
-  private async deleteConnection(): Promise<void> {
-    const connectionId = this.connectionId;
+  private async deleteConnection(
+    connectionId: string | undefined = this.connectionId,
+  ): Promise<void> {
     if (!connectionId) {
       return;
     }
@@ -486,14 +499,17 @@ class HttpStreamTransport {
     }
   }
 
-  private errorReadable(error: unknown): void {
+  private errorReadable(
+    error: unknown,
+    connectionId: string | undefined = this.connectionId,
+  ): void {
     if (this.isClosed) {
       return;
     }
 
     this.isClosed = true;
     this.abortController.abort();
-    void this.deleteConnection()
+    void this.deleteConnection(connectionId)
       .catch(() => undefined)
       .finally(() => {
         this.clearOwnedCookieStore();

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -14,15 +14,17 @@ import type { AnyMessage } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
 
 export interface HttpStreamOptions {
+  /** Fetch implementation to use. Defaults to `globalThis.fetch`. */
   readonly fetch?: typeof globalThis.fetch;
+  /** Headers to include on every HTTP/SSE request. */
   readonly headers?: Record<string, string>;
 }
 
 /**
- * Creates an ACP Stream that speaks the Streamable HTTP transport.
+ * Creates an ACP Stream over Streamable HTTP.
  *
- * The transport uses HTTP POST for client-to-agent messages and SSE GET streams for agent-to-client messages.
- * Cookie management is intentionally not built in; pass a cookie-aware fetch implementation when needed.
+ * Uses POST for client messages and SSE GET streams for server messages.
+ * Pass a custom `fetch` for cookies, auth, proxies, or non-browser runtimes.
  */
 export function createHttpStream(
   serverUrl: string,

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -372,26 +372,25 @@ class HttpStreamTransport {
 
     this.isClosed = true;
 
-    const connectionId = this.connectionId;
-    if (connectionId) {
-      const response = await this.fetchRequest({
-        method: "DELETE",
-        headers: {
-          [HEADER_CONNECTION_ID]: connectionId,
-        },
-      });
+    try {
+      const connectionId = this.connectionId;
+      if (connectionId) {
+        const response = await this.fetchRequest({
+          method: "DELETE",
+          headers: {
+            [HEADER_CONNECTION_ID]: connectionId,
+          },
+        });
 
-      if (!response.ok) {
-        this.abortController.abort();
-        this.clearOwnedCookieStore();
-        this.closeReadable();
-        throw await httpError("ACP DELETE failed", response);
+        if (!response.ok) {
+          throw await httpError("ACP DELETE failed", response);
+        }
       }
+    } finally {
+      this.abortController.abort();
+      this.clearOwnedCookieStore();
+      this.closeReadable();
     }
-
-    this.abortController.abort();
-    this.clearOwnedCookieStore();
-    this.closeReadable();
   }
 
   private clearOwnedCookieStore(): void {

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -18,13 +18,15 @@ export interface HttpStreamOptions {
   readonly fetch?: typeof globalThis.fetch;
   /** Headers to include on every HTTP/SSE request. */
   readonly headers?: Record<string, string>;
+  /** Cookie handling policy for transport requests. Defaults to `include`. */
+  readonly cookies?: "include" | "omit";
 }
 
 /**
  * Creates an ACP Stream over Streamable HTTP.
  *
  * Uses POST for client messages and SSE GET streams for server messages.
- * Pass a custom `fetch` for cookies, auth, proxies, or non-browser runtimes.
+ * Cookies are included by default for the lifetime of one stream.
  */
 export function createHttpStream(
   serverUrl: string,
@@ -38,6 +40,8 @@ class HttpStreamTransport {
 
   private readonly fetchImpl: typeof globalThis.fetch;
   private readonly headers: Record<string, string>;
+  private readonly cookiePolicy: RequestCredentials;
+  private readonly cookieJar = new ConnectionCookieJar();
   private readonly abortController = new AbortController();
   private readonly knownSessions = new Set<string>();
 
@@ -54,6 +58,7 @@ class HttpStreamTransport {
   ) {
     this.fetchImpl = resolveFetch(options.fetch);
     this.headers = options.headers ?? {};
+    this.cookiePolicy = options.cookies ?? "include";
 
     this.stream = {
       readable: new ReadableStream<AnyMessage>({
@@ -95,10 +100,9 @@ class HttpStreamTransport {
       throw new Error("ACP HTTP stream first message must be initialize");
     }
 
-    const response = await this.fetchImpl(this.serverUrl, {
+    const response = await this.fetchRequest({
       method: "POST",
       headers: {
-        ...this.headers,
         "Content-Type": JSON_MIME_TYPE,
       },
       body: JSON.stringify(message),
@@ -130,10 +134,9 @@ class HttpStreamTransport {
     }
 
     const sessionId = sessionIdFromMessageParams(message);
-    const response = await this.fetchImpl(this.serverUrl, {
+    const response = await this.fetchRequest({
       method: "POST",
       headers: {
-        ...this.headers,
         "Content-Type": JSON_MIME_TYPE,
         [HEADER_CONNECTION_ID]: connectionId,
         ...(sessionId ? { [HEADER_SESSION_ID]: sessionId } : {}),
@@ -177,10 +180,9 @@ class HttpStreamTransport {
 
   private async openSse(headers: Record<string, string>): Promise<void> {
     try {
-      const response = await this.fetchImpl(this.serverUrl, {
+      const response = await this.fetchRequest({
         method: "GET",
         headers: {
-          ...this.headers,
           Accept: EVENT_STREAM_MIME_TYPE,
           ...headers,
         },
@@ -216,6 +218,35 @@ class HttpStreamTransport {
     }
   }
 
+  private async fetchRequest(init: RequestInit): Promise<Response> {
+    const response = await this.fetchImpl(this.serverUrl, {
+      ...init,
+      credentials: this.cookiePolicy,
+      headers: this.createRequestHeaders(init.headers),
+    });
+
+    if (this.cookiePolicy === "include") {
+      this.cookieJar.store(response.headers);
+    }
+
+    return response;
+  }
+
+  private createRequestHeaders(headers: HeadersInit | undefined): Headers {
+    const requestHeaders = new Headers(this.headers);
+    const transportHeaders = new Headers(headers);
+
+    transportHeaders.forEach((value, key) => {
+      requestHeaders.set(key, value);
+    });
+
+    if (this.cookiePolicy === "include") {
+      this.cookieJar.apply(requestHeaders);
+    }
+
+    return requestHeaders;
+  }
+
   private async close(): Promise<void> {
     if (this.isClosed) {
       return;
@@ -225,22 +256,23 @@ class HttpStreamTransport {
 
     const connectionId = this.connectionId;
     if (connectionId) {
-      const response = await this.fetchImpl(this.serverUrl, {
+      const response = await this.fetchRequest({
         method: "DELETE",
         headers: {
-          ...this.headers,
           [HEADER_CONNECTION_ID]: connectionId,
         },
       });
 
       if (!response.ok) {
         this.abortController.abort();
+        this.cookieJar.clear();
         this.closeReadable();
         throw await httpError("ACP DELETE failed", response);
       }
     }
 
     this.abortController.abort();
+    this.cookieJar.clear();
     this.closeReadable();
   }
 
@@ -259,6 +291,7 @@ class HttpStreamTransport {
 
     this.isClosed = true;
     this.abortController.abort();
+    this.cookieJar.clear();
 
     try {
       this.readableController?.error(error);
@@ -276,6 +309,48 @@ class HttpStreamTransport {
   }
 }
 
+class ConnectionCookieJar {
+  private readonly cookies = new Map<string, string>();
+
+  store(headers: Headers): void {
+    for (const value of setCookieHeaders(headers)) {
+      const cookie = parseSetCookie(value);
+      if (!cookie) {
+        continue;
+      }
+
+      this.cookies.set(cookie.name, cookie.value);
+    }
+  }
+
+  apply(headers: Headers): void {
+    const merged = mergeCookieHeaders(
+      this.cookieHeader(),
+      headers.get("Cookie"),
+    );
+    if (merged) {
+      headers.set("Cookie", merged);
+    }
+  }
+
+  clear(): void {
+    this.cookies.clear();
+  }
+
+  private cookieHeader(): string | undefined {
+    return this.cookies.size === 0
+      ? undefined
+      : Array.from(this.cookies)
+          .map(([name, value]) => `${name}=${value}`)
+          .join("; ");
+  }
+}
+
+interface CookiePair {
+  readonly name: string;
+  readonly value: string;
+}
+
 function resolveFetch(
   fetchImpl: typeof globalThis.fetch | undefined,
 ): typeof globalThis.fetch {
@@ -290,6 +365,104 @@ function resolveFetch(
   throw new Error(
     "createHttpStream requires globalThis.fetch or options.fetch",
   );
+}
+
+function setCookieHeaders(headers: Headers): string[] {
+  const getSetCookie = headers.getSetCookie;
+  if (typeof getSetCookie === "function") {
+    return getSetCookie.call(headers);
+  }
+
+  const setCookie = headers.get("Set-Cookie");
+  return setCookie ? splitSetCookieHeader(setCookie) : [];
+}
+
+function splitSetCookieHeader(header: string): string[] {
+  const result: string[] = [];
+  let start = 0;
+  let isInExpires = false;
+
+  for (let index = 0; index < header.length; index += 1) {
+    const char = header[index];
+
+    if (char === "," && !isInExpires) {
+      result.push(header.slice(start, index).trim());
+      start = index + 1;
+      continue;
+    }
+
+    if (header.slice(index, index + 8).toLowerCase() === "expires=") {
+      isInExpires = true;
+      index += 7;
+      continue;
+    }
+
+    if (char === ";" && isInExpires) {
+      isInExpires = false;
+    }
+  }
+
+  result.push(header.slice(start).trim());
+  return result.filter((value) => value.length > 0);
+}
+
+function parseSetCookie(header: string): CookiePair | undefined {
+  const pair = header.split(";", 1)[0];
+  const separator = pair.indexOf("=");
+
+  if (separator <= 0) {
+    return undefined;
+  }
+
+  return {
+    name: pair.slice(0, separator).trim(),
+    value: pair.slice(separator + 1).trim(),
+  };
+}
+
+function mergeCookieHeaders(
+  jarCookieHeader: string | undefined,
+  callerCookieHeader: string | null,
+): string | undefined {
+  const cookies = new Map<string, string>();
+
+  for (const cookie of parseCookieHeader(jarCookieHeader)) {
+    cookies.set(cookie.name, cookie.value);
+  }
+
+  for (const cookie of parseCookieHeader(callerCookieHeader ?? undefined)) {
+    cookies.set(cookie.name, cookie.value);
+  }
+
+  return cookies.size === 0
+    ? undefined
+    : Array.from(cookies)
+        .map(([name, value]) => `${name}=${value}`)
+        .join("; ");
+}
+
+function parseCookieHeader(header: string | undefined): CookiePair[] {
+  if (!header) {
+    return [];
+  }
+
+  return header
+    .split(";")
+    .map(parseCookiePair)
+    .filter((cookie): cookie is CookiePair => cookie !== undefined);
+}
+
+function parseCookiePair(value: string): CookiePair | undefined {
+  const separator = value.indexOf("=");
+
+  if (separator <= 0) {
+    return undefined;
+  }
+
+  return {
+    name: value.slice(0, separator).trim(),
+    value: value.slice(separator + 1).trim(),
+  };
 }
 
 async function httpError(prefix: string, response: Response): Promise<Error> {

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -139,6 +139,7 @@ class HttpStreamTransport {
           "Content-Type": JSON_MIME_TYPE,
         },
         body: JSON.stringify(message),
+        signal: this.abortController.signal,
       });
 
       if (!response.ok) {
@@ -151,8 +152,11 @@ class HttpStreamTransport {
       }
 
       cleanupConnectionId = connectionId;
+      this.throwIfClosedDuringInitialize();
 
       const body: unknown = await response.json();
+      this.throwIfClosedDuringInitialize();
+
       if (!isResponseMessage(body)) {
         throw new Error("ACP initialize response was not a JSON-RPC response");
       }
@@ -170,8 +174,20 @@ class HttpStreamTransport {
       this.openConnectionSse();
       this.enqueue(body);
     } catch (error) {
-      this.errorReadable(error, cleanupConnectionId);
+      if (this.isClosed && cleanupConnectionId) {
+        await this.deleteConnection(cleanupConnectionId).catch(() => undefined);
+        this.clearOwnedCookieStore();
+      } else {
+        this.errorReadable(error, cleanupConnectionId);
+      }
+
       throw error;
+    }
+  }
+
+  private throwIfClosedDuringInitialize(): void {
+    if (this.isClosed) {
+      throw new Error("ACP HTTP stream is closed");
     }
   }
 

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -16,6 +16,12 @@ import type { AcpCookieStore } from "./cookie-store.js";
 import type { AnyMessage } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
 
+interface SseLifecycle {
+  readonly onOpen?: () => void;
+  readonly onError?: (error: unknown) => void;
+  readonly onClose?: () => void;
+}
+
 export interface HttpStreamOptions {
   /** Fetch implementation to use. Defaults to `globalThis.fetch`. */
   readonly fetch?: typeof globalThis.fetch;
@@ -65,6 +71,7 @@ class HttpStreamTransport {
   private readonly ownsCookieStore: boolean;
   private readonly abortController = new AbortController();
   private readonly knownSessions = new Set<string>();
+  private readonly sessionSseReady = new Map<string, Promise<void>>();
   private readonly pendingResponseSessions = new Map<string, string>();
   private readonly pendingSessionRequests = new Map<string, string>();
 
@@ -160,7 +167,7 @@ class HttpStreamTransport {
 
     const sessionId = this.sessionIdForOutboundMessage(message);
     if (sessionId) {
-      this.openSessionSse(sessionId);
+      await this.openSessionSse(sessionId);
     }
 
     const pendingSessionRequestKey =
@@ -227,25 +234,73 @@ class HttpStreamTransport {
     });
   }
 
-  private openSessionSse(sessionId: string): void {
+  private openSessionSse(sessionId: string): Promise<void> {
+    const existingReady = this.sessionSseReady.get(sessionId);
+    if (existingReady) {
+      return existingReady;
+    }
+
     if (this.knownSessions.has(sessionId)) {
-      return;
+      return Promise.resolve();
     }
 
     const connectionId = this.connectionId;
     if (!connectionId) {
-      return;
+      return Promise.resolve();
     }
 
-    this.knownSessions.add(sessionId);
-
-    void this.openSse({
-      [HEADER_CONNECTION_ID]: connectionId,
-      [HEADER_SESSION_ID]: sessionId,
+    let isReadySettled = false;
+    let resolveReady: () => void = () => {};
+    let rejectReady: (error: unknown) => void = () => {};
+    const ready = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
     });
+    const settleReady = (callback: () => void): void => {
+      if (isReadySettled) {
+        return;
+      }
+
+      isReadySettled = true;
+      callback();
+    };
+
+    ready.catch(() => undefined);
+    this.knownSessions.add(sessionId);
+    this.sessionSseReady.set(sessionId, ready);
+
+    void this.openSse(
+      {
+        [HEADER_CONNECTION_ID]: connectionId,
+        [HEADER_SESSION_ID]: sessionId,
+      },
+      {
+        onOpen: () => {
+          settleReady(resolveReady);
+        },
+        onError: (error) => {
+          settleReady(() => {
+            rejectReady(error);
+          });
+        },
+        onClose: () => {
+          this.sessionSseReady.delete(sessionId);
+          settleReady(() => {
+            rejectReady(
+              new Error("ACP session SSE stream closed before opening"),
+            );
+          });
+        },
+      },
+    );
+
+    return ready;
   }
 
-  private async openSse(headers: Record<string, string>): Promise<void> {
+  private async openSse(
+    headers: Record<string, string>,
+    lifecycle: SseLifecycle = {},
+  ): Promise<void> {
     const streamSessionId = headers[HEADER_SESSION_ID];
 
     try {
@@ -266,6 +321,8 @@ class HttpStreamTransport {
         throw new Error("ACP SSE response missing body");
       }
 
+      lifecycle.onOpen?.();
+
       for await (const message of parseSseStream(response.body)) {
         if (this.isClosed) {
           return;
@@ -273,7 +330,7 @@ class HttpStreamTransport {
 
         const sessionId = sessionIdFromResponseResult(message);
         if (sessionId) {
-          this.openSessionSse(sessionId);
+          void this.openSessionSse(sessionId);
         }
 
         this.trackServerRequestRoute(message, headers[HEADER_SESSION_ID]);
@@ -287,7 +344,10 @@ class HttpStreamTransport {
         return;
       }
 
+      lifecycle.onError?.(error);
       this.errorReadable(error);
+    } finally {
+      lifecycle.onClose?.();
     }
   }
 
@@ -302,6 +362,7 @@ class HttpStreamTransport {
     }
 
     this.knownSessions.delete(streamSessionId);
+    this.sessionSseReady.delete(streamSessionId);
 
     if (this.hasPendingSessionRequest(streamSessionId)) {
       this.errorReadable(new Error("ACP session SSE stream closed"));

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -1,0 +1,303 @@
+import { isJsonRpcMessage } from "./jsonrpc.js";
+import {
+  EVENT_STREAM_MIME_TYPE,
+  HEADER_CONNECTION_ID,
+  HEADER_SESSION_ID,
+  JSON_MIME_TYPE,
+  isInitializeRequest,
+  sessionIdFromMessageParams,
+  sessionIdFromResponseResult,
+} from "./protocol.js";
+import { parseSseStream } from "./sse.js";
+
+import type { AnyMessage } from "./jsonrpc.js";
+import type { Stream } from "./stream.js";
+
+export interface HttpStreamOptions {
+  readonly fetch?: typeof globalThis.fetch;
+  readonly headers?: Record<string, string>;
+}
+
+/**
+ * Creates an ACP Stream that speaks the Streamable HTTP transport.
+ *
+ * The transport uses HTTP POST for client-to-agent messages and SSE GET streams for agent-to-client messages.
+ * Cookie management is intentionally not built in; pass a cookie-aware fetch implementation when needed.
+ */
+export function createHttpStream(
+  serverUrl: string,
+  options: HttpStreamOptions = {},
+): Stream {
+  return new HttpStreamTransport(serverUrl, options).stream;
+}
+
+class HttpStreamTransport {
+  readonly stream: Stream;
+
+  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly headers: Record<string, string>;
+  private readonly abortController = new AbortController();
+  private readonly knownSessions = new Set<string>();
+
+  private readableController:
+    | ReadableStreamDefaultController<AnyMessage>
+    | undefined;
+  private connectionId: string | undefined;
+  private isClosed = false;
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly serverUrl: string,
+    options: HttpStreamOptions,
+  ) {
+    this.fetchImpl = resolveFetch(options.fetch);
+    this.headers = options.headers ?? {};
+
+    this.stream = {
+      readable: new ReadableStream<AnyMessage>({
+        start: (controller) => {
+          this.readableController = controller;
+        },
+        cancel: () => {
+          void this.close();
+        },
+      }),
+      writable: new WritableStream<AnyMessage>({
+        write: (message) => {
+          this.writeChain = this.writeChain.then(() =>
+            this.writeMessage(message),
+          );
+          return this.writeChain;
+        },
+        close: () => this.close(),
+        abort: () => this.close(),
+      }),
+    };
+  }
+
+  private async writeMessage(message: AnyMessage): Promise<void> {
+    if (this.isClosed) {
+      throw new Error("ACP HTTP stream is closed");
+    }
+
+    if (!this.connectionId) {
+      await this.postInitialize(message);
+      return;
+    }
+
+    await this.postConnectedMessage(message);
+  }
+
+  private async postInitialize(message: AnyMessage): Promise<void> {
+    if (!isInitializeRequest(message)) {
+      throw new Error("ACP HTTP stream first message must be initialize");
+    }
+
+    const response = await this.fetchImpl(this.serverUrl, {
+      method: "POST",
+      headers: {
+        ...this.headers,
+        "Content-Type": JSON_MIME_TYPE,
+      },
+      body: JSON.stringify(message),
+    });
+
+    if (!response.ok) {
+      throw await httpError("ACP initialize failed", response);
+    }
+
+    const connectionId = response.headers.get(HEADER_CONNECTION_ID);
+    if (!connectionId) {
+      throw new Error("ACP initialize response missing Acp-Connection-Id");
+    }
+
+    const body: unknown = await response.json();
+    if (!isJsonRpcMessage(body)) {
+      throw new Error("ACP initialize response was not a JSON-RPC message");
+    }
+
+    this.connectionId = connectionId;
+    this.openConnectionSse();
+    this.enqueue(body);
+  }
+
+  private async postConnectedMessage(message: AnyMessage): Promise<void> {
+    const connectionId = this.connectionId;
+    if (!connectionId) {
+      throw new Error("ACP HTTP stream is not initialized");
+    }
+
+    const sessionId = sessionIdFromMessageParams(message);
+    const response = await this.fetchImpl(this.serverUrl, {
+      method: "POST",
+      headers: {
+        ...this.headers,
+        "Content-Type": JSON_MIME_TYPE,
+        [HEADER_CONNECTION_ID]: connectionId,
+        ...(sessionId ? { [HEADER_SESSION_ID]: sessionId } : {}),
+      },
+      body: JSON.stringify(message),
+    });
+
+    if (!response.ok) {
+      throw await httpError("ACP POST failed", response);
+    }
+  }
+
+  private openConnectionSse(): void {
+    const connectionId = this.connectionId;
+    if (!connectionId) {
+      return;
+    }
+
+    void this.openSse({
+      [HEADER_CONNECTION_ID]: connectionId,
+    });
+  }
+
+  private openSessionSse(sessionId: string): void {
+    if (this.knownSessions.has(sessionId)) {
+      return;
+    }
+
+    const connectionId = this.connectionId;
+    if (!connectionId) {
+      return;
+    }
+
+    this.knownSessions.add(sessionId);
+
+    void this.openSse({
+      [HEADER_CONNECTION_ID]: connectionId,
+      [HEADER_SESSION_ID]: sessionId,
+    });
+  }
+
+  private async openSse(headers: Record<string, string>): Promise<void> {
+    try {
+      const response = await this.fetchImpl(this.serverUrl, {
+        method: "GET",
+        headers: {
+          ...this.headers,
+          Accept: EVENT_STREAM_MIME_TYPE,
+          ...headers,
+        },
+        signal: this.abortController.signal,
+      });
+
+      if (!response.ok) {
+        throw await httpError("ACP SSE connection failed", response);
+      }
+
+      if (!response.body) {
+        throw new Error("ACP SSE response missing body");
+      }
+
+      for await (const message of parseSseStream(response.body)) {
+        if (this.isClosed) {
+          return;
+        }
+
+        const sessionId = sessionIdFromResponseResult(message);
+        if (sessionId) {
+          this.openSessionSse(sessionId);
+        }
+
+        this.enqueue(message);
+      }
+    } catch (error) {
+      if (this.isClosed || this.abortController.signal.aborted) {
+        return;
+      }
+
+      this.errorReadable(error);
+    }
+  }
+
+  private async close(): Promise<void> {
+    if (this.isClosed) {
+      return;
+    }
+
+    this.isClosed = true;
+
+    const connectionId = this.connectionId;
+    if (connectionId) {
+      const response = await this.fetchImpl(this.serverUrl, {
+        method: "DELETE",
+        headers: {
+          ...this.headers,
+          [HEADER_CONNECTION_ID]: connectionId,
+        },
+      });
+
+      if (!response.ok) {
+        this.abortController.abort();
+        this.closeReadable();
+        throw await httpError("ACP DELETE failed", response);
+      }
+    }
+
+    this.abortController.abort();
+    this.closeReadable();
+  }
+
+  private enqueue(message: AnyMessage): void {
+    try {
+      this.readableController?.enqueue(message);
+    } catch (error) {
+      this.errorReadable(error);
+    }
+  }
+
+  private errorReadable(error: unknown): void {
+    if (this.isClosed) {
+      return;
+    }
+
+    this.isClosed = true;
+    this.abortController.abort();
+
+    try {
+      this.readableController?.error(error);
+    } catch {
+      // The readable side may already be closed or cancelled.
+    }
+  }
+
+  private closeReadable(): void {
+    try {
+      this.readableController?.close();
+    } catch {
+      // The readable side may already be closed, cancelled, or errored.
+    }
+  }
+}
+
+function resolveFetch(
+  fetchImpl: typeof globalThis.fetch | undefined,
+): typeof globalThis.fetch {
+  if (fetchImpl) {
+    return fetchImpl;
+  }
+
+  if (typeof globalThis.fetch === "function") {
+    return (input, init) => globalThis.fetch(input, init);
+  }
+
+  throw new Error(
+    "createHttpStream requires globalThis.fetch or options.fetch",
+  );
+}
+
+async function httpError(prefix: string, response: Response): Promise<Error> {
+  const text = await response.text().catch(() => "");
+
+  if (text) {
+    return new Error(
+      `${prefix}: ${response.status} ${response.statusText}: ${text}`,
+    );
+  }
+
+  return new Error(`${prefix}: ${response.status} ${response.statusText}`);
+}

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -203,6 +203,7 @@ class HttpStreamTransport {
         this.pendingSessionRequests.delete(pendingSessionRequestKey);
       }
 
+      this.errorReadable(error);
       throw error;
     }
   }

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -9,8 +9,10 @@ import {
   sessionIdFromMessageParams,
   sessionIdFromResponseResult,
 } from "./protocol.js";
+import { MemoryAcpCookieStore } from "./cookie-store.js";
 import { parseSseStream } from "./sse.js";
 
+import type { AcpCookieStore } from "./cookie-store.js";
 import type { AnyMessage } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
 
@@ -21,13 +23,30 @@ export interface HttpStreamOptions {
   readonly headers?: Record<string, string>;
   /** Cookie handling policy for transport requests. Defaults to `include`. */
   readonly cookies?: "include" | "omit";
+  /**
+   * Caller-owned affinity cookie store to reuse across reconnects.
+   *
+   * If omitted, the SDK creates an ephemeral per-stream store and clears it
+   * when the stream closes/errors.
+   */
+  readonly cookieStore?: AcpCookieStore;
 }
+
+export { MemoryAcpCookieStore } from "./cookie-store.js";
+export type { AcpCookieStore } from "./cookie-store.js";
 
 /**
  * Creates an ACP Stream over Streamable HTTP.
  *
  * Uses POST for client messages and SSE GET streams for server messages.
- * Cookies are included by default for the lifetime of one stream.
+ * Cookies are included by default. Pass a caller-owned `AcpCookieStore` to
+ * retain affinity cookies across fresh streams during reconnect.
+ *
+ * ACP v1 reconnect creates a new transport connection; callers should save the
+ * ACP `sessionId`, create a new stream with the same auth headers/cookie store,
+ * call `initialize`, verify `agentCapabilities.loadSession`, then call
+ * `session/load`. Agents must authorize `session/load`, and ACP v1 does not
+ * replay in-flight transport messages emitted while disconnected.
  */
 export function createHttpStream(
   serverUrl: string,
@@ -42,7 +61,8 @@ class HttpStreamTransport {
   private readonly fetchImpl: typeof globalThis.fetch;
   private readonly headers: Record<string, string>;
   private readonly cookiePolicy: RequestCredentials;
-  private readonly cookieJar = new ConnectionCookieJar();
+  private readonly cookieStore: AcpCookieStore;
+  private readonly ownsCookieStore: boolean;
   private readonly abortController = new AbortController();
   private readonly knownSessions = new Set<string>();
   private readonly pendingResponseSessions = new Map<string, string>();
@@ -61,6 +81,8 @@ class HttpStreamTransport {
     this.fetchImpl = resolveFetch(options.fetch);
     this.headers = options.headers ?? {};
     this.cookiePolicy = options.cookies ?? "include";
+    this.cookieStore = options.cookieStore ?? new MemoryAcpCookieStore();
+    this.ownsCookieStore = options.cookieStore === undefined;
 
     this.stream = {
       readable: new ReadableStream<AnyMessage>({
@@ -261,7 +283,7 @@ class HttpStreamTransport {
     });
 
     if (this.cookiePolicy === "include") {
-      this.cookieJar.store(response.headers);
+      this.cookieStore.store(response.headers);
     }
 
     return response;
@@ -276,7 +298,7 @@ class HttpStreamTransport {
     });
 
     if (this.cookiePolicy === "include") {
-      this.cookieJar.apply(requestHeaders);
+      this.cookieStore.apply(requestHeaders);
     }
 
     return requestHeaders;
@@ -300,15 +322,21 @@ class HttpStreamTransport {
 
       if (!response.ok) {
         this.abortController.abort();
-        this.cookieJar.clear();
+        this.clearOwnedCookieStore();
         this.closeReadable();
         throw await httpError("ACP DELETE failed", response);
       }
     }
 
     this.abortController.abort();
-    this.cookieJar.clear();
+    this.clearOwnedCookieStore();
     this.closeReadable();
+  }
+
+  private clearOwnedCookieStore(): void {
+    if (this.ownsCookieStore) {
+      this.cookieStore.clear();
+    }
   }
 
   private enqueue(message: AnyMessage): void {
@@ -326,7 +354,7 @@ class HttpStreamTransport {
 
     this.isClosed = true;
     this.abortController.abort();
-    this.cookieJar.clear();
+    this.clearOwnedCookieStore();
 
     try {
       this.readableController?.error(error);
@@ -344,48 +372,6 @@ class HttpStreamTransport {
   }
 }
 
-class ConnectionCookieJar {
-  private readonly cookies = new Map<string, string>();
-
-  store(headers: Headers): void {
-    for (const value of setCookieHeaders(headers)) {
-      const cookie = parseSetCookie(value);
-      if (!cookie) {
-        continue;
-      }
-
-      this.cookies.set(cookie.name, cookie.value);
-    }
-  }
-
-  apply(headers: Headers): void {
-    const merged = mergeCookieHeaders(
-      this.cookieHeader(),
-      headers.get("Cookie"),
-    );
-    if (merged) {
-      headers.set("Cookie", merged);
-    }
-  }
-
-  clear(): void {
-    this.cookies.clear();
-  }
-
-  private cookieHeader(): string | undefined {
-    return this.cookies.size === 0
-      ? undefined
-      : Array.from(this.cookies)
-          .map(([name, value]) => `${name}=${value}`)
-          .join("; ");
-  }
-}
-
-interface CookiePair {
-  readonly name: string;
-  readonly value: string;
-}
-
 function resolveFetch(
   fetchImpl: typeof globalThis.fetch | undefined,
 ): typeof globalThis.fetch {
@@ -400,104 +386,6 @@ function resolveFetch(
   throw new Error(
     "createHttpStream requires globalThis.fetch or options.fetch",
   );
-}
-
-function setCookieHeaders(headers: Headers): string[] {
-  const getSetCookie = headers.getSetCookie;
-  if (typeof getSetCookie === "function") {
-    return getSetCookie.call(headers);
-  }
-
-  const setCookie = headers.get("Set-Cookie");
-  return setCookie ? splitSetCookieHeader(setCookie) : [];
-}
-
-function splitSetCookieHeader(header: string): string[] {
-  const result: string[] = [];
-  let start = 0;
-  let isInExpires = false;
-
-  for (let index = 0; index < header.length; index += 1) {
-    const char = header[index];
-
-    if (char === "," && !isInExpires) {
-      result.push(header.slice(start, index).trim());
-      start = index + 1;
-      continue;
-    }
-
-    if (header.slice(index, index + 8).toLowerCase() === "expires=") {
-      isInExpires = true;
-      index += 7;
-      continue;
-    }
-
-    if (char === ";" && isInExpires) {
-      isInExpires = false;
-    }
-  }
-
-  result.push(header.slice(start).trim());
-  return result.filter((value) => value.length > 0);
-}
-
-function parseSetCookie(header: string): CookiePair | undefined {
-  const pair = header.split(";", 1)[0];
-  const separator = pair.indexOf("=");
-
-  if (separator <= 0) {
-    return undefined;
-  }
-
-  return {
-    name: pair.slice(0, separator).trim(),
-    value: pair.slice(separator + 1).trim(),
-  };
-}
-
-function mergeCookieHeaders(
-  jarCookieHeader: string | undefined,
-  callerCookieHeader: string | null,
-): string | undefined {
-  const cookies = new Map<string, string>();
-
-  for (const cookie of parseCookieHeader(jarCookieHeader)) {
-    cookies.set(cookie.name, cookie.value);
-  }
-
-  for (const cookie of parseCookieHeader(callerCookieHeader ?? undefined)) {
-    cookies.set(cookie.name, cookie.value);
-  }
-
-  return cookies.size === 0
-    ? undefined
-    : Array.from(cookies)
-        .map(([name, value]) => `${name}=${value}`)
-        .join("; ");
-}
-
-function parseCookieHeader(header: string | undefined): CookiePair[] {
-  if (!header) {
-    return [];
-  }
-
-  return header
-    .split(";")
-    .map(parseCookiePair)
-    .filter((cookie): cookie is CookiePair => cookie !== undefined);
-}
-
-function parseCookiePair(value: string): CookiePair | undefined {
-  const separator = value.indexOf("=");
-
-  if (separator <= 0) {
-    return undefined;
-  }
-
-  return {
-    name: value.slice(0, separator).trim(),
-    value: value.slice(separator + 1).trim(),
-  };
 }
 
 async function httpError(prefix: string, response: Response): Promise<Error> {

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -126,35 +126,41 @@ class HttpStreamTransport {
   }
 
   private async postInitialize(message: AnyMessage): Promise<void> {
-    if (!isInitializeRequest(message)) {
-      throw new Error("ACP HTTP stream first message must be initialize");
+    try {
+      if (!isInitializeRequest(message)) {
+        throw new Error("ACP HTTP stream first message must be initialize");
+      }
+
+      const response = await this.fetchRequest({
+        method: "POST",
+        headers: {
+          "Content-Type": JSON_MIME_TYPE,
+        },
+        body: JSON.stringify(message),
+      });
+
+      if (!response.ok) {
+        throw await httpError("ACP initialize failed", response);
+      }
+
+      const connectionId = response.headers.get(HEADER_CONNECTION_ID);
+      if (!connectionId) {
+        throw new Error("ACP initialize response missing Acp-Connection-Id");
+      }
+
+      this.connectionId = connectionId;
+
+      const body: unknown = await response.json();
+      if (!isJsonRpcMessage(body)) {
+        throw new Error("ACP initialize response was not a JSON-RPC message");
+      }
+
+      this.openConnectionSse();
+      this.enqueue(body);
+    } catch (error) {
+      this.errorReadable(error);
+      throw error;
     }
-
-    const response = await this.fetchRequest({
-      method: "POST",
-      headers: {
-        "Content-Type": JSON_MIME_TYPE,
-      },
-      body: JSON.stringify(message),
-    });
-
-    if (!response.ok) {
-      throw await httpError("ACP initialize failed", response);
-    }
-
-    const connectionId = response.headers.get(HEADER_CONNECTION_ID);
-    if (!connectionId) {
-      throw new Error("ACP initialize response missing Acp-Connection-Id");
-    }
-
-    const body: unknown = await response.json();
-    if (!isJsonRpcMessage(body)) {
-      throw new Error("ACP initialize response was not a JSON-RPC message");
-    }
-
-    this.connectionId = connectionId;
-    this.openConnectionSse();
-    this.enqueue(body);
   }
 
   private async postConnectedMessage(message: AnyMessage): Promise<void> {

--- a/src/http-stream.ts
+++ b/src/http-stream.ts
@@ -440,23 +440,29 @@ class HttpStreamTransport {
     this.isClosed = true;
 
     try {
-      const connectionId = this.connectionId;
-      if (connectionId) {
-        const response = await this.fetchRequest({
-          method: "DELETE",
-          headers: {
-            [HEADER_CONNECTION_ID]: connectionId,
-          },
-        });
-
-        if (!response.ok) {
-          throw await httpError("ACP DELETE failed", response);
-        }
-      }
+      await this.deleteConnection();
     } finally {
       this.abortController.abort();
       this.clearOwnedCookieStore();
       this.closeReadable();
+    }
+  }
+
+  private async deleteConnection(): Promise<void> {
+    const connectionId = this.connectionId;
+    if (!connectionId) {
+      return;
+    }
+
+    const response = await this.fetchRequest({
+      method: "DELETE",
+      headers: {
+        [HEADER_CONNECTION_ID]: connectionId,
+      },
+    });
+
+    if (!response.ok) {
+      throw await httpError("ACP DELETE failed", response);
     }
   }
 
@@ -481,7 +487,11 @@ class HttpStreamTransport {
 
     this.isClosed = true;
     this.abortController.abort();
-    this.clearOwnedCookieStore();
+    void this.deleteConnection()
+      .catch(() => undefined)
+      .finally(() => {
+        this.clearOwnedCookieStore();
+      });
 
     try {
       this.readableController?.error(error);

--- a/src/jsonrpc.test.ts
+++ b/src/jsonrpc.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { isJsonRpcMessage } from "./jsonrpc.js";
+
+describe("JSON-RPC envelope validation", () => {
+  it.each([
+    { jsonrpc: "2.0", method: "initialized" },
+    { jsonrpc: "2.0", id: 1, method: "initialize" },
+    { jsonrpc: "2.0", id: "request-1", result: null },
+    {
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32603,
+        message: "Internal error",
+        data: { retry: false },
+      },
+    },
+  ])("accepts valid JSON-RPC messages: %o", (message) => {
+    expect(isJsonRpcMessage(message)).toBe(true);
+  });
+
+  it.each([
+    { jsonrpc: "2.0", id: 1 },
+    { jsonrpc: "2.0", id: {}, result: true },
+    { jsonrpc: "2.0", id: Number.NaN, result: true },
+    { jsonrpc: "2.0", id: Number.POSITIVE_INFINITY, result: true },
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      result: true,
+      error: { code: -32603, message: "Internal error" },
+    },
+    { jsonrpc: "2.0", id: 1, error: { code: "-32603", message: "Error" } },
+    { jsonrpc: "2.0", id: 1, error: { code: -32603 } },
+    { jsonrpc: "2.0", method: "initialize", id: {} },
+  ])("rejects malformed JSON-RPC messages: %o", (message) => {
+    expect(isJsonRpcMessage(message)).toBe(false);
+  });
+});

--- a/src/jsonrpc.ts
+++ b/src/jsonrpc.ts
@@ -44,3 +44,33 @@ export type NotificationHandler = (
   method: string,
   params: unknown,
 ) => Promise<void>;
+
+export function isJsonRpcMessage(value: unknown): value is AnyMessage {
+  if (!isRecord(value) || value["jsonrpc"] !== "2.0") {
+    return false;
+  }
+
+  if ("method" in value) {
+    return typeof value["method"] === "string";
+  }
+
+  return "id" in value;
+}
+
+export function isRequestMessage(message: AnyMessage): message is AnyRequest {
+  return "id" in message && "method" in message;
+}
+
+export function isResponseMessage(message: AnyMessage): message is AnyResponse {
+  return "id" in message && !("method" in message);
+}
+
+export function isNotificationMessage(
+  message: AnyMessage,
+): message is AnyNotification {
+  return "method" in message && !("id" in message);
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/jsonrpc.ts
+++ b/src/jsonrpc.ts
@@ -46,31 +46,74 @@ export type NotificationHandler = (
 ) => Promise<void>;
 
 export function isJsonRpcMessage(value: unknown): value is AnyMessage {
-  if (!isRecord(value) || value["jsonrpc"] !== "2.0") {
+  return (
+    isRequestMessage(value) ||
+    isResponseMessage(value) ||
+    isNotificationMessage(value)
+  );
+}
+
+export function isRequestMessage(value: unknown): value is AnyRequest {
+  return (
+    isJsonRpcEnvelope(value) &&
+    "id" in value &&
+    typeof value["method"] === "string" &&
+    isJsonRpcId(value["id"])
+  );
+}
+
+export function isResponseMessage(value: unknown): value is AnyResponse {
+  if (!isJsonRpcEnvelope(value) || "method" in value) {
     return false;
   }
 
-  if ("method" in value) {
-    return typeof value["method"] === "string";
+  if (!("id" in value) || !isJsonRpcId(value["id"])) {
+    return false;
   }
 
-  return "id" in value;
-}
+  const hasResult = Object.hasOwn(value, "result");
+  const hasError = Object.hasOwn(value, "error");
 
-export function isRequestMessage(message: AnyMessage): message is AnyRequest {
-  return "id" in message && "method" in message;
-}
+  if (hasResult === hasError) {
+    return false;
+  }
 
-export function isResponseMessage(message: AnyMessage): message is AnyResponse {
-  return "id" in message && !("method" in message);
+  return !hasError || isErrorResponse(value["error"]);
 }
 
 export function isNotificationMessage(
-  message: AnyMessage,
-): message is AnyNotification {
-  return "method" in message && !("id" in message);
+  value: unknown,
+): value is AnyNotification {
+  return (
+    isJsonRpcEnvelope(value) &&
+    !("id" in value) &&
+    typeof value["method"] === "string"
+  );
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function isJsonRpcEnvelope(
+  value: unknown,
+): value is Record<string, unknown> & { jsonrpc: "2.0" } {
+  return isRecord(value) && value["jsonrpc"] === "2.0";
+}
+
+function isJsonRpcId(value: unknown): value is string | number | null {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
+function isErrorResponse(value: unknown): value is ErrorResponse {
+  return (
+    isRecord(value) &&
+    typeof value["code"] === "number" &&
+    Number.isInteger(value["code"]) &&
+    typeof value["message"] === "string"
+  );
 }

--- a/src/node-adapter.test.ts
+++ b/src/node-adapter.test.ts
@@ -1,4 +1,5 @@
 import http from "node:http";
+import { EventEmitter } from "node:events";
 
 import { describe, expect, it } from "vitest";
 import { AcpServer } from "./server.js";
@@ -6,6 +7,7 @@ import { createNodeHttpHandler } from "./node-adapter.js";
 import { TestAgent } from "./test-support/test-agent.js";
 
 import type { AgentSideConnection } from "./acp.js";
+import type { IncomingMessage, ServerResponse } from "node:http";
 
 interface RunningServer {
   readonly url: string;
@@ -123,7 +125,109 @@ describe("createNodeHttpHandler", () => {
       await server.close();
     }
   });
+
+  it("cancels streaming response bodies when the Node response closes while backpressured", async () => {
+    const acpServer = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => new TestAgent(conn),
+    });
+    const responseCancelled = createDeferred<void>();
+    const response = new BackpressuredServerResponse();
+
+    acpServer.handleRequest = () =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("data: one\n\n"));
+            },
+            cancel() {
+              responseCancelled.resolve();
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "text/event-stream",
+            },
+          },
+        ),
+      );
+
+    createNodeHttpHandler(acpServer)(
+      fakeRequest(),
+      response as unknown as ServerResponse,
+    );
+
+    await response.wroteChunk;
+    response.close();
+    await responseCancelled.promise;
+    await flushMicrotasks();
+
+    expect(response.ended).toBe(false);
+  });
 });
+
+class BackpressuredServerResponse extends EventEmitter {
+  statusCode = 200;
+  headersSent = false;
+  destroyed = false;
+  writableEnded = false;
+  ended = false;
+
+  private readonly writeDeferred = createDeferred<void>();
+  readonly wroteChunk = this.writeDeferred.promise;
+
+  setHeader(): void {}
+
+  flushHeaders(): void {
+    this.headersSent = true;
+  }
+
+  write(): boolean {
+    this.writeDeferred.resolve();
+    return false;
+  }
+
+  end(): void {
+    this.ended = true;
+    this.writableEnded = true;
+  }
+
+  close(): void {
+    this.destroyed = true;
+    this.emit("close");
+  }
+}
+
+function fakeRequest(): IncomingMessage {
+  return {
+    method: "GET",
+    url: "/acp",
+    headers: {
+      host: "127.0.0.1",
+    },
+  } as IncomingMessage;
+}
+
+function createDeferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+  readonly reject: (error: unknown) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (error: unknown) => void = () => {};
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 async function startNodeServer(acpServer: AcpServer): Promise<RunningServer> {
   const server = http.createServer(createNodeHttpHandler(acpServer));

--- a/src/node-adapter.test.ts
+++ b/src/node-adapter.test.ts
@@ -126,6 +126,43 @@ describe("createNodeHttpHandler", () => {
     }
   });
 
+  it("decodes request bodies across split UTF-8 chunks", async () => {
+    const acpServer = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => new TestAgent(conn),
+    });
+    const seenBodies: string[] = [];
+    const response = new CapturingServerResponse();
+    const body = JSON.stringify({ prompt: "split 🚀 path" });
+    const bodyBytes = new TextEncoder().encode(body);
+    const splitIndex = new TextEncoder().encode(
+      body.slice(0, body.indexOf("🚀")),
+    ).length;
+
+    acpServer.handleRequest = async (req) => {
+      seenBodies.push(await req.text());
+      return new Response("ok");
+    };
+
+    createNodeHttpHandler(acpServer)(
+      fakeRequest({
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        bodyChunks: [
+          bodyBytes.slice(0, splitIndex + 1),
+          bodyBytes.slice(splitIndex + 1),
+        ],
+      }),
+      response as unknown as ServerResponse,
+    );
+
+    await response.finished;
+
+    expect(response.statusCode).toBe(200);
+    expect(seenBodies).toEqual([body]);
+  });
+
   it("cancels streaming response bodies when the Node response closes while backpressured", async () => {
     const acpServer = new AcpServer({
       createAgent: (conn: AgentSideConnection) => new TestAgent(conn),
@@ -167,6 +204,39 @@ describe("createNodeHttpHandler", () => {
   });
 });
 
+class CapturingServerResponse extends EventEmitter {
+  statusCode = 200;
+  headersSent = false;
+  destroyed = false;
+  writableEnded = false;
+  readonly chunks: string[] = [];
+
+  private readonly finishDeferred = createDeferred<void>();
+  readonly finished = this.finishDeferred.promise;
+
+  setHeader(): void {}
+
+  flushHeaders(): void {
+    this.headersSent = true;
+  }
+
+  write(chunk: Uint8Array | string): boolean {
+    this.chunks.push(
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+    );
+    return true;
+  }
+
+  end(chunk?: Uint8Array | string): void {
+    if (chunk !== undefined) {
+      this.write(chunk);
+    }
+
+    this.writableEnded = true;
+    this.finishDeferred.resolve();
+  }
+}
+
 class BackpressuredServerResponse extends EventEmitter {
   statusCode = 200;
   headersSent = false;
@@ -199,14 +269,26 @@ class BackpressuredServerResponse extends EventEmitter {
   }
 }
 
-function fakeRequest(): IncomingMessage {
+function fakeRequest(
+  options: {
+    readonly method?: string;
+    readonly headers?: Record<string, string>;
+    readonly bodyChunks?: readonly Uint8Array[];
+  } = {},
+): IncomingMessage {
   return {
-    method: "GET",
+    method: options.method ?? "GET",
     url: "/acp",
     headers: {
       host: "127.0.0.1",
+      ...options.headers,
     },
-  } as IncomingMessage;
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of options.bodyChunks ?? []) {
+        yield chunk;
+      }
+    },
+  } as unknown as IncomingMessage;
 }
 
 function createDeferred<T>(): {

--- a/src/node-adapter.test.ts
+++ b/src/node-adapter.test.ts
@@ -1,0 +1,167 @@
+import http from "node:http";
+
+import { describe, expect, it } from "vitest";
+import { AcpServer } from "./server.js";
+import { createNodeHttpHandler } from "./node-adapter.js";
+import { TestAgent } from "./test-support/test-agent.js";
+
+import type { AgentSideConnection } from "./acp.js";
+
+interface RunningServer {
+  readonly url: string;
+  readonly close: () => Promise<void>;
+}
+
+describe("createNodeHttpHandler", () => {
+  it("forwards method, URL, headers, and body to AcpServer.handleRequest", async () => {
+    const acpServer = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => new TestAgent(conn),
+    });
+    const seenRequests: Request[] = [];
+    const seenBodies: string[] = [];
+    acpServer.handleRequest = async (req) => {
+      seenRequests.push(req);
+      seenBodies.push(await req.text());
+      return new Response("created", {
+        status: 201,
+        headers: {
+          "X-Adapter-Test": "ok",
+        },
+      });
+    };
+
+    const server = await startNodeServer(acpServer);
+
+    try {
+      const response = await fetch(`${server.url}/acp?hello=world`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Client-Test": "forwarded",
+        },
+        body: JSON.stringify({ ok: true }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.headers.get("X-Adapter-Test")).toBe("ok");
+      expect(await response.text()).toBe("created");
+      expect(seenRequests).toHaveLength(1);
+      expect(seenRequests[0]?.method).toBe("POST");
+      expect(seenRequests[0]?.url).toBe(`${server.url}/acp?hello=world`);
+      expect(seenRequests[0]?.headers.get("Content-Type")).toBe(
+        "application/json",
+      );
+      expect(seenRequests[0]?.headers.get("X-Client-Test")).toBe("forwarded");
+      expect(seenBodies).toEqual([JSON.stringify({ ok: true })]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("streams response bodies to ServerResponse", async () => {
+    const acpServer = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => new TestAgent(conn),
+    });
+    acpServer.handleRequest = () =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              const encoder = new TextEncoder();
+              controller.enqueue(encoder.encode("data: one\n\n"));
+              controller.enqueue(encoder.encode("data: two\n\n"));
+              controller.close();
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "text/event-stream",
+            },
+          },
+        ),
+      );
+
+    const server = await startNodeServer(acpServer);
+
+    try {
+      const response = await fetch(server.url, { method: "POST" });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toContain(
+        "text/event-stream",
+      );
+      expect(await response.text()).toBe("data: one\n\ndata: two\n\n");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("handles empty response bodies", async () => {
+    const acpServer = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => new TestAgent(conn),
+    });
+    acpServer.handleRequest = () =>
+      Promise.resolve(
+        new Response(null, {
+          status: 202,
+          headers: {
+            "X-Empty-Body": "yes",
+          },
+        }),
+      );
+
+    const server = await startNodeServer(acpServer);
+
+    try {
+      const response = await fetch(server.url, { method: "POST" });
+
+      expect(response.status).toBe(202);
+      expect(response.headers.get("X-Empty-Body")).toBe("yes");
+      expect(await response.text()).toBe("");
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+async function startNodeServer(acpServer: AcpServer): Promise<RunningServer> {
+  const server = http.createServer(createNodeHttpHandler(acpServer));
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error): void => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+
+    const onListening = (): void => {
+      server.off("error", onError);
+      resolve();
+    };
+
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(0, "127.0.0.1");
+  });
+
+  const address = server.address();
+
+  if (typeof address !== "object" || address === null) {
+    throw new Error("Node test server did not bind to a TCP port");
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      }),
+  };
+}

--- a/src/node-adapter.test.ts
+++ b/src/node-adapter.test.ts
@@ -76,6 +76,36 @@ describe("createNodeHttpHandler", () => {
     }
   });
 
+  it("aborts forwarded requests when the Node response closes before finishing", async () => {
+    const acpServer = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => new TestAgent(conn),
+    });
+    const seenRequest = createDeferred<Request>();
+    const pendingResponse = createDeferred<Response>();
+    const response = new CapturingServerResponse();
+
+    acpServer.handleRequest = (req) => {
+      seenRequest.resolve(req);
+      return pendingResponse.promise;
+    };
+
+    createNodeHttpHandler(acpServer)(
+      fakeRequest(),
+      response as unknown as ServerResponse,
+    );
+
+    const request = await seenRequest.promise;
+
+    expect(request.signal.aborted).toBe(false);
+    response.emit("close");
+    expect(request.signal.aborted).toBe(true);
+
+    pendingResponse.resolve(new Response("closed", { status: 499 }));
+    await response.finished;
+
+    expect(response.statusCode).toBe(499);
+  });
+
   it("streams response bodies to ServerResponse", async () => {
     const acpServer = new AcpServer({
       createAgent: (conn: AgentSideConnection) => new TestAgent(conn),
@@ -392,19 +422,24 @@ function fakeRequest(
     readonly bodyChunks?: readonly Uint8Array[];
   } = {},
 ): IncomingMessage {
-  return {
+  const request = Object.assign(new EventEmitter(), {
     method: options.method ?? "GET",
     url: "/acp",
     headers: {
       host: "127.0.0.1",
       ...options.headers,
     },
+  });
+
+  Object.assign(request, {
     async *[Symbol.asyncIterator]() {
       for (const chunk of options.bodyChunks ?? []) {
         yield chunk;
       }
     },
-  } as unknown as IncomingMessage;
+  });
+
+  return request as unknown as IncomingMessage;
 }
 
 function createDeferred<T>(): {

--- a/src/node-adapter.test.ts
+++ b/src/node-adapter.test.ts
@@ -7,11 +7,21 @@ import { createNodeHttpHandler } from "./node-adapter.js";
 import { TestAgent } from "./test-support/test-agent.js";
 
 import type { AgentSideConnection } from "./acp.js";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import type {
+  IncomingHttpHeaders,
+  IncomingMessage,
+  ServerResponse,
+} from "node:http";
 
 interface RunningServer {
   readonly url: string;
   readonly close: () => Promise<void>;
+}
+
+interface RawHttpResponse {
+  readonly statusCode: number | undefined;
+  readonly headers: IncomingHttpHeaders;
+  readonly body: string;
 }
 
 describe("createNodeHttpHandler", () => {
@@ -121,6 +131,42 @@ describe("createNodeHttpHandler", () => {
       expect(response.status).toBe(202);
       expect(response.headers.get("X-Empty-Body")).toBe("yes");
       expect(await response.text()).toBe("");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("preserves multiple Set-Cookie response headers", async () => {
+    const acpServer = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => new TestAgent(conn),
+    });
+    acpServer.handleRequest = () => {
+      const headers = new Headers({
+        "X-Adapter-Test": "cookies",
+      });
+      headers.append("Set-Cookie", "transport=alpha; Path=/");
+      headers.append("Set-Cookie", "route=bravo; Path=/");
+
+      return Promise.resolve(
+        new Response("cookies", {
+          status: 200,
+          headers,
+        }),
+      );
+    };
+
+    const server = await startNodeServer(acpServer);
+
+    try {
+      const response = await rawHttpRequest(server.url);
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers["x-adapter-test"]).toBe("cookies");
+      expect(response.headers["set-cookie"]).toEqual([
+        "transport=alpha; Path=/",
+        "route=bravo; Path=/",
+      ]);
+      expect(response.body).toBe("cookies");
     } finally {
       await server.close();
     }
@@ -350,4 +396,26 @@ async function startNodeServer(acpServer: AcpServer): Promise<RunningServer> {
         });
       }),
   };
+}
+
+async function rawHttpRequest(url: string): Promise<RawHttpResponse> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (response) => {
+      let body = "";
+
+      response.setEncoding("utf8");
+      response.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      response.on("end", () => {
+        resolve({
+          statusCode: response.statusCode,
+          headers: response.headers,
+          body,
+        });
+      });
+    });
+
+    req.on("error", reject);
+  });
 }

--- a/src/node-adapter.test.ts
+++ b/src/node-adapter.test.ts
@@ -3,7 +3,10 @@ import { EventEmitter } from "node:events";
 
 import { describe, expect, it } from "vitest";
 import { AcpServer } from "./server.js";
-import { createNodeHttpHandler } from "./node-adapter.js";
+import {
+  createNodeHttpHandler,
+  createNodeWebSocketUpgradeHandler,
+} from "./node-adapter.js";
 import { TestAgent } from "./test-support/test-agent.js";
 
 import type { AgentSideConnection } from "./acp.js";
@@ -12,6 +15,9 @@ import type {
   IncomingMessage,
   ServerResponse,
 } from "node:http";
+import type { Duplex } from "node:stream";
+import type { NodeWebSocketUpgradeServer } from "./node-adapter.js";
+import type { WebSocketServerSocket } from "./ws-server.js";
 
 interface RunningServer {
   readonly url: string;
@@ -249,6 +255,70 @@ describe("createNodeHttpHandler", () => {
     expect(response.ended).toBe(false);
   });
 });
+
+describe("createNodeWebSocketUpgradeHandler", () => {
+  it("destroys the upgrade socket when WebSocket preparation throws", async () => {
+    const error = new Error("factory failed");
+    const acpServer = new AcpServer({
+      createAgent: () => {
+        throw error;
+      },
+    });
+    const webSocketServer = new FakeNodeWebSocketUpgradeServer();
+    const socket = new FakeUpgradeSocket();
+    const handler = createNodeWebSocketUpgradeHandler(
+      acpServer,
+      webSocketServer,
+    );
+
+    try {
+      expect(() =>
+        handler(fakeRequest(), socket as unknown as Duplex, Buffer.alloc(0)),
+      ).not.toThrow();
+
+      expect(webSocketServer.handleUpgradeCalls).toBe(0);
+      expect(socket.destroyed).toBe(true);
+      expect(socket.destroyError).toBe(error);
+    } finally {
+      await acpServer.close();
+    }
+  });
+});
+
+class FakeNodeWebSocketUpgradeServer implements NodeWebSocketUpgradeServer {
+  handleUpgradeCalls = 0;
+
+  on(
+    _event: "headers",
+    _listener: (headers: string[], request: IncomingMessage) => void,
+  ): void {}
+
+  off(
+    _event: "headers",
+    _listener: (headers: string[], request: IncomingMessage) => void,
+  ): void {}
+
+  handleUpgrade(
+    _req: IncomingMessage,
+    _socket: Duplex,
+    _head: Buffer,
+    _callback: (webSocket: WebSocketServerSocket) => void,
+  ): void {
+    this.handleUpgradeCalls += 1;
+  }
+}
+
+class FakeUpgradeSocket extends EventEmitter {
+  destroyed = false;
+  destroyError: Error | undefined;
+
+  destroy(error?: Error): this {
+    this.destroyed = true;
+    this.destroyError = error;
+    this.emit("close");
+    return this;
+  }
+}
 
 class CapturingServerResponse extends EventEmitter {
   statusCode = 200;

--- a/src/node-adapter.ts
+++ b/src/node-adapter.ts
@@ -1,0 +1,138 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { AcpServer } from "./server.js";
+
+export function createNodeHttpHandler(
+  server: AcpServer,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    void handleNodeRequest(server, req, res);
+  };
+}
+
+async function handleNodeRequest(
+  server: AcpServer,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  try {
+    await writeNodeResponse(
+      res,
+      await server.handleRequest(await toWebRequest(req)),
+    );
+  } catch (error) {
+    if (!res.headersSent) {
+      res.statusCode = 500;
+      res.setHeader("Content-Type", "text/plain");
+    }
+
+    res.end(error instanceof Error ? error.message : "Internal Server Error");
+  }
+}
+
+async function toWebRequest(req: IncomingMessage): Promise<Request> {
+  return new Request(nodeRequestUrl(req), {
+    method: req.method ?? "GET",
+    headers: nodeHeaders(req),
+    body: hasRequestBody(req) ? await readRequestBody(req) : undefined,
+  });
+}
+
+function hasRequestBody(req: IncomingMessage): boolean {
+  return req.method !== "GET" && req.method !== "HEAD";
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  const chunks: string[] = [];
+
+  for await (const chunk of req) {
+    chunks.push(
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+    );
+  }
+
+  return chunks.join("");
+}
+
+function nodeRequestUrl(req: IncomingMessage): string {
+  const host = req.headers.host ?? "localhost";
+  return `http://${host}${req.url ?? "/"}`;
+}
+
+function nodeHeaders(req: IncomingMessage): Headers {
+  const headers = new Headers();
+
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        headers.append(name, item);
+      }
+
+      continue;
+    }
+
+    if (value !== undefined) {
+      headers.set(name, value);
+    }
+  }
+
+  return headers;
+}
+
+async function writeNodeResponse(
+  res: ServerResponse,
+  response: Response,
+): Promise<void> {
+  res.statusCode = response.status;
+
+  response.headers.forEach((value, name) => {
+    res.setHeader(name, value);
+  });
+
+  const responseBody = response.body;
+
+  if (!responseBody) {
+    res.end();
+    return;
+  }
+
+  const reader = responseBody.getReader();
+
+  try {
+    while (true) {
+      const result = await reader.read();
+
+      if (result.done) {
+        res.end();
+        return;
+      }
+
+      await writeChunk(res, result.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function writeChunk(res: ServerResponse, chunk: Uint8Array): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error): void => {
+      res.off("drain", onDrain);
+      reject(error);
+    };
+
+    const onDrain = (): void => {
+      res.off("error", onError);
+      resolve();
+    };
+
+    res.once("error", onError);
+
+    if (res.write(chunk)) {
+      res.off("error", onError);
+      resolve();
+      return;
+    }
+
+    res.once("drain", onDrain);
+  });
+}

--- a/src/node-adapter.ts
+++ b/src/node-adapter.ts
@@ -110,15 +110,20 @@ function hasRequestBody(req: IncomingMessage): boolean {
 }
 
 async function readRequestBody(req: IncomingMessage): Promise<string> {
-  const chunks: string[] = [];
+  const decoder = new TextDecoder();
+  let body = "";
 
   for await (const chunk of req) {
-    chunks.push(
-      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
-    );
+    if (typeof chunk === "string") {
+      body += decoder.decode();
+      body += chunk;
+      continue;
+    }
+
+    body += decoder.decode(chunk, { stream: true });
   }
 
-  return chunks.join("");
+  return body + decoder.decode();
 }
 
 function nodeRequestUrl(req: IncomingMessage): string {

--- a/src/node-adapter.ts
+++ b/src/node-adapter.ts
@@ -88,6 +88,8 @@ async function writeNodeResponse(
     res.setHeader(name, value);
   });
 
+  res.flushHeaders();
+
   const responseBody = response.body;
 
   if (!responseBody) {

--- a/src/node-adapter.ts
+++ b/src/node-adapter.ts
@@ -83,10 +83,12 @@ async function handleNodeRequest(
   req: IncomingMessage,
   res: ServerResponse,
 ): Promise<void> {
+  const requestAbort = nodeRequestAbortSignal(req, res);
+
   try {
     await writeNodeResponse(
       res,
-      await server.handleRequest(await toWebRequest(req)),
+      await server.handleRequest(await toWebRequest(req, requestAbort.signal)),
     );
   } catch (error) {
     if (!res.headersSent) {
@@ -95,6 +97,8 @@ async function handleNodeRequest(
     }
 
     res.end(error instanceof Error ? error.message : "Internal Server Error");
+  } finally {
+    requestAbort.cleanup();
   }
 }
 
@@ -102,11 +106,50 @@ function destroyUpgradeSocket(socket: Duplex, error: unknown): void {
   socket.destroy(error instanceof Error ? error : undefined);
 }
 
-async function toWebRequest(req: IncomingMessage): Promise<Request> {
+interface NodeRequestAbortSignal {
+  readonly signal: AbortSignal;
+  cleanup(): void;
+}
+
+function nodeRequestAbortSignal(
+  req: IncomingMessage,
+  res: ServerResponse,
+): NodeRequestAbortSignal {
+  const abortController = new AbortController();
+  let isFinished = false;
+
+  const onFinish = (): void => {
+    isFinished = true;
+  };
+  const onClose = (): void => {
+    if (!isFinished) {
+      abortController.abort(new Error("Node HTTP response closed"));
+    }
+  };
+
+  req.once("aborted", onClose);
+  res.once("finish", onFinish);
+  res.once("close", onClose);
+
+  return {
+    signal: abortController.signal,
+    cleanup: () => {
+      req.off("aborted", onClose);
+      res.off("finish", onFinish);
+      res.off("close", onClose);
+    },
+  };
+}
+
+async function toWebRequest(
+  req: IncomingMessage,
+  signal: AbortSignal,
+): Promise<Request> {
   return new Request(nodeRequestUrl(req), {
     method: req.method ?? "GET",
     headers: nodeHeaders(req),
     body: hasRequestBody(req) ? await readRequestBody(req) : undefined,
+    signal,
   });
 }
 

--- a/src/node-adapter.ts
+++ b/src/node-adapter.ts
@@ -1,7 +1,7 @@
 import { HEADER_CONNECTION_ID } from "./protocol.js";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
-import type { AcpServer } from "./server.js";
+import type { AcpServer, PreparedWebSocketUpgrade } from "./server.js";
 import type { WebSocketServerSocket } from "./ws-server.js";
 
 type NodeWebSocketHeadersListener = (
@@ -33,7 +33,7 @@ export function createNodeWebSocketUpgradeHandler(
   webSocketServer: NodeWebSocketUpgradeServer,
 ): (req: IncomingMessage, socket: Duplex, head: Buffer) => void {
   return (req, socket, head) => {
-    const upgrade = server.prepareWebSocketUpgrade();
+    let upgrade: PreparedWebSocketUpgrade | undefined;
     let hasAccepted = false;
 
     const cleanup = (): void => {
@@ -43,7 +43,7 @@ export function createNodeWebSocketUpgradeHandler(
     };
 
     const onHeaders = (headers: string[], request: IncomingMessage): void => {
-      if (request !== req) {
+      if (request !== req || !upgrade) {
         return;
       }
 
@@ -56,23 +56,24 @@ export function createNodeWebSocketUpgradeHandler(
       }
 
       cleanup();
-      upgrade.reject();
+      upgrade?.reject();
     };
 
-    webSocketServer.on("headers", onHeaders);
-    socket.once("close", onUpgradeFailed);
-    socket.once("error", onUpgradeFailed);
-
     try {
+      upgrade = server.prepareWebSocketUpgrade();
+      webSocketServer.on("headers", onHeaders);
+      socket.once("close", onUpgradeFailed);
+      socket.once("error", onUpgradeFailed);
+
       webSocketServer.handleUpgrade(req, socket, head, (webSocket) => {
         hasAccepted = true;
         cleanup();
-        upgrade.accept(webSocket);
+        upgrade?.accept(webSocket);
       });
     } catch (error) {
       cleanup();
-      upgrade.reject();
-      throw error;
+      upgrade?.reject();
+      destroyUpgradeSocket(socket, error);
     }
   };
 }
@@ -95,6 +96,10 @@ async function handleNodeRequest(
 
     res.end(error instanceof Error ? error.message : "Internal Server Error");
   }
+}
+
+function destroyUpgradeSocket(socket: Duplex, error: unknown): void {
+  socket.destroy(error instanceof Error ? error : undefined);
 }
 
 async function toWebRequest(req: IncomingMessage): Promise<Request> {

--- a/src/node-adapter.ts
+++ b/src/node-adapter.ts
@@ -2,7 +2,23 @@ import { HEADER_CONNECTION_ID } from "./protocol.js";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
 import type { AcpServer } from "./server.js";
-import type { WebSocketServer } from "ws";
+import type { WebSocketServerSocket } from "./ws-server.js";
+
+type NodeWebSocketHeadersListener = (
+  headers: string[],
+  request: IncomingMessage,
+) => void;
+
+export interface NodeWebSocketUpgradeServer {
+  on(event: "headers", listener: NodeWebSocketHeadersListener): void;
+  off(event: "headers", listener: NodeWebSocketHeadersListener): void;
+  handleUpgrade(
+    req: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+    callback: (webSocket: WebSocketServerSocket) => void,
+  ): void;
+}
 
 export function createNodeHttpHandler(
   server: AcpServer,
@@ -14,7 +30,7 @@ export function createNodeHttpHandler(
 
 export function createNodeWebSocketUpgradeHandler(
   server: AcpServer,
-  webSocketServer: WebSocketServer,
+  webSocketServer: NodeWebSocketUpgradeServer,
 ): (req: IncomingMessage, socket: Duplex, head: Buffer) => void {
   return (req, socket, head) => {
     const upgrade = server.prepareWebSocketUpgrade();

--- a/src/node-adapter.ts
+++ b/src/node-adapter.ts
@@ -166,43 +166,100 @@ async function writeNodeResponse(
   }
 
   const reader = responseBody.getReader();
+  let cancelReader: Promise<void> | undefined;
+
+  const onClose = (): void => {
+    cancelReader = reader
+      .cancel(new NodeResponseClosedError())
+      .catch(() => undefined);
+  };
+
+  res.once("close", onClose);
 
   try {
     while (true) {
       const result = await reader.read();
 
       if (result.done) {
-        res.end();
+        res.off("close", onClose);
+
+        if (!isNodeResponseClosed(res)) {
+          res.end();
+        }
+
         return;
       }
 
       await writeChunk(res, result.value);
     }
+  } catch (error) {
+    if (error instanceof NodeResponseClosedError) {
+      return;
+    }
+
+    throw error;
   } finally {
+    res.off("close", onClose);
+    await cancelReader;
     reader.releaseLock();
   }
 }
 
 function writeChunk(res: ServerResponse, chunk: Uint8Array): Promise<void> {
   return new Promise((resolve, reject) => {
-    const onError = (error: Error): void => {
+    let isSettled = false;
+
+    const settle = (callback: () => void): void => {
+      if (isSettled) {
+        return;
+      }
+
+      isSettled = true;
+      res.off("close", onClose);
       res.off("drain", onDrain);
-      reject(error);
+      res.off("error", onError);
+      callback();
+    };
+
+    const onError = (error: Error): void => {
+      settle(() => {
+        reject(error);
+      });
     };
 
     const onDrain = (): void => {
-      res.off("error", onError);
-      resolve();
+      settle(resolve);
     };
 
+    const onClose = (): void => {
+      settle(() => {
+        reject(new NodeResponseClosedError());
+      });
+    };
+
+    if (isNodeResponseClosed(res)) {
+      reject(new NodeResponseClosedError());
+      return;
+    }
+
+    res.once("close", onClose);
     res.once("error", onError);
 
     if (res.write(chunk)) {
-      res.off("error", onError);
-      resolve();
+      settle(resolve);
       return;
     }
 
     res.once("drain", onDrain);
   });
+}
+
+function isNodeResponseClosed(res: ServerResponse): boolean {
+  return res.destroyed || res.writableEnded;
+}
+
+class NodeResponseClosedError extends Error {
+  constructor() {
+    super("Node HTTP response closed");
+  }
 }

--- a/src/node-adapter.ts
+++ b/src/node-adapter.ts
@@ -157,9 +157,7 @@ async function writeNodeResponse(
 ): Promise<void> {
   res.statusCode = response.status;
 
-  response.headers.forEach((value, name) => {
-    res.setHeader(name, value);
-  });
+  writeNodeHeaders(res, response.headers);
 
   res.flushHeaders();
 
@@ -208,6 +206,36 @@ async function writeNodeResponse(
     await cancelReader;
     reader.releaseLock();
   }
+}
+
+function writeNodeHeaders(res: ServerResponse, headers: Headers): void {
+  const setCookieHeaders = getSetCookieHeaders(headers);
+  const fallbackSetCookieHeaders: string[] = [];
+
+  headers.forEach((value, name) => {
+    if (name.toLowerCase() === "set-cookie") {
+      if (!setCookieHeaders) {
+        fallbackSetCookieHeaders.push(value);
+      }
+
+      return;
+    }
+
+    res.setHeader(name, value);
+  });
+
+  const cookieHeaders = setCookieHeaders ?? fallbackSetCookieHeaders;
+
+  if (cookieHeaders.length > 0) {
+    res.setHeader("Set-Cookie", cookieHeaders);
+  }
+}
+
+function getSetCookieHeaders(headers: Headers): string[] | undefined {
+  const getSetCookie = headers.getSetCookie;
+  return typeof getSetCookie === "function"
+    ? getSetCookie.call(headers)
+    : undefined;
 }
 
 function writeChunk(res: ServerResponse, chunk: Uint8Array): Promise<void> {

--- a/src/node-adapter.ts
+++ b/src/node-adapter.ts
@@ -1,11 +1,63 @@
+import { HEADER_CONNECTION_ID } from "./protocol.js";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Duplex } from "node:stream";
 import type { AcpServer } from "./server.js";
+import type { WebSocketServer } from "ws";
 
 export function createNodeHttpHandler(
   server: AcpServer,
 ): (req: IncomingMessage, res: ServerResponse) => void {
   return (req, res) => {
     void handleNodeRequest(server, req, res);
+  };
+}
+
+export function createNodeWebSocketUpgradeHandler(
+  server: AcpServer,
+  webSocketServer: WebSocketServer,
+): (req: IncomingMessage, socket: Duplex, head: Buffer) => void {
+  return (req, socket, head) => {
+    const upgrade = server.prepareWebSocketUpgrade();
+    let hasAccepted = false;
+
+    const cleanup = (): void => {
+      webSocketServer.off("headers", onHeaders);
+      socket.off("close", onUpgradeFailed);
+      socket.off("error", onUpgradeFailed);
+    };
+
+    const onHeaders = (headers: string[], request: IncomingMessage): void => {
+      if (request !== req) {
+        return;
+      }
+
+      headers.push(`${HEADER_CONNECTION_ID}: ${upgrade.connectionId}`);
+    };
+
+    const onUpgradeFailed = (): void => {
+      if (hasAccepted) {
+        return;
+      }
+
+      cleanup();
+      upgrade.reject();
+    };
+
+    webSocketServer.on("headers", onHeaders);
+    socket.once("close", onUpgradeFailed);
+    socket.once("error", onUpgradeFailed);
+
+    try {
+      webSocketServer.handleUpgrade(req, socket, head, (webSocket) => {
+        hasAccepted = true;
+        cleanup();
+        upgrade.accept(webSocket);
+      });
+    } catch (error) {
+      cleanup();
+      upgrade.reject();
+      throw error;
+    }
   };
 }
 

--- a/src/protocol.test.ts
+++ b/src/protocol.test.ts
@@ -40,9 +40,6 @@ describe("protocol transport helpers", () => {
     expect(methodRequiresSessionHeader(AGENT_METHODS.session_set_mode)).toBe(
       true,
     );
-    expect(methodRequiresSessionHeader(AGENT_METHODS.session_set_model)).toBe(
-      true,
-    );
   });
 
   it("does not require a session header for connection-level or unsupported methods", () => {

--- a/src/protocol.test.ts
+++ b/src/protocol.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { AGENT_METHODS } from "./schema/index.js";
+import {
+  methodRequiresSessionHeader,
+  sessionIdFromParams,
+  isInitializeRequest,
+  messageIdKey,
+  HEADER_CONNECTION_ID,
+  HEADER_SESSION_ID,
+  EVENT_STREAM_MIME_TYPE,
+  JSON_MIME_TYPE,
+} from "./protocol.js";
+
+import type { AnyMessage } from "./jsonrpc.js";
+
+describe("protocol transport helpers", () => {
+  it("exports HTTP transport constants", () => {
+    expect(HEADER_CONNECTION_ID).toBe("Acp-Connection-Id");
+    expect(HEADER_SESSION_ID).toBe("Acp-Session-Id");
+    expect(EVENT_STREAM_MIME_TYPE).toBe("text/event-stream");
+    expect(JSON_MIME_TYPE).toBe("application/json");
+  });
+
+  it("requires a session header for existing-session methods", () => {
+    expect(methodRequiresSessionHeader(AGENT_METHODS.session_cancel)).toBe(
+      true,
+    );
+    expect(methodRequiresSessionHeader(AGENT_METHODS.session_close)).toBe(true);
+    expect(methodRequiresSessionHeader(AGENT_METHODS.session_load)).toBe(true);
+    expect(methodRequiresSessionHeader(AGENT_METHODS.session_prompt)).toBe(
+      true,
+    );
+    expect(methodRequiresSessionHeader(AGENT_METHODS.session_resume)).toBe(
+      true,
+    );
+    expect(
+      methodRequiresSessionHeader(AGENT_METHODS.session_set_config_option),
+    ).toBe(true);
+    expect(methodRequiresSessionHeader(AGENT_METHODS.session_set_mode)).toBe(
+      true,
+    );
+    expect(methodRequiresSessionHeader(AGENT_METHODS.session_set_model)).toBe(
+      true,
+    );
+  });
+
+  it("does not require a session header for connection-level or unsupported methods", () => {
+    expect(methodRequiresSessionHeader(AGENT_METHODS.initialize)).toBe(false);
+    expect(methodRequiresSessionHeader(AGENT_METHODS.session_new)).toBe(false);
+    expect(methodRequiresSessionHeader(AGENT_METHODS.session_list)).toBe(false);
+    expect(methodRequiresSessionHeader(AGENT_METHODS.session_fork)).toBe(false);
+    expect(methodRequiresSessionHeader(AGENT_METHODS.nes_start)).toBe(false);
+    expect(methodRequiresSessionHeader(AGENT_METHODS.nes_suggest)).toBe(false);
+    expect(methodRequiresSessionHeader(AGENT_METHODS.nes_close)).toBe(false);
+  });
+
+  it("extracts a top-level string session ID from params", () => {
+    expect(sessionIdFromParams({ sessionId: "session-1" })).toBe("session-1");
+  });
+
+  it("returns undefined when params do not contain a top-level string session ID", () => {
+    expect(sessionIdFromParams(undefined)).toBeUndefined();
+    expect(sessionIdFromParams(null)).toBeUndefined();
+    expect(sessionIdFromParams("session-1")).toBeUndefined();
+    expect(sessionIdFromParams({})).toBeUndefined();
+    expect(sessionIdFromParams({ sessionId: 1 })).toBeUndefined();
+    expect(
+      sessionIdFromParams({ nested: { sessionId: "session-1" } }),
+    ).toBeUndefined();
+  });
+
+  it("detects initialize requests", () => {
+    const request: AnyMessage = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: AGENT_METHODS.initialize,
+      params: { protocolVersion: 1, clientCapabilities: {} },
+    };
+
+    expect(isInitializeRequest(request)).toBe(true);
+  });
+
+  it("rejects non-initialize messages", () => {
+    const notification: AnyMessage = {
+      jsonrpc: "2.0",
+      method: AGENT_METHODS.initialize,
+      params: { protocolVersion: 1, clientCapabilities: {} },
+    };
+    const response: AnyMessage = { jsonrpc: "2.0", id: 1, result: {} };
+    const otherRequest: AnyMessage = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: AGENT_METHODS.session_new,
+      params: { cwd: "/tmp", mcpServers: [] },
+    };
+
+    expect(isInitializeRequest(notification)).toBe(false);
+    expect(isInitializeRequest(response)).toBe(false);
+    expect(isInitializeRequest(otherRequest)).toBe(false);
+  });
+
+  it("normalizes JSON-RPC request IDs for map keys", () => {
+    expect(messageIdKey("foo")).toBe("string:foo");
+    expect(messageIdKey(1)).toBe("number:1");
+    expect(messageIdKey(null)).toBeUndefined();
+    expect(messageIdKey(undefined)).toBeUndefined();
+  });
+});

--- a/src/protocol.test.ts
+++ b/src/protocol.test.ts
@@ -100,7 +100,7 @@ describe("protocol transport helpers", () => {
   it("normalizes JSON-RPC request IDs for map keys", () => {
     expect(messageIdKey("foo")).toBe("string:foo");
     expect(messageIdKey(1)).toBe("number:1");
-    expect(messageIdKey(null)).toBeUndefined();
+    expect(messageIdKey(null)).toBe("null");
     expect(messageIdKey(undefined)).toBeUndefined();
   });
 });

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,0 +1,59 @@
+import { AGENT_METHODS } from "./schema/index.js";
+
+import type { AnyMessage } from "./jsonrpc.js";
+
+export const HEADER_CONNECTION_ID = "Acp-Connection-Id";
+export const HEADER_SESSION_ID = "Acp-Session-Id";
+export const EVENT_STREAM_MIME_TYPE = "text/event-stream";
+export const JSON_MIME_TYPE = "application/json";
+
+const SESSION_SCOPED_METHODS = new Set<string>([
+  AGENT_METHODS.session_cancel,
+  AGENT_METHODS.session_close,
+  AGENT_METHODS.session_load,
+  AGENT_METHODS.session_prompt,
+  AGENT_METHODS.session_resume,
+  AGENT_METHODS.session_set_config_option,
+  AGENT_METHODS.session_set_mode,
+  AGENT_METHODS.session_set_model,
+]);
+
+export function methodRequiresSessionHeader(method: string): boolean {
+  return SESSION_SCOPED_METHODS.has(method);
+}
+
+export function sessionIdFromParams(params: unknown): string | undefined {
+  if (!isRecord(params)) {
+    return undefined;
+  }
+
+  const sessionId = params["sessionId"];
+  return typeof sessionId === "string" ? sessionId : undefined;
+}
+
+export function isInitializeRequest(msg: AnyMessage): boolean {
+  return (
+    msg.jsonrpc === "2.0" &&
+    "id" in msg &&
+    "method" in msg &&
+    msg.method === AGENT_METHODS.initialize
+  );
+}
+
+export function messageIdKey(
+  id: string | number | null | undefined,
+): string | undefined {
+  if (typeof id === "string") {
+    return `string:${id}`;
+  }
+
+  if (typeof id === "number") {
+    return `number:${id}`;
+  }
+
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -15,7 +15,6 @@ const SESSION_SCOPED_METHODS = new Set<string>([
   AGENT_METHODS.session_resume,
   AGENT_METHODS.session_set_config_option,
   AGENT_METHODS.session_set_mode,
-  AGENT_METHODS.session_set_model,
 ]);
 
 export function methodRequiresSessionHeader(method: string): boolean {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,5 +1,5 @@
 import { AGENT_METHODS } from "./schema/index.js";
-
+import { isRecord, isResponseMessage } from "./jsonrpc.js";
 import type { AnyMessage } from "./jsonrpc.js";
 
 export const HEADER_CONNECTION_ID = "Acp-Connection-Id";
@@ -31,6 +31,27 @@ export function sessionIdFromParams(params: unknown): string | undefined {
   return typeof sessionId === "string" ? sessionId : undefined;
 }
 
+export function sessionIdFromMessageParams(
+  message: AnyMessage,
+): string | undefined {
+  return "method" in message ? sessionIdFromParams(message.params) : undefined;
+}
+
+export function sessionIdFromResponseResult(
+  message: AnyMessage,
+): string | undefined {
+  if (!isResponseMessage(message) || !("result" in message)) {
+    return undefined;
+  }
+
+  if (!isRecord(message.result)) {
+    return undefined;
+  }
+
+  const sessionId = message.result["sessionId"];
+  return typeof sessionId === "string" ? sessionId : undefined;
+}
+
 export function isInitializeRequest(msg: AnyMessage): boolean {
   return (
     msg.jsonrpc === "2.0" &&
@@ -52,8 +73,4 @@ export function messageIdKey(
   }
 
   return undefined;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -71,5 +71,9 @@ export function messageIdKey(
     return `number:${id}`;
   }
 
+  if (id === null) {
+    return "null";
+  }
+
   return undefined;
 }

--- a/src/server-permission.test.ts
+++ b/src/server-permission.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "vitest";
+import {
+  EVENT_STREAM_MIME_TYPE,
+  HEADER_CONNECTION_ID,
+  HEADER_SESSION_ID,
+  JSON_MIME_TYPE,
+} from "./protocol.js";
+import { parseSseStream } from "./sse.js";
+import { TestAgent } from "./test-support/test-agent.js";
+import { startTestServer } from "./test-support/test-http-server.js";
+
+import type { AgentSideConnection } from "./acp.js";
+import type { AnyMessage } from "./jsonrpc.js";
+
+const initializeRequest = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: 1,
+    clientCapabilities: {},
+  },
+};
+
+const sessionNewRequest = {
+  jsonrpc: "2.0",
+  id: 2,
+  method: "session/new",
+  params: {
+    cwd: "/tmp",
+    mcpServers: [],
+  },
+};
+
+function createPromptRequest(id: number, sessionId: string) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "session/prompt",
+    params: {
+      sessionId,
+      prompt: [{ type: "text", text: "Hello" }],
+    },
+  };
+}
+
+describe("AcpServer permission requests over HTTP", () => {
+  it("routes permission requests over session SSE and accepts client responses", async () => {
+    const server = await startTestServer(
+      (conn: AgentSideConnection) =>
+        new TestAgent(conn, { enablePermission: true }),
+    );
+
+    try {
+      const connectionId = await initialize(server.url);
+      const sessionId = await createSession(server.url, connectionId);
+      const connectionAbort = new AbortController();
+      const connectionSse = await openConnectionSse(
+        server.url,
+        connectionId,
+        connectionAbort.signal,
+      );
+      const sessionSse = await openSessionSse(
+        server.url,
+        connectionId,
+        sessionId,
+      );
+      const sessionEvents = createSseMessageIterator(sessionSse);
+
+      expect(
+        await postJson(server.url, createPromptRequest(3, sessionId), {
+          [HEADER_CONNECTION_ID]: connectionId,
+          [HEADER_SESSION_ID]: sessionId,
+        }),
+      ).toMatchObject({ status: 202 });
+
+      expect(await readNextSseMessage(sessionEvents)).toMatchObject({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { text: "chunk-1" },
+          },
+        },
+      });
+
+      const permissionRequest = await readNextSseMessage(sessionEvents);
+      expect(permissionRequest).toMatchObject({
+        jsonrpc: "2.0",
+        id: expect.any(Number),
+        method: "session/request_permission",
+        params: {
+          sessionId,
+          toolCall: {
+            toolCallId: "permission-tool",
+            title: "Permission tool",
+          },
+          options: expect.arrayContaining([
+            expect.objectContaining({
+              kind: "allow_once",
+              optionId: "allow",
+            }),
+          ]),
+        },
+      });
+      expect(
+        await readNextMessageOrUndefined(connectionSse, connectionAbort),
+      ).toBeUndefined();
+
+      expect(
+        await postJson(
+          server.url,
+          {
+            jsonrpc: "2.0",
+            id: readMessageId(permissionRequest),
+            result: {
+              outcome: {
+                outcome: "selected",
+                optionId: "allow",
+              },
+            },
+          },
+          { [HEADER_CONNECTION_ID]: connectionId },
+        ),
+      ).toMatchObject({ status: 202 });
+
+      expect(await readNextSseMessage(sessionEvents)).toMatchObject({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { text: "permission-selected-allow" },
+          },
+        },
+      });
+      expect(await readNextSseMessage(sessionEvents)).toMatchObject({
+        jsonrpc: "2.0",
+        id: 3,
+        result: { stopReason: "end_turn" },
+      });
+
+      await sessionEvents.return?.();
+      await sessionSse.body?.cancel();
+    } finally {
+      await server.close();
+    }
+  }, 10_000);
+});
+
+async function initialize(url: string): Promise<string> {
+  const response = await postJson(url, initializeRequest);
+  const connectionId = response.headers.get(HEADER_CONNECTION_ID);
+
+  expect(response.status).toBe(200);
+  expect(connectionId).toMatch(/^[0-9a-f-]{36}$/);
+
+  return connectionId ?? "";
+}
+
+async function createSession(
+  url: string,
+  connectionId: string,
+): Promise<string> {
+  const response = await openConnectionSse(url, connectionId);
+  const events = createSseMessageIterator(response);
+
+  try {
+    expect(
+      await postJson(url, sessionNewRequest, {
+        [HEADER_CONNECTION_ID]: connectionId,
+      }),
+    ).toMatchObject({ status: 202 });
+
+    return readSessionId(await readNextSseMessage(events));
+  } finally {
+    await events.return?.();
+    await response.body?.cancel();
+  }
+}
+
+function openConnectionSse(
+  url: string,
+  connectionId: string,
+  signal?: AbortSignal,
+): Promise<Response> {
+  return fetch(url, {
+    method: "GET",
+    headers: {
+      Accept: EVENT_STREAM_MIME_TYPE,
+      [HEADER_CONNECTION_ID]: connectionId,
+    },
+    signal,
+  });
+}
+
+function openSessionSse(
+  url: string,
+  connectionId: string,
+  sessionId: string,
+): Promise<Response> {
+  return fetch(url, {
+    method: "GET",
+    headers: {
+      Accept: EVENT_STREAM_MIME_TYPE,
+      [HEADER_CONNECTION_ID]: connectionId,
+      [HEADER_SESSION_ID]: sessionId,
+    },
+  });
+}
+
+function createSseMessageIterator(
+  response: Response,
+): AsyncIterator<AnyMessage> {
+  if (!response.body) {
+    throw new Error("Expected SSE response body");
+  }
+
+  return parseSseStream(response.body)[Symbol.asyncIterator]();
+}
+
+async function readNextSseMessage(
+  iterator: AsyncIterator<AnyMessage>,
+): Promise<AnyMessage> {
+  const result = await iterator.next();
+
+  if (result.done) {
+    throw new Error("Expected SSE message");
+  }
+
+  return result.value;
+}
+
+async function readNextMessageOrUndefined(
+  response: Response,
+  abort: AbortController,
+): Promise<AnyMessage | undefined> {
+  if (!response.body) {
+    throw new Error("Expected SSE response body");
+  }
+
+  const iterator = parseSseStream(response.body)[Symbol.asyncIterator]();
+
+  try {
+    const result = await Promise.race([
+      iterator.next(),
+      delay(50).then(() => ({ done: true, value: undefined })),
+    ]);
+
+    return result.done ? undefined : result.value;
+  } finally {
+    abort.abort();
+    await iterator.return?.();
+  }
+}
+
+function readMessageId(message: AnyMessage): string | number | null {
+  if (!("id" in message)) {
+    throw new Error("Expected message ID");
+  }
+
+  return message.id;
+}
+
+function readSessionId(message: AnyMessage): string {
+  if (!("result" in message) || !isRecord(message.result)) {
+    throw new Error("Expected session/new response result");
+  }
+
+  const sessionId = message.result["sessionId"];
+
+  if (typeof sessionId !== "string") {
+    throw new Error("Expected session ID");
+  }
+
+  return sessionId;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function postJson(
+  url: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": JSON_MIME_TYPE,
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}

--- a/src/server-permission.test.ts
+++ b/src/server-permission.test.ts
@@ -45,6 +45,64 @@ function createPromptRequest(id: number, sessionId: string) {
 }
 
 describe("AcpServer permission requests over HTTP", () => {
+  it("rejects session-scoped client responses without a session header", async () => {
+    const server = await startTestServer(
+      (conn: AgentSideConnection) =>
+        new TestAgent(conn, { enablePermission: true }),
+    );
+
+    try {
+      const connectionId = await initialize(server.url);
+      const sessionId = await createSession(server.url, connectionId);
+      const sessionSse = await openSessionSse(
+        server.url,
+        connectionId,
+        sessionId,
+      );
+      const sessionEvents = createSseMessageIterator(sessionSse);
+
+      expect(
+        await postJson(server.url, createPromptRequest(3, sessionId), {
+          [HEADER_CONNECTION_ID]: connectionId,
+          [HEADER_SESSION_ID]: sessionId,
+        }),
+      ).toMatchObject({ status: 202 });
+
+      await readNextSseMessage(sessionEvents);
+      const permissionRequest = await readNextSseMessage(sessionEvents);
+
+      const permissionResponse = {
+        jsonrpc: "2.0",
+        id: readMessageId(permissionRequest),
+        result: {
+          outcome: {
+            outcome: "selected",
+            optionId: "allow",
+          },
+        },
+      };
+
+      expect(
+        await postJson(server.url, permissionResponse, {
+          [HEADER_CONNECTION_ID]: connectionId,
+        }),
+      ).toMatchObject({ status: 400 });
+      expect(
+        await postJson(server.url, permissionResponse, {
+          [HEADER_CONNECTION_ID]: connectionId,
+          [HEADER_SESSION_ID]: sessionId,
+        }),
+      ).toMatchObject({ status: 202 });
+
+      await readNextSseMessage(sessionEvents);
+      await readNextSseMessage(sessionEvents);
+      await sessionEvents.return?.();
+      await sessionSse.body?.cancel();
+    } finally {
+      await server.close();
+    }
+  }, 10_000);
+
   it("routes permission requests over session SSE and accepts client responses", async () => {
     const server = await startTestServer(
       (conn: AgentSideConnection) =>
@@ -122,7 +180,10 @@ describe("AcpServer permission requests over HTTP", () => {
               },
             },
           },
-          { [HEADER_CONNECTION_ID]: connectionId },
+          {
+            [HEADER_CONNECTION_ID]: connectionId,
+            [HEADER_SESSION_ID]: sessionId,
+          },
         ),
       ).toMatchObject({ status: 202 });
 

--- a/src/server-session-sse.test.ts
+++ b/src/server-session-sse.test.ts
@@ -5,11 +5,18 @@ import {
   HEADER_SESSION_ID,
   JSON_MIME_TYPE,
 } from "./protocol.js";
+import { PROTOCOL_VERSION } from "./schema/index.js";
 import { parseSseStream } from "./sse.js";
 import { TestAgent } from "./test-support/test-agent.js";
 import { startTestServer } from "./test-support/test-http-server.js";
 
-import type { AgentSideConnection } from "./acp.js";
+import type {
+  AgentSideConnection,
+  InitializeRequest,
+  InitializeResponse,
+  LoadSessionRequest,
+  LoadSessionResponse,
+} from "./acp.js";
 import type { AnyMessage } from "./jsonrpc.js";
 
 const initializeRequest = {
@@ -55,6 +62,49 @@ function createForkRequest(id: number, sessionId: string) {
       sessionId,
     },
   };
+}
+
+function createLoadSessionRequest(id: number, sessionId: string) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "session/load",
+    params: {
+      cwd: "/tmp",
+      mcpServers: [],
+      sessionId,
+    },
+  };
+}
+
+class LoadSessionAgent extends TestAgent {
+  constructor(private readonly agentConnection: AgentSideConnection) {
+    super(agentConnection);
+  }
+
+  initialize(_params: InitializeRequest): Promise<InitializeResponse> {
+    return Promise.resolve({
+      protocolVersion: PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: true,
+      },
+    });
+  }
+
+  async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
+    await this.agentConnection.sessionUpdate({
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "replayed-session-history",
+        },
+      },
+    });
+
+    return {};
+  }
 }
 
 describe("AcpServer session SSE", () => {
@@ -198,6 +248,58 @@ describe("AcpServer session SSE", () => {
       );
 
       expect(response.status).toBe(202);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("routes session/load replay updates to session SSE and final response to connection SSE", async () => {
+    const server = await startTestServer(
+      (conn: AgentSideConnection) => new LoadSessionAgent(conn),
+    );
+
+    try {
+      const connectionId = await initialize(server.url);
+      const sessionId = "existing-session";
+      const connectionSse = await openConnectionSse(server.url, connectionId);
+      const sessionSse = await openSessionSse(
+        server.url,
+        connectionId,
+        sessionId,
+      );
+      const accepted = await postJson(
+        server.url,
+        createLoadSessionRequest(3, sessionId),
+        {
+          [HEADER_CONNECTION_ID]: connectionId,
+          [HEADER_SESSION_ID]: sessionId,
+        },
+      );
+
+      expect(sessionSse.status).toBe(200);
+      expect(accepted.status).toBe(202);
+      expect(await readSseMessages(sessionSse, 1)).toMatchObject([
+        {
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            sessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: {
+                text: "replayed-session-history",
+              },
+            },
+          },
+        },
+      ]);
+      expect(await readSseMessages(connectionSse, 1)).toMatchObject([
+        {
+          jsonrpc: "2.0",
+          id: 3,
+          result: {},
+        },
+      ]);
     } finally {
       await server.close();
     }

--- a/src/server-session-sse.test.ts
+++ b/src/server-session-sse.test.ts
@@ -39,7 +39,7 @@ const sessionNewRequest = {
   },
 };
 
-function createPromptRequest(id: number, sessionId?: string) {
+function createPromptRequest(id: string | number | null, sessionId?: string) {
   return {
     jsonrpc: "2.0",
     id,
@@ -182,6 +182,49 @@ describe("AcpServer session SSE", () => {
       expect(
         await readNextConnectionSseMessage(server.url, connectionId),
       ).toBeUndefined();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("routes null-ID session request responses to the session SSE stream", async () => {
+    const server = await startTestServer(
+      (conn: AgentSideConnection) => new TestAgent(conn, { chunkCount: 1 }),
+    );
+
+    try {
+      const connectionId = await initialize(server.url);
+      const sessionId = await createSession(server.url, connectionId);
+      const sessionSse = await openSessionSse(
+        server.url,
+        connectionId,
+        sessionId,
+      );
+
+      const accepted = await postJson(
+        server.url,
+        createPromptRequest(null, sessionId),
+        {
+          [HEADER_CONNECTION_ID]: connectionId,
+          [HEADER_SESSION_ID]: sessionId,
+        },
+      );
+
+      expect(accepted.status).toBe(202);
+      expect(await readSseMessages(sessionSse, 2)).toMatchObject([
+        {
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: { sessionId },
+        },
+        {
+          jsonrpc: "2.0",
+          id: null,
+          result: {
+            stopReason: "end_turn",
+          },
+        },
+      ]);
     } finally {
       await server.close();
     }

--- a/src/server-session-sse.test.ts
+++ b/src/server-session-sse.test.ts
@@ -1,0 +1,455 @@
+import { describe, expect, it } from "vitest";
+import {
+  EVENT_STREAM_MIME_TYPE,
+  HEADER_CONNECTION_ID,
+  HEADER_SESSION_ID,
+  JSON_MIME_TYPE,
+} from "./protocol.js";
+import { parseSseStream } from "./sse.js";
+import { TestAgent } from "./test-support/test-agent.js";
+import { startTestServer } from "./test-support/test-http-server.js";
+
+import type { AgentSideConnection } from "./acp.js";
+import type { AnyMessage } from "./jsonrpc.js";
+
+const initializeRequest = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: 1,
+    clientCapabilities: {},
+  },
+};
+
+const sessionNewRequest = {
+  jsonrpc: "2.0",
+  id: 2,
+  method: "session/new",
+  params: {
+    cwd: "/tmp",
+    mcpServers: [],
+  },
+};
+
+function createPromptRequest(id: number, sessionId?: string) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "session/prompt",
+    params: {
+      ...(sessionId === undefined ? {} : { sessionId }),
+      prompt: [{ type: "text", text: "Hello" }],
+    },
+  };
+}
+
+describe("AcpServer session SSE", () => {
+  it("streams prompt updates and responses on the session SSE stream", async () => {
+    const server = await startTestServer(
+      (conn: AgentSideConnection) => new TestAgent(conn, { chunkCount: 2 }),
+    );
+
+    try {
+      const connectionId = await initialize(server.url);
+      const sessionId = await createSession(server.url, connectionId);
+      const sessionSse = await openSessionSse(
+        server.url,
+        connectionId,
+        sessionId,
+      );
+
+      expect(sessionSse.status).toBe(200);
+
+      const accepted = await postJson(
+        server.url,
+        createPromptRequest(3, sessionId),
+        {
+          [HEADER_CONNECTION_ID]: connectionId,
+          [HEADER_SESSION_ID]: sessionId,
+        },
+      );
+
+      expect(accepted.status).toBe(202);
+      expect(await readSseMessages(sessionSse, 3)).toMatchObject([
+        {
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            sessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: {
+                text: "chunk-1",
+              },
+            },
+          },
+        },
+        {
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            sessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: {
+                text: "chunk-2",
+              },
+            },
+          },
+        },
+        {
+          jsonrpc: "2.0",
+          id: 3,
+          result: {
+            stopReason: "end_turn",
+          },
+        },
+      ]);
+      expect(
+        await readNextConnectionSseMessage(server.url, connectionId),
+      ).toBeUndefined();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("routes session prompts using params.sessionId when the session header is absent", async () => {
+    const server = await startTestServer();
+
+    try {
+      const connectionId = await initialize(server.url);
+      const sessionId = await createSession(server.url, connectionId);
+      const sessionSse = await openSessionSse(
+        server.url,
+        connectionId,
+        sessionId,
+      );
+      const accepted = await postJson(
+        server.url,
+        createPromptRequest(3, sessionId),
+        {
+          [HEADER_CONNECTION_ID]: connectionId,
+        },
+      );
+
+      expect(accepted.status).toBe(202);
+      expect(await readSseMessages(sessionSse, 2)).toMatchObject([
+        {
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: { sessionId },
+        },
+        {
+          jsonrpc: "2.0",
+          id: 3,
+          result: { stopReason: "end_turn" },
+        },
+      ]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects session-scoped requests without a session identifier", async () => {
+    const server = await startTestServer();
+
+    try {
+      const connectionId = await initialize(server.url);
+      const response = await postJson(server.url, createPromptRequest(3), {
+        [HEADER_CONNECTION_ID]: connectionId,
+      });
+
+      expect(response.status).toBe(400);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("replays buffered session messages when session SSE attaches after prompt", async () => {
+    const server = await startTestServer();
+
+    try {
+      const connectionId = await initialize(server.url);
+      const sessionId = await createSession(server.url, connectionId);
+      const accepted = await postJson(
+        server.url,
+        createPromptRequest(3, sessionId),
+        {
+          [HEADER_CONNECTION_ID]: connectionId,
+          [HEADER_SESSION_ID]: sessionId,
+        },
+      );
+      const sessionSse = await openSessionSse(
+        server.url,
+        connectionId,
+        sessionId,
+      );
+
+      expect(accepted.status).toBe(202);
+      expect(await readSseMessages(sessionSse, 2)).toMatchObject([
+        {
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: { sessionId },
+        },
+        {
+          jsonrpc: "2.0",
+          id: 3,
+          result: { stopReason: "end_turn" },
+        },
+      ]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("isolates prompt events for multiple sessions on the same connection", async () => {
+    const server = await startTestServer();
+
+    try {
+      const connectionId = await initialize(server.url);
+      const connectionSse = await openConnectionSse(server.url, connectionId);
+      const connectionEvents = createSseMessageIterator(connectionSse);
+      const firstSessionId = await createSessionFromConnectionEvents(
+        server.url,
+        connectionId,
+        connectionEvents,
+      );
+      const secondSessionId = await createSessionFromConnectionEvents(
+        server.url,
+        connectionId,
+        connectionEvents,
+      );
+      const firstSse = await openSessionSse(
+        server.url,
+        connectionId,
+        firstSessionId,
+      );
+      const secondSse = await openSessionSse(
+        server.url,
+        connectionId,
+        secondSessionId,
+      );
+
+      expect(
+        await postJson(server.url, createPromptRequest(3, firstSessionId), {
+          [HEADER_CONNECTION_ID]: connectionId,
+          [HEADER_SESSION_ID]: firstSessionId,
+        }),
+      ).toMatchObject({ status: 202 });
+      expect(
+        await postJson(server.url, createPromptRequest(4, secondSessionId), {
+          [HEADER_CONNECTION_ID]: connectionId,
+          [HEADER_SESSION_ID]: secondSessionId,
+        }),
+      ).toMatchObject({ status: 202 });
+
+      expect(await readSseMessages(firstSse, 2)).toMatchObject([
+        { method: "session/update", params: { sessionId: firstSessionId } },
+        { id: 3, result: { stopReason: "end_turn" } },
+      ]);
+      expect(await readSseMessages(secondSse, 2)).toMatchObject([
+        { method: "session/update", params: { sessionId: secondSessionId } },
+        { id: 4, result: { stopReason: "end_turn" } },
+      ]);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+async function initialize(url: string): Promise<string> {
+  const response = await postJson(url, initializeRequest);
+  const connectionId = response.headers.get(HEADER_CONNECTION_ID);
+
+  expect(response.status).toBe(200);
+  expect(connectionId).toMatch(/^[0-9a-f-]{36}$/);
+
+  return connectionId ?? "";
+}
+
+async function createSession(
+  url: string,
+  connectionId: string,
+): Promise<string> {
+  return createSessionFromConnectionSse(
+    url,
+    connectionId,
+    await openConnectionSse(url, connectionId),
+  );
+}
+
+async function createSessionFromConnectionSse(
+  url: string,
+  connectionId: string,
+  response: Response,
+): Promise<string> {
+  return createSessionFromConnectionEvents(
+    url,
+    connectionId,
+    createSseMessageIterator(response),
+  );
+}
+
+async function createSessionFromConnectionEvents(
+  url: string,
+  connectionId: string,
+  events: AsyncIterator<AnyMessage>,
+): Promise<string> {
+  const accepted = await postJson(url, sessionNewRequest, {
+    [HEADER_CONNECTION_ID]: connectionId,
+  });
+
+  expect(accepted.status).toBe(202);
+
+  return readSessionId(await readNextSseMessage(events));
+}
+
+function openConnectionSse(
+  url: string,
+  connectionId: string,
+  signal?: AbortSignal,
+): Promise<Response> {
+  return fetch(url, {
+    method: "GET",
+    headers: {
+      Accept: EVENT_STREAM_MIME_TYPE,
+      [HEADER_CONNECTION_ID]: connectionId,
+    },
+    signal,
+  });
+}
+
+function openSessionSse(
+  url: string,
+  connectionId: string,
+  sessionId: string,
+): Promise<Response> {
+  return fetch(url, {
+    method: "GET",
+    headers: {
+      Accept: EVENT_STREAM_MIME_TYPE,
+      [HEADER_CONNECTION_ID]: connectionId,
+      [HEADER_SESSION_ID]: sessionId,
+    },
+  });
+}
+
+function createSseMessageIterator(
+  response: Response,
+): AsyncIterator<AnyMessage> {
+  if (!response.body) {
+    throw new Error("Expected SSE response body");
+  }
+
+  return parseSseStream(response.body)[Symbol.asyncIterator]();
+}
+
+async function readNextSseMessage(
+  iterator: AsyncIterator<AnyMessage>,
+): Promise<AnyMessage> {
+  const result = await iterator.next();
+
+  if (result.done) {
+    throw new Error("Expected SSE message");
+  }
+
+  return result.value;
+}
+
+async function readSseMessages(
+  response: Response,
+  count: number,
+): Promise<AnyMessage[]> {
+  if (!response.body) {
+    throw new Error("Expected SSE response body");
+  }
+
+  const iterator = parseSseStream(response.body)[Symbol.asyncIterator]();
+
+  try {
+    const messages: AnyMessage[] = [];
+
+    for (const __unused of Array.from({ length: count })) {
+      void __unused;
+      const result = await iterator.next();
+
+      if (result.done) {
+        throw new Error("Expected SSE message");
+      }
+
+      messages.push(result.value);
+    }
+
+    return messages;
+  } finally {
+    await iterator.return?.();
+    await response.body.cancel();
+  }
+}
+
+async function readNextConnectionSseMessage(
+  url: string,
+  connectionId: string,
+): Promise<AnyMessage | undefined> {
+  const abort = new AbortController();
+  const response = await openConnectionSse(url, connectionId, abort.signal);
+
+  if (!response.body) {
+    throw new Error("Expected SSE response body");
+  }
+
+  const iterator = parseSseStream(response.body)[Symbol.asyncIterator]();
+
+  try {
+    const result = await Promise.race([
+      iterator.next(),
+      delay(50).then(() => ({ done: true, value: undefined })),
+    ]);
+
+    return result.done ? undefined : result.value;
+  } finally {
+    abort.abort();
+    await iterator.return?.();
+  }
+}
+
+function readSessionId(message: AnyMessage): string {
+  if (!("result" in message) || !isRecord(message.result)) {
+    throw new Error("Expected session/new response result");
+  }
+
+  const sessionId = message.result["sessionId"];
+
+  if (typeof sessionId !== "string") {
+    throw new Error("Expected session ID");
+  }
+
+  return sessionId;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function postJson(
+  url: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": JSON_MIME_TYPE,
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}

--- a/src/server-session-sse.test.ts
+++ b/src/server-session-sse.test.ts
@@ -77,6 +77,16 @@ function createLoadSessionRequest(id: number, sessionId: string) {
   };
 }
 
+function createCancelNotification(sessionId: string) {
+  return {
+    jsonrpc: "2.0",
+    method: "session/cancel",
+    params: {
+      sessionId,
+    },
+  };
+}
+
 class LoadSessionAgent extends TestAgent {
   constructor(private readonly agentConnection: AgentSideConnection) {
     super(agentConnection);
@@ -218,6 +228,47 @@ describe("AcpServer session SSE", () => {
     }
   });
 
+  it("rejects session-scoped notifications without a session header", async () => {
+    const server = await startTestServer();
+
+    try {
+      const connectionId = await initialize(server.url);
+      const sessionId = await createSession(server.url, connectionId);
+      const response = await postJson(
+        server.url,
+        createCancelNotification(sessionId),
+        {
+          [HEADER_CONNECTION_ID]: connectionId,
+        },
+      );
+
+      expect(response.status).toBe(400);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects session-scoped notifications with mismatched session header and params", async () => {
+    const server = await startTestServer();
+
+    try {
+      const connectionId = await initialize(server.url);
+      const sessionId = await createSession(server.url, connectionId);
+      const response = await postJson(
+        server.url,
+        createCancelNotification("other-session"),
+        {
+          [HEADER_CONNECTION_ID]: connectionId,
+          [HEADER_SESSION_ID]: sessionId,
+        },
+      );
+
+      expect(response.status).toBe(400);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("rejects session-scoped requests without any session identifier", async () => {
     const server = await startTestServer();
 
@@ -262,11 +313,6 @@ describe("AcpServer session SSE", () => {
       const connectionId = await initialize(server.url);
       const sessionId = "existing-session";
       const connectionSse = await openConnectionSse(server.url, connectionId);
-      const sessionSse = await openSessionSse(
-        server.url,
-        connectionId,
-        sessionId,
-      );
       const accepted = await postJson(
         server.url,
         createLoadSessionRequest(3, sessionId),
@@ -275,9 +321,14 @@ describe("AcpServer session SSE", () => {
           [HEADER_SESSION_ID]: sessionId,
         },
       );
+      const sessionSse = await openSessionSse(
+        server.url,
+        connectionId,
+        sessionId,
+      );
 
-      expect(sessionSse.status).toBe(200);
       expect(accepted.status).toBe(202);
+      expect(sessionSse.status).toBe(200);
       expect(await readSseMessages(sessionSse, 1)).toMatchObject([
         {
           jsonrpc: "2.0",

--- a/src/server-session-sse.test.ts
+++ b/src/server-session-sse.test.ts
@@ -44,6 +44,19 @@ function createPromptRequest(id: number, sessionId?: string) {
   };
 }
 
+function createForkRequest(id: number, sessionId: string) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "session/fork",
+    params: {
+      cwd: "/tmp",
+      mcpServers: [],
+      sessionId,
+    },
+  };
+}
+
 describe("AcpServer session SSE", () => {
   it("streams prompt updates and responses on the session SSE stream", async () => {
     const server = await startTestServer(
@@ -114,18 +127,13 @@ describe("AcpServer session SSE", () => {
     }
   });
 
-  it("routes session prompts using params.sessionId when the session header is absent", async () => {
+  it("rejects session-scoped requests without a session header", async () => {
     const server = await startTestServer();
 
     try {
       const connectionId = await initialize(server.url);
       const sessionId = await createSession(server.url, connectionId);
-      const sessionSse = await openSessionSse(
-        server.url,
-        connectionId,
-        sessionId,
-      );
-      const accepted = await postJson(
+      const response = await postJson(
         server.url,
         createPromptRequest(3, sessionId),
         {
@@ -133,25 +141,34 @@ describe("AcpServer session SSE", () => {
         },
       );
 
-      expect(accepted.status).toBe(202);
-      expect(await readSseMessages(sessionSse, 2)).toMatchObject([
-        {
-          jsonrpc: "2.0",
-          method: "session/update",
-          params: { sessionId },
-        },
-        {
-          jsonrpc: "2.0",
-          id: 3,
-          result: { stopReason: "end_turn" },
-        },
-      ]);
+      expect(response.status).toBe(400);
     } finally {
       await server.close();
     }
   });
 
-  it("rejects session-scoped requests without a session identifier", async () => {
+  it("rejects session-scoped requests with mismatched session header and params", async () => {
+    const server = await startTestServer();
+
+    try {
+      const connectionId = await initialize(server.url);
+      const sessionId = await createSession(server.url, connectionId);
+      const response = await postJson(
+        server.url,
+        createPromptRequest(3, "other-session"),
+        {
+          [HEADER_CONNECTION_ID]: connectionId,
+          [HEADER_SESSION_ID]: sessionId,
+        },
+      );
+
+      expect(response.status).toBe(400);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects session-scoped requests without any session identifier", async () => {
     const server = await startTestServer();
 
     try {
@@ -161,6 +178,26 @@ describe("AcpServer session SSE", () => {
       });
 
       expect(response.status).toBe(400);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("routes non-required session methods using params.sessionId when the session header is absent", async () => {
+    const server = await startTestServer();
+
+    try {
+      const connectionId = await initialize(server.url);
+      const sessionId = await createSession(server.url, connectionId);
+      const response = await postJson(
+        server.url,
+        createForkRequest(3, sessionId),
+        {
+          [HEADER_CONNECTION_ID]: connectionId,
+        },
+      );
+
+      expect(response.status).toBe(202);
     } finally {
       await server.close();
     }

--- a/src/server-session-sse.test.ts
+++ b/src/server-session-sse.test.ts
@@ -313,6 +313,11 @@ describe("AcpServer session SSE", () => {
       const connectionId = await initialize(server.url);
       const sessionId = "existing-session";
       const connectionSse = await openConnectionSse(server.url, connectionId);
+      const sessionSse = await openSessionSse(
+        server.url,
+        connectionId,
+        sessionId,
+      );
       const accepted = await postJson(
         server.url,
         createLoadSessionRequest(3, sessionId),
@@ -321,14 +326,9 @@ describe("AcpServer session SSE", () => {
           [HEADER_SESSION_ID]: sessionId,
         },
       );
-      const sessionSse = await openSessionSse(
-        server.url,
-        connectionId,
-        sessionId,
-      );
 
-      expect(accepted.status).toBe(202);
       expect(sessionSse.status).toBe(200);
+      expect(accepted.status).toBe(202);
       expect(await readSseMessages(sessionSse, 1)).toMatchObject([
         {
           jsonrpc: "2.0",

--- a/src/server-websocket-upgrade.test.ts
+++ b/src/server-websocket-upgrade.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from "vitest";
 
 import { PROTOCOL_VERSION } from "./acp.js";
+import { ConnectionRegistry } from "./connection.js";
 import { HEADER_CONNECTION_ID, JSON_MIME_TYPE } from "./protocol.js";
 import { AcpServer } from "./server.js";
 import { TestAgent } from "./test-support/test-agent.js";
+import { handleWebSocketConnection } from "./ws-server.js";
 
-import type { Agent, AgentSideConnection } from "./acp.js";
+import type {
+  Agent,
+  AgentSideConnection,
+  InitializeRequest,
+  InitializeResponse,
+  NewSessionRequest,
+  NewSessionResponse,
+} from "./acp.js";
 import type { AnyMessage } from "./jsonrpc.js";
 import type { WebSocketServerSocket } from "./ws-server.js";
 
@@ -223,6 +232,111 @@ describe("AcpServer prepared WebSocket upgrades", () => {
     }
   });
 
+  it("queues WebSocket frames while initialize is pending", async () => {
+    const initialize = createDeferred<InitializeResponse>();
+    const server = new AcpServer({
+      createAgent: (conn) =>
+        new DelayedInitializeAgent(conn, initialize.promise),
+    });
+    const socket = new FakeServerSocket();
+
+    try {
+      server.prepareWebSocketUpgrade().accept(socket);
+      socket.receive(JSON.stringify(initializeRequest));
+      socket.receive(JSON.stringify(sessionNewRequest));
+
+      expect(socket.sent).toEqual([]);
+
+      initialize.resolve({
+        protocolVersion: PROTOCOL_VERSION,
+        agentCapabilities: {
+          loadSession: false,
+        },
+      });
+
+      await expect(readSentMessage(socket)).resolves.toMatchObject({
+        jsonrpc: "2.0",
+        id: initializeRequest.id,
+        result: {
+          protocolVersion: PROTOCOL_VERSION,
+        },
+      });
+      await expect(readSentMessage(socket)).resolves.toMatchObject({
+        jsonrpc: "2.0",
+        id: sessionNewRequest.id,
+        result: {
+          sessionId: "queued-session",
+        },
+      });
+    } finally {
+      socket.close();
+      await server.close();
+    }
+  });
+
+  it("clears WebSocket client-response routes after forwarding responses", async () => {
+    const registry = new ConnectionRegistry();
+    const createAgent = (conn: AgentSideConnection): Agent =>
+      new TestAgent(conn);
+    const connection = registry.createPendingConnection(createAgent);
+    const socket = new FakeServerSocket();
+
+    try {
+      handleWebSocketConnection(socket, {
+        registry,
+        createAgent,
+        connection,
+      });
+      socket.receive(JSON.stringify(initializeRequest));
+      await readSentMessage(socket);
+
+      const permission = connection.agentConnection.requestPermission({
+        sessionId: "session-1",
+        toolCall: {
+          toolCallId: "permission-tool",
+          title: "Permission tool",
+        },
+        options: [
+          {
+            kind: "allow_once",
+            name: "Allow once",
+            optionId: "allow",
+          },
+        ],
+      });
+      const permissionRequest = await readSentMessage(socket);
+      if (!("id" in permissionRequest)) {
+        throw new Error("Expected permission request ID");
+      }
+
+      expect(connection.clientResponseRoutes.size).toBe(1);
+
+      socket.receive(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: permissionRequest.id,
+          result: {
+            outcome: {
+              outcome: "selected",
+              optionId: "allow",
+            },
+          },
+        }),
+      );
+
+      await expect(permission).resolves.toEqual({
+        outcome: {
+          outcome: "selected",
+          optionId: "allow",
+        },
+      });
+      expect(connection.clientResponseRoutes.size).toBe(0);
+    } finally {
+      socket.close();
+      registry.closeAll();
+    }
+  });
+
   it("keeps existing double-settle behavior for prepared WebSocket upgrades", async () => {
     const server = new AcpServer({
       createAgent: (conn) => new TestAgent(conn),
@@ -259,6 +373,38 @@ function recordingFactory(
   };
 }
 
+class DelayedInitializeAgent extends TestAgent {
+  constructor(
+    conn: AgentSideConnection,
+    private readonly initializeResponse: Promise<InitializeResponse>,
+  ) {
+    super(conn);
+  }
+
+  initialize(_params: InitializeRequest): Promise<InitializeResponse> {
+    return this.initializeResponse;
+  }
+
+  newSession(_params: NewSessionRequest): Promise<NewSessionResponse> {
+    return Promise.resolve({ sessionId: "queued-session" });
+  }
+}
+
+function createDeferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+  readonly reject: (error: unknown) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (error: unknown) => void = () => {};
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
 function readSentMessage(socket: FakeServerSocket): Promise<AnyMessage> {
   const message = socket.sent.shift();
 
@@ -268,7 +414,8 @@ function readSentMessage(socket: FakeServerSocket): Promise<AnyMessage> {
 
   return new Promise((resolve) => {
     socket.onSend = (data) => {
-      resolve(JSON.parse(data));
+      const message = socket.sent.shift();
+      resolve(JSON.parse(message ?? data));
     };
   });
 }

--- a/src/server-websocket-upgrade.test.ts
+++ b/src/server-websocket-upgrade.test.ts
@@ -274,6 +274,55 @@ describe("AcpServer prepared WebSocket upgrades", () => {
     }
   });
 
+  it("rejects duplicate WebSocket initialize requests after connection setup", async () => {
+    let initializeCalls = 0;
+    const server = new AcpServer({
+      createAgent: (conn) =>
+        new RecordingInitializeAgent(conn, () => {
+          initializeCalls += 1;
+        }),
+    });
+    const socket = new FakeServerSocket();
+
+    try {
+      server.prepareWebSocketUpgrade().accept(socket);
+      socket.receive(JSON.stringify(initializeRequest));
+
+      await expect(readSentMessage(socket)).resolves.toMatchObject({
+        jsonrpc: "2.0",
+        id: initializeRequest.id,
+        result: {
+          protocolVersion: PROTOCOL_VERSION,
+        },
+      });
+
+      socket.receive(JSON.stringify({ ...initializeRequest, id: 99 }));
+
+      await expect(readSentMessage(socket)).resolves.toMatchObject({
+        jsonrpc: "2.0",
+        id: 99,
+        error: {
+          code: -32600,
+          message: "Initialize not allowed on existing connection",
+        },
+      });
+      expect(initializeCalls).toBe(1);
+
+      socket.receive(JSON.stringify(sessionNewRequest));
+
+      await expect(readSentMessage(socket)).resolves.toMatchObject({
+        jsonrpc: "2.0",
+        id: sessionNewRequest.id,
+        result: {
+          sessionId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+        },
+      });
+    } finally {
+      socket.close();
+      await server.close();
+    }
+  });
+
   it("clears WebSocket client-response routes after forwarding responses", async () => {
     const registry = new ConnectionRegistry();
     const createAgent = (conn: AgentSideConnection): Agent =>
@@ -371,6 +420,20 @@ function recordingFactory(
     createdBy.push(label);
     return new TestAgent(conn);
   };
+}
+
+class RecordingInitializeAgent extends TestAgent {
+  constructor(
+    conn: AgentSideConnection,
+    private readonly onInitialize: () => void,
+  ) {
+    super(conn);
+  }
+
+  initialize(params: InitializeRequest): Promise<InitializeResponse> {
+    this.onInitialize();
+    return super.initialize(params);
+  }
 }
 
 class DelayedInitializeAgent extends TestAgent {

--- a/src/server-websocket-upgrade.test.ts
+++ b/src/server-websocket-upgrade.test.ts
@@ -382,7 +382,7 @@ describe("AcpServer prepared WebSocket upgrades", () => {
       expect(connection.clientResponseRoutes.size).toBe(0);
     } finally {
       socket.close();
-      registry.closeAll();
+      await registry.closeAll();
     }
   });
 

--- a/src/server-websocket-upgrade.test.ts
+++ b/src/server-websocket-upgrade.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+
+import { PROTOCOL_VERSION } from "./acp.js";
+import { HEADER_CONNECTION_ID } from "./protocol.js";
+import { AcpServer } from "./server.js";
+import { TestAgent } from "./test-support/test-agent.js";
+
+import type { Agent, AgentSideConnection } from "./acp.js";
+import type { AnyMessage } from "./jsonrpc.js";
+import type { WebSocketServerSocket } from "./ws-server.js";
+
+const initializeRequest = {
+  jsonrpc: "2.0",
+  id: 0,
+  method: "initialize",
+  params: {
+    protocolVersion: PROTOCOL_VERSION,
+    clientCapabilities: {},
+  },
+} satisfies AnyMessage;
+
+describe("AcpServer prepared WebSocket upgrades", () => {
+  it("uses the default factory when no per-upgrade override is provided", async () => {
+    const createdBy: string[] = [];
+    const server = new AcpServer({
+      createAgent: recordingFactory(createdBy, "default"),
+    });
+    const socket = new FakeServerSocket();
+
+    try {
+      server.prepareWebSocketUpgrade().accept(socket);
+      socket.receive(JSON.stringify(initializeRequest));
+
+      await expect(readSentMessage(socket)).resolves.toMatchObject({
+        jsonrpc: "2.0",
+        id: initializeRequest.id,
+        result: {
+          protocolVersion: PROTOCOL_VERSION,
+        },
+      });
+      expect(createdBy).toEqual(["default"]);
+    } finally {
+      socket.close();
+      await server.close();
+    }
+  });
+
+  it("uses a per-upgrade factory override for that WebSocket connection", async () => {
+    const createdBy: string[] = [];
+    const server = new AcpServer({
+      createAgent: recordingFactory(createdBy, "default"),
+    });
+    const socket = new FakeServerSocket();
+
+    try {
+      server
+        .prepareWebSocketUpgrade({
+          createAgent: recordingFactory(createdBy, "override"),
+        })
+        .accept(socket);
+      socket.receive(JSON.stringify(initializeRequest));
+
+      await readSentMessage(socket);
+      expect(createdBy).toEqual(["override"]);
+    } finally {
+      socket.close();
+      await server.close();
+    }
+  });
+
+  it("does not leak WebSocket factory overrides to later prepared upgrades", async () => {
+    const createdBy: string[] = [];
+    const server = new AcpServer({
+      createAgent: recordingFactory(createdBy, "default"),
+    });
+    const overrideSocket = new FakeServerSocket();
+    const defaultSocket = new FakeServerSocket();
+
+    try {
+      server
+        .prepareWebSocketUpgrade({
+          createAgent: recordingFactory(createdBy, "override"),
+        })
+        .accept(overrideSocket);
+      server.prepareWebSocketUpgrade().accept(defaultSocket);
+
+      overrideSocket.receive(JSON.stringify(initializeRequest));
+      defaultSocket.receive(JSON.stringify({ ...initializeRequest, id: 1 }));
+
+      await Promise.all([
+        readSentMessage(overrideSocket),
+        readSentMessage(defaultSocket),
+      ]);
+      expect(createdBy).toEqual(["override", "default"]);
+    } finally {
+      overrideSocket.close();
+      defaultSocket.close();
+      await server.close();
+    }
+  });
+
+  it("keeps concurrent WebSocket factory overrides isolated", async () => {
+    const createdBy: string[] = [];
+    const server = new AcpServer({
+      createAgent: recordingFactory(createdBy, "default"),
+    });
+    const firstSocket = new FakeServerSocket();
+    const secondSocket = new FakeServerSocket();
+
+    try {
+      const first = server.prepareWebSocketUpgrade({
+        createAgent: recordingFactory(createdBy, "first"),
+      });
+      const second = server.prepareWebSocketUpgrade({
+        createAgent: recordingFactory(createdBy, "second"),
+      });
+
+      second.accept(secondSocket);
+      first.accept(firstSocket);
+      secondSocket.receive(JSON.stringify({ ...initializeRequest, id: 2 }));
+      firstSocket.receive(JSON.stringify({ ...initializeRequest, id: 1 }));
+
+      await Promise.all([
+        readSentMessage(firstSocket),
+        readSentMessage(secondSocket),
+      ]);
+      expect(createdBy).toEqual(expect.arrayContaining(["first", "second"]));
+      expect(createdBy).toHaveLength(2);
+    } finally {
+      firstSocket.close();
+      secondSocket.close();
+      await server.close();
+    }
+  });
+
+  it("removes rejected prepared WebSocket connections", async () => {
+    const server = new AcpServer({
+      createAgent: (conn) => new TestAgent(conn),
+    });
+    const prepared = server.prepareWebSocketUpgrade();
+
+    try {
+      prepared.reject();
+      const response = await server.handleRequest(
+        new Request("http://127.0.0.1/acp", {
+          method: "GET",
+          headers: {
+            Accept: "text/event-stream",
+            [HEADER_CONNECTION_ID]: prepared.connectionId,
+          },
+        }),
+      );
+
+      expect(response.status).toBe(404);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("keeps existing double-settle behavior for prepared WebSocket upgrades", async () => {
+    const server = new AcpServer({
+      createAgent: (conn) => new TestAgent(conn),
+    });
+    const rejected = server.prepareWebSocketUpgrade();
+    const accepted = server.prepareWebSocketUpgrade();
+    const socket = new FakeServerSocket();
+
+    try {
+      rejected.reject();
+      expect(() => rejected.accept(new FakeServerSocket())).toThrow(
+        "ACP WebSocket upgrade has already been settled",
+      );
+
+      accepted.accept(socket);
+      expect(() => accepted.accept(new FakeServerSocket())).toThrow(
+        "ACP WebSocket upgrade has already been settled",
+      );
+      expect(() => accepted.reject()).not.toThrow();
+    } finally {
+      socket.close();
+      await server.close();
+    }
+  });
+});
+
+function recordingFactory(
+  createdBy: string[],
+  label: string,
+): (conn: AgentSideConnection) => Agent {
+  return (conn) => {
+    createdBy.push(label);
+    return new TestAgent(conn);
+  };
+}
+
+function readSentMessage(socket: FakeServerSocket): Promise<AnyMessage> {
+  const message = socket.sent.shift();
+
+  if (message) {
+    return Promise.resolve(JSON.parse(message));
+  }
+
+  return new Promise((resolve) => {
+    socket.onSend = (data) => {
+      resolve(JSON.parse(data));
+    };
+  });
+}
+
+class FakeServerSocket implements WebSocketServerSocket {
+  readonly sent: string[] = [];
+  readonly listeners = new Map<string, Set<(event: unknown) => void>>();
+  onSend: ((data: string) => void) | undefined;
+
+  send(data: string): void {
+    this.sent.push(data);
+    this.onSend?.(data);
+    this.onSend = undefined;
+  }
+
+  close(_code?: number, _reason?: string): void {
+    this.emit("close", {});
+  }
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    this.listeners.set(type, this.listeners.get(type) ?? new Set());
+    this.listeners.get(type)?.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  receive(data: string): void {
+    this.emit("message", { data });
+  }
+
+  private emit(type: string, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}

--- a/src/server-websocket-upgrade.test.ts
+++ b/src/server-websocket-upgrade.test.ts
@@ -232,6 +232,23 @@ describe("AcpServer prepared WebSocket upgrades", () => {
     }
   });
 
+  it("closes accepted WebSocket upgrades before initialize on server close", async () => {
+    const server = new AcpServer({
+      createAgent: (conn) => new TestAgent(conn),
+    });
+    const socket = new FakeServerSocket();
+
+    server.prepareWebSocketUpgrade().accept(socket);
+
+    expect(socket.closeCount).toBe(0);
+
+    await server.close();
+
+    expect(socket.closeCount).toBe(1);
+    expect(socket.closeCode).toBe(1001);
+    expect(socket.closeReason).toBe("Server shutting down");
+  });
+
   it("queues WebSocket frames while initialize is pending", async () => {
     const initialize = createDeferred<InitializeResponse>();
     const server = new AcpServer({
@@ -487,6 +504,9 @@ class FakeServerSocket implements WebSocketServerSocket {
   readonly sent: string[] = [];
   readonly listeners = new Map<string, Set<(event: unknown) => void>>();
   onSend: ((data: string) => void) | undefined;
+  closeCount = 0;
+  closeCode: number | undefined;
+  closeReason: string | undefined;
 
   send(data: string): void {
     this.sent.push(data);
@@ -494,7 +514,10 @@ class FakeServerSocket implements WebSocketServerSocket {
     this.onSend = undefined;
   }
 
-  close(_code?: number, _reason?: string): void {
+  close(code?: number, reason?: string): void {
+    this.closeCount += 1;
+    this.closeCode = code;
+    this.closeReason = reason;
     this.emit("close", {});
   }
 

--- a/src/server-websocket-upgrade.test.ts
+++ b/src/server-websocket-upgrade.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { PROTOCOL_VERSION } from "./acp.js";
-import { HEADER_CONNECTION_ID } from "./protocol.js";
+import { HEADER_CONNECTION_ID, JSON_MIME_TYPE } from "./protocol.js";
 import { AcpServer } from "./server.js";
 import { TestAgent } from "./test-support/test-agent.js";
 
@@ -16,6 +16,16 @@ const initializeRequest = {
   params: {
     protocolVersion: PROTOCOL_VERSION,
     clientCapabilities: {},
+  },
+} satisfies AnyMessage;
+
+const sessionNewRequest = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "session/new",
+  params: {
+    cwd: "/tmp",
+    mcpServers: [],
   },
 } satisfies AnyMessage;
 
@@ -153,6 +163,62 @@ describe("AcpServer prepared WebSocket upgrades", () => {
 
       expect(response.status).toBe(404);
     } finally {
+      await server.close();
+    }
+  });
+
+  it("does not expose accepted WebSocket upgrades to HTTP before initialize succeeds", async () => {
+    const server = new AcpServer({
+      createAgent: (conn) => new TestAgent(conn),
+    });
+    const prepared = server.prepareWebSocketUpgrade();
+    const socket = new FakeServerSocket();
+
+    try {
+      prepared.accept(socket);
+
+      const getResponse = await server.handleRequest(
+        new Request("http://127.0.0.1/acp", {
+          method: "GET",
+          headers: {
+            Accept: "text/event-stream",
+            [HEADER_CONNECTION_ID]: prepared.connectionId,
+          },
+        }),
+      );
+      const postResponse = await server.handleRequest(
+        new Request("http://127.0.0.1/acp", {
+          method: "POST",
+          headers: {
+            "Content-Type": JSON_MIME_TYPE,
+            [HEADER_CONNECTION_ID]: prepared.connectionId,
+          },
+          body: JSON.stringify(sessionNewRequest),
+        }),
+      );
+      const deleteResponse = await server.handleRequest(
+        new Request("http://127.0.0.1/acp", {
+          method: "DELETE",
+          headers: {
+            [HEADER_CONNECTION_ID]: prepared.connectionId,
+          },
+        }),
+      );
+
+      expect(getResponse.status).toBe(404);
+      expect(postResponse.status).toBe(404);
+      expect(deleteResponse.status).toBe(404);
+
+      socket.receive(JSON.stringify(initializeRequest));
+      await expect(readSentMessage(socket)).resolves.toMatchObject({
+        jsonrpc: "2.0",
+        id: initializeRequest.id,
+        result: {
+          protocolVersion: PROTOCOL_VERSION,
+        },
+      });
+    } finally {
+      socket.close();
       await server.close();
     }
   });

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { HEADER_CONNECTION_ID, JSON_MIME_TYPE } from "./protocol.js";
-import { startTestServer } from "./test-support/test-http-server.js";
+import {
+  EVENT_STREAM_MIME_TYPE,
+  HEADER_CONNECTION_ID,
+  HEADER_SESSION_ID,
+  JSON_MIME_TYPE,
+} from "./protocol.js";
+import { AcpServer } from "./server.js";
+import { parseSseStream } from "./sse.js";
 import { TestAgent } from "./test-support/test-agent.js";
+import { startTestServer } from "./test-support/test-http-server.js";
 
 import type { AgentSideConnection } from "./acp.js";
+import type { AnyMessage } from "./jsonrpc.js";
 
 const initializeRequest = {
   jsonrpc: "2.0",
@@ -12,6 +20,16 @@ const initializeRequest = {
   params: {
     protocolVersion: 1,
     clientCapabilities: {},
+  },
+};
+
+const sessionNewRequest = {
+  jsonrpc: "2.0",
+  id: 2,
+  method: "session/new",
+  params: {
+    cwd: "/tmp",
+    mcpServers: [],
   },
 };
 
@@ -42,20 +60,223 @@ describe("AcpServer", () => {
     }
   });
 
-  it.each(["GET", "PUT", "PATCH", "DELETE"])(
-    "rejects %s requests in Phase 1",
-    async (method) => {
-      const server = await startTestServer();
+  it("streams session/new responses over the connection SSE stream", async () => {
+    const server = await startTestServer();
 
-      try {
-        const response = await fetch(server.url, { method });
+    try {
+      const connectionId = await initialize(server.url);
+      const sseResponse = await openConnectionSse(server.url, connectionId);
 
-        expect(response.status).toBe(405);
-      } finally {
-        await server.close();
-      }
-    },
-  );
+      expect(sseResponse.status).toBe(200);
+      expect(sseResponse.headers.get("Content-Type")).toContain(
+        EVENT_STREAM_MIME_TYPE,
+      );
+
+      const accepted = await postJson(server.url, sessionNewRequest, {
+        [HEADER_CONNECTION_ID]: connectionId,
+      });
+
+      expect(accepted.status).toBe(202);
+      expect(await accepted.text()).toBe("");
+      expect(await readFirstSseMessage(sseResponse)).toMatchObject({
+        jsonrpc: "2.0",
+        id: sessionNewRequest.id,
+        result: {
+          sessionId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+        },
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("replays buffered connection messages when SSE attaches after POST", async () => {
+    const server = await startTestServer();
+
+    try {
+      const connectionId = await initialize(server.url);
+      const accepted = await postJson(server.url, sessionNewRequest, {
+        [HEADER_CONNECTION_ID]: connectionId,
+      });
+
+      expect(accepted.status).toBe(202);
+
+      const sseResponse = await openConnectionSse(server.url, connectionId);
+
+      expect(await readFirstSseMessage(sseResponse)).toMatchObject({
+        jsonrpc: "2.0",
+        id: sessionNewRequest.id,
+        result: {
+          sessionId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+        },
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it.each(["PUT", "PATCH"])("rejects %s requests", async (method) => {
+    const server = await startTestServer();
+
+    try {
+      const response = await fetch(server.url, { method });
+
+      expect(response.status).toBe(405);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects GET without Accept: text/event-stream", async () => {
+    const server = await startTestServer();
+
+    try {
+      const response = await fetch(server.url, {
+        method: "GET",
+        headers: {
+          [HEADER_CONNECTION_ID]: globalThis.crypto.randomUUID(),
+        },
+      });
+
+      expect(response.status).toBe(406);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects GET without a connection ID", async () => {
+    const server = await startTestServer();
+
+    try {
+      const response = await fetch(server.url, {
+        method: "GET",
+        headers: {
+          Accept: EVENT_STREAM_MIME_TYPE,
+        },
+      });
+
+      expect(response.status).toBe(400);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects GET with an unknown connection ID", async () => {
+    const server = await startTestServer();
+
+    try {
+      const response = await openConnectionSse(
+        server.url,
+        globalThis.crypto.randomUUID(),
+      );
+
+      expect(response.status).toBe(404);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects session-scoped GETs until session SSE is implemented", async () => {
+    const server = await startTestServer();
+
+    try {
+      const connectionId = await initialize(server.url);
+      const response = await fetch(server.url, {
+        method: "GET",
+        headers: {
+          Accept: EVENT_STREAM_MIME_TYPE,
+          [HEADER_CONNECTION_ID]: connectionId,
+          [HEADER_SESSION_ID]: globalThis.crypto.randomUUID(),
+        },
+      });
+
+      expect(response.status).toBe(404);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("returns 426 for WebSocket upgrade GETs", async () => {
+    const server = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => new TestAgent(conn),
+    });
+
+    try {
+      const response = await server.handleRequest(
+        new Request("http://127.0.0.1/acp", {
+          method: "GET",
+          headers: {
+            Accept: EVENT_STREAM_MIME_TYPE,
+            Upgrade: "websocket",
+          },
+        }),
+      );
+
+      expect(response.status).toBe(426);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("deletes connections and closes SSE streams", async () => {
+    const server = await startTestServer();
+
+    try {
+      const connectionId = await initialize(server.url);
+      const sseResponse = await openConnectionSse(server.url, connectionId);
+      const reader = sseResponse.body?.getReader();
+
+      expect(reader).toBeDefined();
+
+      const deleted = await fetch(server.url, {
+        method: "DELETE",
+        headers: {
+          [HEADER_CONNECTION_ID]: connectionId,
+        },
+      });
+
+      expect(deleted.status).toBe(202);
+      expect(await reader?.read()).toEqual({ done: true, value: undefined });
+      reader?.releaseLock();
+
+      const postAfterDelete = await postJson(server.url, sessionNewRequest, {
+        [HEADER_CONNECTION_ID]: connectionId,
+      });
+
+      expect(postAfterDelete.status).toBe(404);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects DELETE without a connection ID", async () => {
+    const server = await startTestServer();
+
+    try {
+      const response = await fetch(server.url, { method: "DELETE" });
+
+      expect(response.status).toBe(400);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects DELETE with an unknown connection ID", async () => {
+    const server = await startTestServer();
+
+    try {
+      const response = await fetch(server.url, {
+        method: "DELETE",
+        headers: {
+          [HEADER_CONNECTION_ID]: globalThis.crypto.randomUUID(),
+        },
+      });
+
+      expect(response.status).toBe(404);
+    } finally {
+      await server.close();
+    }
+  });
 
   it("rejects POST without application/json Content-Type", async () => {
     const server = await startTestServer();
@@ -127,15 +348,7 @@ describe("AcpServer", () => {
     const server = await startTestServer();
 
     try {
-      const response = await postJson(server.url, {
-        jsonrpc: "2.0",
-        id: 2,
-        method: "session/new",
-        params: {
-          cwd: "/tmp",
-          mcpServers: [],
-        },
-      });
+      const response = await postJson(server.url, sessionNewRequest);
 
       expect(response.status).toBe(400);
     } finally {
@@ -147,54 +360,11 @@ describe("AcpServer", () => {
     const server = await startTestServer();
 
     try {
-      const response = await postJson(
-        server.url,
-        {
-          jsonrpc: "2.0",
-          id: 2,
-          method: "session/new",
-          params: {
-            cwd: "/tmp",
-            mcpServers: [],
-          },
-        },
-        {
-          [HEADER_CONNECTION_ID]: globalThis.crypto.randomUUID(),
-        },
-      );
+      const response = await postJson(server.url, sessionNewRequest, {
+        [HEADER_CONNECTION_ID]: globalThis.crypto.randomUUID(),
+      });
 
       expect(response.status).toBe(404);
-    } finally {
-      await server.close();
-    }
-  });
-
-  it("rejects connected POSTs after initialize in Phase 1", async () => {
-    const server = await startTestServer();
-
-    try {
-      const initializeResponse = await postJson(server.url, initializeRequest);
-      const connectionId = initializeResponse.headers.get(HEADER_CONNECTION_ID);
-
-      expect(connectionId).toBeTruthy();
-
-      const response = await postJson(
-        server.url,
-        {
-          jsonrpc: "2.0",
-          id: 2,
-          method: "session/new",
-          params: {
-            cwd: "/tmp",
-            mcpServers: [],
-          },
-        },
-        {
-          [HEADER_CONNECTION_ID]: connectionId ?? "",
-        },
-      );
-
-      expect(response.status).toBe(400);
     } finally {
       await server.close();
     }
@@ -257,6 +427,46 @@ describe("AcpServer", () => {
     }
   });
 });
+
+async function initialize(url: string): Promise<string> {
+  const response = await postJson(url, initializeRequest);
+  const connectionId = response.headers.get(HEADER_CONNECTION_ID);
+
+  expect(response.status).toBe(200);
+  expect(connectionId).toMatch(/^[0-9a-f-]{36}$/);
+
+  return connectionId ?? "";
+}
+
+function openConnectionSse(
+  url: string,
+  connectionId: string,
+): Promise<Response> {
+  return fetch(url, {
+    method: "GET",
+    headers: {
+      Accept: EVENT_STREAM_MIME_TYPE,
+      [HEADER_CONNECTION_ID]: connectionId,
+    },
+  });
+}
+
+async function readFirstSseMessage(response: Response): Promise<AnyMessage> {
+  if (!response.body) {
+    throw new Error("Expected SSE response body");
+  }
+
+  const iterator = parseSseStream(response.body)[Symbol.asyncIterator]();
+  const result = await iterator.next();
+  await iterator.return?.();
+  await response.body.cancel();
+
+  if (result.done) {
+    throw new Error("Expected SSE message");
+  }
+
+  return result.value;
+}
 
 function postJson(
   url: string,

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -176,19 +176,16 @@ describe("AcpServer", () => {
     }
   });
 
-  it("rejects session-scoped GETs until session SSE is implemented", async () => {
+  it("rejects session-scoped GETs for unknown sessions", async () => {
     const server = await startTestServer();
 
     try {
       const connectionId = await initialize(server.url);
-      const response = await fetch(server.url, {
-        method: "GET",
-        headers: {
-          Accept: EVENT_STREAM_MIME_TYPE,
-          [HEADER_CONNECTION_ID]: connectionId,
-          [HEADER_SESSION_ID]: globalThis.crypto.randomUUID(),
-        },
-      });
+      const response = await openSessionSse(
+        server.url,
+        connectionId,
+        globalThis.crypto.randomUUID(),
+      );
 
       expect(response.status).toBe(404);
     } finally {
@@ -447,6 +444,21 @@ function openConnectionSse(
     headers: {
       Accept: EVENT_STREAM_MIME_TYPE,
       [HEADER_CONNECTION_ID]: connectionId,
+    },
+  });
+}
+
+function openSessionSse(
+  url: string,
+  connectionId: string,
+  sessionId: string,
+): Promise<Response> {
+  return fetch(url, {
+    method: "GET",
+    headers: {
+      Accept: EVENT_STREAM_MIME_TYPE,
+      [HEADER_CONNECTION_ID]: connectionId,
+      [HEADER_SESSION_ID]: sessionId,
     },
   });
 }

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -183,6 +183,38 @@ describe("AcpServer", () => {
     }
   });
 
+  it("waits for registry shutdowns before close resolves", async () => {
+    const server = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => new TestAgent(conn),
+    });
+    const registry = (
+      server as unknown as {
+        registry: {
+          closeAll(): Promise<void>;
+        };
+      }
+    ).registry;
+    const shutdownStarted = createDeferred<void>();
+    const allowShutdown = createDeferred<void>();
+    vi.spyOn(registry, "closeAll").mockImplementation(async () => {
+      shutdownStarted.resolve();
+      await allowShutdown.promise;
+    });
+    let closeResolved = false;
+
+    const close = server.close().then(() => {
+      closeResolved = true;
+    });
+
+    await shutdownStarted.promise;
+    await flushMicrotasks();
+    expect(closeResolved).toBe(false);
+
+    allowShutdown.resolve();
+    await close;
+    expect(closeResolved).toBe(true);
+  });
+
   it("discards HTTP initialize connections when the request aborts", async () => {
     const agentCreated = createDeferred<void>();
     const initializeStarted = createDeferred<void>();

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -275,15 +275,47 @@ describe("AcpServer", () => {
     }
   });
 
-  it("rejects POST without application/json Content-Type", async () => {
+  it("accepts POST with application/json Content-Type parameters", async () => {
     const server = await startTestServer();
 
     try {
       const response = await fetch(server.url, {
         method: "POST",
         headers: {
-          "Content-Type": "text/plain",
+          "Content-Type": "application/json; charset=utf-8",
         },
+        body: JSON.stringify(initializeRequest),
+      });
+
+      expect(response.status).toBe(200);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects POST without Content-Type", async () => {
+    const server = await startTestServer();
+
+    try {
+      const response = await fetch(server.url, { method: "POST" });
+
+      expect(response.status).toBe(415);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it.each([
+    "text/plain",
+    "application/jsonfoobar",
+    "application/json-patch+json",
+  ])("rejects POST with %s Content-Type", async (contentType) => {
+    const server = await startTestServer();
+
+    try {
+      const response = await fetch(server.url, {
+        method: "POST",
+        headers: { "Content-Type": contentType },
         body: JSON.stringify(initializeRequest),
       });
 

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -176,7 +176,7 @@ describe("AcpServer", () => {
     }
   });
 
-  it("opens session-scoped GETs for sessions without local streams", async () => {
+  it("rejects session-scoped GETs for unknown sessions", async () => {
     const server = await startTestServer();
 
     try {
@@ -187,7 +187,7 @@ describe("AcpServer", () => {
         globalThis.crypto.randomUUID(),
       );
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(404);
     } finally {
       await server.close();
     }
@@ -378,6 +378,21 @@ describe("AcpServer", () => {
 
     try {
       const response = await postJson(server.url, sessionNewRequest);
+
+      expect(response.status).toBe(400);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects initialize requests on existing connections", async () => {
+    const server = await startTestServer();
+
+    try {
+      const connectionId = await initialize(server.url);
+      const response = await postJson(server.url, initializeRequest, {
+        [HEADER_CONNECTION_ID]: connectionId,
+      });
 
       expect(response.status).toBe(400);
     } finally {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -183,6 +183,71 @@ describe("AcpServer", () => {
     }
   });
 
+  it("discards HTTP initialize connections when the request aborts", async () => {
+    const agentCreated = createDeferred<void>();
+    const initializeStarted = createDeferred<void>();
+    const initializeResponse = createDeferred<{
+      protocolVersion: 1;
+      agentCapabilities: { loadSession: false };
+    }>();
+    const connectionClosed = createDeferred<void>();
+    const abortController = new AbortController();
+    const server = new AcpServer({
+      createAgent: (conn: AgentSideConnection): Agent => {
+        queueMicrotask(() => {
+          if (conn.signal.aborted) {
+            connectionClosed.resolve();
+            return;
+          }
+
+          conn.signal.addEventListener(
+            "abort",
+            () => {
+              connectionClosed.resolve();
+            },
+            { once: true },
+          );
+        });
+        agentCreated.resolve();
+
+        return {
+          initialize: () => {
+            initializeStarted.resolve();
+            return initializeResponse.promise;
+          },
+          newSession: () => Promise.resolve({ sessionId: "session-1" }),
+          authenticate: () => Promise.resolve(),
+          cancel: () => Promise.resolve(),
+          prompt: () => Promise.resolve({ stopReason: "end_turn" }),
+        };
+      },
+    });
+
+    try {
+      const responsePromise = server.handleRequest(
+        jsonRequest(initializeRequest, {}, abortController.signal),
+      );
+
+      await agentCreated.promise;
+      await withTimeout(initializeStarted.promise);
+      abortController.abort();
+
+      const response = await withTimeout(responsePromise);
+
+      expect(response.status).toBe(499);
+      expect(response.headers.get(HEADER_CONNECTION_ID)).toBeNull();
+      await withTimeout(connectionClosed.promise);
+
+      initializeResponse.resolve({
+        protocolVersion: 1,
+        agentCapabilities: { loadSession: false },
+      });
+      await flushMicrotasks();
+    } finally {
+      await server.close();
+    }
+  });
+
   it("ignores HTTP factory overrides for existing-connection POST requests", async () => {
     const createdBy: string[] = [];
     const server = new AcpServer({
@@ -785,6 +850,7 @@ async function initializeDirect(server: AcpServer): Promise<string> {
 function jsonRequest(
   body: unknown,
   headers: Record<string, string> = {},
+  signal?: AbortSignal,
 ): Request {
   return new Request("http://127.0.0.1/acp", {
     method: "POST",
@@ -793,6 +859,7 @@ function jsonRequest(
       ...headers,
     },
     body: JSON.stringify(body),
+    signal,
   });
 }
 
@@ -955,6 +1022,43 @@ async function waitFor(callback: () => boolean): Promise<void> {
 
     await new Promise((resolve) => setTimeout(resolve, 1));
   }
+}
+
+function createDeferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+  readonly reject: (error: unknown) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (error: unknown) => void = () => {};
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+async function withTimeout<T>(promise: Promise<T>): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error("Timed out waiting for promise"));
+        }, 1_000);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 function postJson(

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   EVENT_STREAM_MIME_TYPE,
   HEADER_CONNECTION_ID,
@@ -10,7 +10,7 @@ import { parseSseStream } from "./sse.js";
 import { TestAgent } from "./test-support/test-agent.js";
 import { startTestServer } from "./test-support/test-http-server.js";
 
-import type { AgentSideConnection } from "./acp.js";
+import type { Agent, AgentSideConnection } from "./acp.js";
 import type { AnyMessage } from "./jsonrpc.js";
 
 const initializeRequest = {
@@ -30,6 +30,16 @@ const sessionNewRequest = {
   params: {
     cwd: "/tmp",
     mcpServers: [],
+  },
+};
+
+const promptRequest = {
+  jsonrpc: "2.0",
+  id: 3,
+  method: "session/prompt",
+  params: {
+    sessionId: "session-1",
+    prompt: [{ type: "text", text: "Hello" }],
   },
 };
 
@@ -337,6 +347,69 @@ describe("AcpServer", () => {
         },
       });
     } finally {
+      await server.close();
+    }
+  });
+
+  it("does not drain outbound subscriptions faster than SSE body demand", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let resolvePromptDone: () => void = () => {};
+    const promptDone = new Promise<void>((resolve) => {
+      resolvePromptDone = resolve;
+    });
+    const server = new AcpServer({
+      createAgent: (conn: AgentSideConnection) =>
+        createBackpressureAgent(conn, resolvePromptDone),
+    });
+    let iterator: AsyncIterator<AnyMessage> | undefined;
+    let body: ReadableStream<Uint8Array> | null | undefined;
+
+    try {
+      const connectionId = await initializeDirect(server);
+      const sseResponse = await server.handleRequest(
+        new Request("http://127.0.0.1/acp", {
+          method: "GET",
+          headers: {
+            Accept: EVENT_STREAM_MIME_TYPE,
+            [HEADER_CONNECTION_ID]: connectionId,
+            [HEADER_SESSION_ID]: "session-1",
+          },
+        }),
+      );
+      body = sseResponse.body;
+
+      expect(sseResponse.status).toBe(200);
+      expect(body).toBeDefined();
+
+      iterator = parseSseStream(body!)[Symbol.asyncIterator]();
+      const firstMessage = iterator.next();
+
+      const accepted = await server.handleRequest(
+        jsonRequest(promptRequest, {
+          [HEADER_CONNECTION_ID]: connectionId,
+          [HEADER_SESSION_ID]: "session-1",
+        }),
+      );
+
+      expect(accepted.status).toBe(202);
+      expect(chunkText(await firstMessage)).toBe("chunk-1");
+      await promptDone;
+      await waitFor(() => warnSpy.mock.calls.length > 0);
+
+      const chunkNumbers = [1];
+      for (let index = 0; index < 128; index++) {
+        const chunk = chunkText(await iterator.next());
+        chunkNumbers.push(Number(chunk.slice("chunk-".length)));
+      }
+
+      expect(hasGap(chunkNumbers)).toBe(true);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "ACP outbound subscriber lagged; dropping oldest message",
+      );
+    } finally {
+      await iterator?.return?.();
+      await body?.cancel().catch(() => undefined);
+      warnSpy.mockRestore();
       await server.close();
     }
   });
@@ -806,6 +879,81 @@ async function readSseMessages(
   } finally {
     await iterator.return?.();
     await response.body.cancel();
+  }
+}
+
+function chunkText(result: IteratorResult<AnyMessage>): string {
+  if (result.done) {
+    throw new Error("Expected SSE message");
+  }
+
+  const text = (
+    result.value as {
+      params?: { update?: { content?: { text?: unknown } } };
+    }
+  ).params?.update?.content?.text;
+
+  if (typeof text !== "string") {
+    throw new Error("Expected session update chunk text");
+  }
+
+  return text;
+}
+
+function hasGap(values: readonly number[]): boolean {
+  return values.some((value, index) => {
+    if (index === 0) {
+      return false;
+    }
+
+    return value !== values[index - 1] + 1;
+  });
+}
+
+function createBackpressureAgent(
+  connection: AgentSideConnection,
+  onPromptDone: () => void,
+): Agent {
+  return {
+    initialize: () =>
+      Promise.resolve({
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: false,
+        },
+      }),
+    newSession: () => Promise.resolve({ sessionId: "session-1" }),
+    authenticate: () => Promise.resolve(),
+    cancel: () => Promise.resolve(),
+    prompt: async (params) => {
+      for (let index = 0; index < 1_100; index++) {
+        await connection.sessionUpdate({
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: {
+              type: "text",
+              text: `chunk-${index + 1}`,
+            },
+          },
+        });
+      }
+
+      onPromptDone();
+      return { stopReason: "end_turn" };
+    },
+  };
+}
+
+async function waitFor(callback: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+
+  while (!callback()) {
+    if (Date.now() > deadline) {
+      throw new Error("Timed out waiting for condition");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1));
   }
 }
 

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -203,6 +203,45 @@ describe("AcpServer", () => {
     }
   });
 
+  it("serializes concurrent POST writes for the same connection", async () => {
+    const server = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => new TestAgent(conn),
+    });
+
+    try {
+      const connectionId = await initializeDirect(server);
+      const headers = { [HEADER_CONNECTION_ID]: connectionId };
+      const first = server.handleRequest(
+        jsonRequest(sessionNewRequest, headers),
+      );
+      const second = server.handleRequest(
+        jsonRequest({ ...sessionNewRequest, id: 3 }, headers),
+      );
+
+      const responses = await Promise.all([first, second]);
+
+      expect(responses.map((response) => response.status)).toEqual([202, 202]);
+
+      const sseResponse = await server.handleRequest(
+        new Request("http://127.0.0.1/acp", {
+          method: "GET",
+          headers: {
+            Accept: EVENT_STREAM_MIME_TYPE,
+            [HEADER_CONNECTION_ID]: connectionId,
+          },
+        }),
+      );
+
+      expect(sseResponse.status).toBe(200);
+      const messages = await readSseMessages(sseResponse, 2);
+      expect(
+        messages.map((message) => ("id" in message ? message.id : undefined)),
+      ).toEqual([2, 3]);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("ignores HTTP factory overrides for GET and DELETE requests", async () => {
     const createdBy: string[] = [];
     const server = new AcpServer({
@@ -737,6 +776,37 @@ async function readFirstSseMessage(response: Response): Promise<AnyMessage> {
   }
 
   return result.value;
+}
+
+async function readSseMessages(
+  response: Response,
+  count: number,
+): Promise<AnyMessage[]> {
+  if (!response.body) {
+    throw new Error("Expected SSE response body");
+  }
+
+  const iterator = parseSseStream(response.body)[Symbol.asyncIterator]();
+
+  try {
+    const messages: AnyMessage[] = [];
+
+    for (const __unused of Array.from({ length: count })) {
+      void __unused;
+      const result = await iterator.next();
+
+      if (result.done) {
+        throw new Error("Expected SSE message");
+      }
+
+      messages.push(result.value);
+    }
+
+    return messages;
+  } finally {
+    await iterator.return?.();
+    await response.body.cancel();
+  }
 }
 
 function postJson(

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -176,7 +176,7 @@ describe("AcpServer", () => {
     }
   });
 
-  it("rejects session-scoped GETs for unknown sessions", async () => {
+  it("opens session-scoped GETs for sessions without local streams", async () => {
     const server = await startTestServer();
 
     try {
@@ -187,7 +187,7 @@ describe("AcpServer", () => {
         globalThis.crypto.randomUUID(),
       );
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(200);
     } finally {
       await server.close();
     }

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -60,6 +60,193 @@ describe("AcpServer", () => {
     }
   });
 
+  it("uses the default factory for direct HTTP initialize requests", async () => {
+    const createdBy: string[] = [];
+    const server = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => {
+        createdBy.push("default");
+        return new TestAgent(conn);
+      },
+    });
+
+    try {
+      const response = await server.handleRequest(
+        jsonRequest(initializeRequest),
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get(HEADER_CONNECTION_ID)).toMatch(
+        /^[0-9a-f-]{36}$/,
+      );
+      expect(createdBy).toEqual(["default"]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("uses per-request factory overrides for direct HTTP initialize requests", async () => {
+    const createdBy: string[] = [];
+    const server = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => {
+        createdBy.push("default");
+        return new TestAgent(conn);
+      },
+    });
+
+    try {
+      const response = await server.handleRequest(
+        jsonRequest(initializeRequest),
+        {
+          createAgent: (conn) => {
+            createdBy.push("override");
+            return new TestAgent(conn);
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get(HEADER_CONNECTION_ID)).toMatch(
+        /^[0-9a-f-]{36}$/,
+      );
+      expect(createdBy).toEqual(["override"]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("does not leak HTTP factory overrides to later initialize requests", async () => {
+    const createdBy: string[] = [];
+    const server = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => {
+        createdBy.push("default");
+        return new TestAgent(conn);
+      },
+    });
+
+    try {
+      await server.handleRequest(jsonRequest(initializeRequest), {
+        createAgent: (conn) => {
+          createdBy.push("override");
+          return new TestAgent(conn);
+        },
+      });
+      await server.handleRequest(jsonRequest({ ...initializeRequest, id: 2 }));
+
+      expect(createdBy).toEqual(["override", "default"]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("keeps concurrent HTTP initialize factory overrides isolated", async () => {
+    const createdBy: string[] = [];
+    const server = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => {
+        createdBy.push("default");
+        return new TestAgent(conn);
+      },
+    });
+
+    try {
+      const first = server.handleRequest(jsonRequest(initializeRequest), {
+        createAgent: (conn) => {
+          createdBy.push("first");
+          return new TestAgent(conn);
+        },
+      });
+      const second = server.handleRequest(
+        jsonRequest({ ...initializeRequest, id: 2 }),
+        {
+          createAgent: (conn) => {
+            createdBy.push("second");
+            return new TestAgent(conn);
+          },
+        },
+      );
+
+      await Promise.all([first, second]);
+
+      expect(createdBy).toEqual(expect.arrayContaining(["first", "second"]));
+      expect(createdBy).toHaveLength(2);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("ignores HTTP factory overrides for existing-connection POST requests", async () => {
+    const createdBy: string[] = [];
+    const server = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => {
+        createdBy.push("default");
+        return new TestAgent(conn);
+      },
+    });
+
+    try {
+      const connectionId = await initializeDirect(server);
+      const response = await server.handleRequest(
+        jsonRequest(sessionNewRequest, {
+          [HEADER_CONNECTION_ID]: connectionId,
+        }),
+        {
+          createAgent: (conn) => {
+            createdBy.push("override");
+            return new TestAgent(conn);
+          },
+        },
+      );
+
+      expect(response.status).toBe(202);
+      expect(createdBy).toEqual(["default"]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("ignores HTTP factory overrides for GET and DELETE requests", async () => {
+    const createdBy: string[] = [];
+    const server = new AcpServer({
+      createAgent: (conn: AgentSideConnection) => {
+        createdBy.push("default");
+        return new TestAgent(conn);
+      },
+    });
+
+    try {
+      const connectionId = await initializeDirect(server);
+      const createAgent = (conn: AgentSideConnection): TestAgent => {
+        createdBy.push("override");
+        return new TestAgent(conn);
+      };
+      const getResponse = await server.handleRequest(
+        new Request("http://127.0.0.1/acp", {
+          method: "GET",
+          headers: {
+            Accept: EVENT_STREAM_MIME_TYPE,
+            [HEADER_CONNECTION_ID]: connectionId,
+          },
+        }),
+        { createAgent },
+      );
+
+      expect(getResponse.status).toBe(200);
+      await getResponse.body?.cancel();
+
+      const deleteResponse = await server.handleRequest(
+        new Request("http://127.0.0.1/acp", {
+          method: "DELETE",
+          headers: { [HEADER_CONNECTION_ID]: connectionId },
+        }),
+        { createAgent },
+      );
+
+      expect(deleteResponse.status).toBe(202);
+      expect(createdBy).toEqual(["default"]);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("streams session/new responses over the connection SSE stream", async () => {
     const server = await startTestServer();
 
@@ -471,6 +658,30 @@ describe("AcpServer", () => {
     }
   });
 });
+
+async function initializeDirect(server: AcpServer): Promise<string> {
+  const response = await server.handleRequest(jsonRequest(initializeRequest));
+  const connectionId = response.headers.get(HEADER_CONNECTION_ID);
+
+  expect(response.status).toBe(200);
+  expect(connectionId).toMatch(/^[0-9a-f-]{36}$/);
+
+  return connectionId ?? "";
+}
+
+function jsonRequest(
+  body: unknown,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request("http://127.0.0.1/acp", {
+    method: "POST",
+    headers: {
+      "Content-Type": JSON_MIME_TYPE,
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
 
 async function initialize(url: string): Promise<string> {
   const response = await postJson(url, initializeRequest);

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import { HEADER_CONNECTION_ID, JSON_MIME_TYPE } from "./protocol.js";
+import { startTestServer } from "./test-support/test-http-server.js";
+import { TestAgent } from "./test-support/test-agent.js";
+
+import type { AgentSideConnection } from "./acp.js";
+
+const initializeRequest = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: 1,
+    clientCapabilities: {},
+  },
+};
+
+describe("AcpServer", () => {
+  it("handles initialize over HTTP and returns a connection ID", async () => {
+    const server = await startTestServer();
+
+    try {
+      const response = await postJson(server.url, initializeRequest);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get(HEADER_CONNECTION_ID)).toMatch(
+        /^[0-9a-f-]{36}$/,
+      );
+      expect(body).toMatchObject({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          protocolVersion: 1,
+          agentCapabilities: {
+            loadSession: false,
+          },
+        },
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it.each(["GET", "PUT", "PATCH", "DELETE"])(
+    "rejects %s requests in Phase 1",
+    async (method) => {
+      const server = await startTestServer();
+
+      try {
+        const response = await fetch(server.url, { method });
+
+        expect(response.status).toBe(405);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+
+  it("rejects POST without application/json Content-Type", async () => {
+    const server = await startTestServer();
+
+    try {
+      const response = await fetch(server.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "text/plain",
+        },
+        body: JSON.stringify(initializeRequest),
+      });
+
+      expect(response.status).toBe(415);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects invalid JSON", async () => {
+    const server = await startTestServer();
+
+    try {
+      const response = await fetch(server.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": JSON_MIME_TYPE,
+        },
+        body: "{ nope",
+      });
+
+      expect(response.status).toBe(400);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects JSON-RPC batches", async () => {
+    const server = await startTestServer();
+
+    try {
+      const response = await postJson(server.url, [initializeRequest]);
+
+      expect(response.status).toBe(501);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it.each([
+    null,
+    "initialize",
+    1,
+    {},
+    { jsonrpc: "1.0", method: "initialize" },
+  ])("rejects invalid JSON-RPC messages", async (body) => {
+    const server = await startTestServer();
+
+    try {
+      const response = await postJson(server.url, body);
+
+      expect(response.status).toBe(400);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects non-initialize requests without a connection ID", async () => {
+    const server = await startTestServer();
+
+    try {
+      const response = await postJson(server.url, {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "session/new",
+        params: {
+          cwd: "/tmp",
+          mcpServers: [],
+        },
+      });
+
+      expect(response.status).toBe(400);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects unknown connection IDs", async () => {
+    const server = await startTestServer();
+
+    try {
+      const response = await postJson(
+        server.url,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "session/new",
+          params: {
+            cwd: "/tmp",
+            mcpServers: [],
+          },
+        },
+        {
+          [HEADER_CONNECTION_ID]: globalThis.crypto.randomUUID(),
+        },
+      );
+
+      expect(response.status).toBe(404);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects connected POSTs after initialize in Phase 1", async () => {
+    const server = await startTestServer();
+
+    try {
+      const initializeResponse = await postJson(server.url, initializeRequest);
+      const connectionId = initializeResponse.headers.get(HEADER_CONNECTION_ID);
+
+      expect(connectionId).toBeTruthy();
+
+      const response = await postJson(
+        server.url,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "session/new",
+          params: {
+            cwd: "/tmp",
+            mcpServers: [],
+          },
+        },
+        {
+          [HEADER_CONNECTION_ID]: connectionId ?? "",
+        },
+      );
+
+      expect(response.status).toBe(400);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("returns an error response when agent creation fails", async () => {
+    const server = await startTestServer(() => {
+      throw new Error("agent factory failed");
+    });
+
+    try {
+      const response = await postJson(server.url, initializeRequest);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(response.headers.get(HEADER_CONNECTION_ID)).toBeNull();
+      expect(body).toMatchObject({
+        jsonrpc: "2.0",
+        id: 1,
+        error: {
+          code: -32603,
+          message: "Initialize failed",
+          data: "agent factory failed",
+        },
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("returns JSON-RPC initialize errors as the initialize response", async () => {
+    class FailingInitializeAgent extends TestAgent {
+      initialize() {
+        return Promise.reject(new Error("initialize failed"));
+      }
+    }
+
+    const server = await startTestServer(
+      (conn: AgentSideConnection) => new FailingInitializeAgent(conn),
+    );
+
+    try {
+      const response = await postJson(server.url, initializeRequest);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get(HEADER_CONNECTION_ID)).toMatch(
+        /^[0-9a-f-]{36}$/,
+      );
+      expect(body).toMatchObject({
+        jsonrpc: "2.0",
+        id: 1,
+        error: {
+          code: -32603,
+          message: "Internal error",
+        },
+      });
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+function postJson(
+  url: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": JSON_MIME_TYPE,
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -363,7 +363,7 @@ describe("AcpServer", () => {
     }
   });
 
-  it("rejects session-scoped GETs for unknown sessions", async () => {
+  it("opens session-scoped GETs before session/load creates session state", async () => {
     const server = await startTestServer();
 
     try {
@@ -374,7 +374,8 @@ describe("AcpServer", () => {
         globalThis.crypto.randomUUID(),
       );
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(200);
+      await response.body?.cancel();
     } finally {
       await server.close();
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,19 @@
 import { ConnectionRegistry } from "./connection.js";
 import {
+  EVENT_STREAM_MIME_TYPE,
   HEADER_CONNECTION_ID,
+  HEADER_SESSION_ID,
   JSON_MIME_TYPE,
   isInitializeRequest,
+  messageIdKey,
 } from "./protocol.js";
+import { serializeSseEvent, serializeSseKeepAlive } from "./sse.js";
 
+import type {
+  ConnectionState,
+  OutboundSubscription,
+  ResponseRoute,
+} from "./connection.js";
 import type { Agent, AgentSideConnection } from "./acp.js";
 import type { AnyMessage } from "./jsonrpc.js";
 
@@ -21,10 +30,26 @@ export class AcpServer {
   }
 
   async handleRequest(req: Request): Promise<Response> {
-    if (req.method !== "POST") {
-      return textResponse("Method Not Allowed", 405);
+    if (req.method === "POST") {
+      return await this.handlePost(req);
     }
 
+    if (req.method === "GET") {
+      return this.handleGet(req);
+    }
+
+    if (req.method === "DELETE") {
+      return this.handleDelete(req);
+    }
+
+    return textResponse("Method Not Allowed", 405);
+  }
+
+  async close(): Promise<void> {
+    this.registry.closeAll();
+  }
+
+  private async handlePost(req: Request): Promise<Response> {
     const contentType = req.headers.get("Content-Type");
 
     if (!contentType?.startsWith(JSON_MIME_TYPE)) {
@@ -55,18 +80,58 @@ export class AcpServer {
       return textResponse("Missing Acp-Connection-Id", 400);
     }
 
-    if (!this.registry.get(connectionId)) {
+    const connection = this.registry.get(connectionId);
+
+    if (!connection) {
       return textResponse("Unknown Acp-Connection-Id", 404);
     }
 
-    return textResponse(
-      "Connected POST handling is not implemented in Phase 1",
-      400,
-    );
+    await this.forwardConnectedMessage(connection, body.value);
+    return emptyResponse(202);
   }
 
-  async close(): Promise<void> {
-    this.registry.closeAll();
+  private handleGet(req: Request): Response {
+    if (req.headers.get("Upgrade")?.toLowerCase() === "websocket") {
+      return textResponse("WebSocket upgrade is not implemented", 426);
+    }
+
+    const accept = req.headers.get("Accept")?.toLowerCase();
+
+    if (!accept?.includes(EVENT_STREAM_MIME_TYPE)) {
+      return textResponse("Not Acceptable", 406);
+    }
+
+    const connectionId = req.headers.get(HEADER_CONNECTION_ID);
+
+    if (!connectionId) {
+      return textResponse("Missing Acp-Connection-Id", 400);
+    }
+
+    const connection = this.registry.get(connectionId);
+
+    if (!connection) {
+      return textResponse("Unknown Acp-Connection-Id", 404);
+    }
+
+    if (req.headers.get(HEADER_SESSION_ID)) {
+      return textResponse("Unknown Acp-Session-Id", 404);
+    }
+
+    return sseResponse(connection.connectionStream.subscribe());
+  }
+
+  private handleDelete(req: Request): Response {
+    const connectionId = req.headers.get(HEADER_CONNECTION_ID);
+
+    if (!connectionId) {
+      return textResponse("Missing Acp-Connection-Id", 400);
+    }
+
+    if (!this.registry.remove(connectionId)) {
+      return textResponse("Unknown Acp-Connection-Id", 404);
+    }
+
+    return emptyResponse(202);
   }
 
   private async handleInitialize(message: AnyMessage): Promise<Response> {
@@ -80,15 +145,10 @@ export class AcpServer {
 
     try {
       connection = this.registry.createConnection(this.createAgent);
-      const writer = connection.inboundTx.getWriter();
-
-      try {
-        await writer.write(message);
-      } finally {
-        writer.releaseLock();
-      }
+      await writeInbound(connection, message);
 
       const initialResponse = await connection.recvInitial(message.id);
+      connection.startRouter();
 
       return jsonResponse(initialResponse, 200, {
         [HEADER_CONNECTION_ID]: connection.connectionId,
@@ -111,6 +171,21 @@ export class AcpServer {
         500,
       );
     }
+  }
+
+  private async forwardConnectedMessage(
+    connection: ConnectionState,
+    message: AnyMessage,
+  ): Promise<void> {
+    if (isRequestMessage(message)) {
+      const key = messageIdKey(message.id);
+
+      if (key) {
+        connection.pendingRoutes.set(key, determineRoute());
+      }
+    }
+
+    await writeInbound(connection, message);
   }
 }
 
@@ -136,6 +211,23 @@ async function readJson(req: Request): Promise<JsonResult> {
   }
 }
 
+async function writeInbound(
+  connection: ConnectionState,
+  message: AnyMessage,
+): Promise<void> {
+  const writer = connection.inboundTx.getWriter();
+
+  try {
+    await writer.write(message);
+  } finally {
+    writer.releaseLock();
+  }
+}
+
+function determineRoute(): ResponseRoute {
+  return "connection";
+}
+
 function isJsonRpcMessage(value: unknown): value is AnyMessage {
   return (
     isRecord(value) &&
@@ -144,8 +236,99 @@ function isJsonRpcMessage(value: unknown): value is AnyMessage {
   );
 }
 
+function isRequestMessage(
+  message: AnyMessage,
+): message is AnyMessage & { readonly id: string | number | null } {
+  return "method" in message && "id" in message;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function sseResponse(subscription: OutboundSubscription): Response {
+  return new Response(createSseBody(subscription), {
+    status: 200,
+    headers: {
+      "Content-Type": EVENT_STREAM_MIME_TYPE,
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+function createSseBody(
+  subscription: OutboundSubscription,
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let keepAliveTimer: ReturnType<typeof setInterval> | undefined;
+  let reader: ReadableStreamDefaultReader<AnyMessage> | undefined;
+
+  const clearKeepAlive = (): void => {
+    if (keepAliveTimer) {
+      clearInterval(keepAliveTimer);
+      keepAliveTimer = undefined;
+    }
+  };
+
+  const enqueueText = (
+    controller: ReadableStreamDefaultController<Uint8Array>,
+    text: string,
+  ): boolean => {
+    try {
+      controller.enqueue(encoder.encode(text));
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      for (const message of subscription.replay) {
+        if (!enqueueText(controller, serializeSseEvent(message))) {
+          return;
+        }
+      }
+
+      reader = subscription.stream.getReader();
+
+      keepAliveTimer = setInterval(() => {
+        if (!enqueueText(controller, serializeSseKeepAlive())) {
+          clearKeepAlive();
+        }
+      }, 15_000);
+
+      try {
+        while (true) {
+          const result = await reader.read();
+
+          if (result.done) {
+            return;
+          }
+
+          if (!enqueueText(controller, serializeSseEvent(result.value))) {
+            return;
+          }
+        }
+      } catch (error) {
+        controller.error(error);
+      } finally {
+        clearKeepAlive();
+        reader.releaseLock();
+
+        try {
+          controller.close();
+        } catch {
+          // Stream may already be cancelled by the consumer.
+        }
+      }
+    },
+    cancel() {
+      clearKeepAlive();
+      void reader?.cancel();
+    },
+  });
 }
 
 function jsonResponse(
@@ -169,4 +352,8 @@ function textResponse(body: string, status: number): Response {
       "Content-Type": "text/plain",
     },
   });
+}
+
+function emptyResponse(status: number): Response {
+  return new Response(null, { status });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import {
   isRequestMessage,
   isResponseMessage,
 } from "./jsonrpc.js";
+import { AGENT_METHODS } from "./schema/index.js";
 import { serializeSseEvent, serializeSseKeepAlive } from "./sse.js";
 import { handleWebSocketConnection } from "./ws-server.js";
 import type { WebSocketServerSocket } from "./ws-server.js";
@@ -179,12 +180,7 @@ export class AcpServer {
 
     const sessionId = req.headers.get(HEADER_SESSION_ID);
     if (sessionId) {
-      const sessionStream = connection.sessionStreams.get(sessionId);
-      if (!sessionStream) {
-        return textResponse("Unknown Acp-Session-Id", 404);
-      }
-
-      return sseResponse(sessionStream.subscribe());
+      return sseResponse(connection.ensureSession(sessionId).subscribe());
     }
 
     return sseResponse(connection.connectionStream.subscribe());
@@ -336,7 +332,10 @@ async function forwardClientRequest(
   const key = messageIdKey(message.id);
 
   if (key) {
-    connection.pendingRoutes.set(key, route.value);
+    connection.pendingRoutes.set(
+      key,
+      pendingResponseRoute(message, route.value),
+    );
   }
 
   await writeInbound(connection, message);
@@ -357,6 +356,13 @@ async function forwardClientNotification(
 ): Promise<ForwardResult> {
   await writeInbound(connection, message);
   return { ok: true };
+}
+
+function pendingResponseRoute(
+  message: ClientRequestMessage,
+  route: ResponseRoute,
+): ResponseRoute {
+  return message.method === AGENT_METHODS.session_load ? "connection" : route;
 }
 
 function determineRoute(

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import type {
   ResponseRoute,
 } from "./connection.js";
 import type { Agent, AgentSideConnection } from "./acp.js";
-import type { AnyMessage } from "./jsonrpc.js";
+import type { AnyMessage, AnyResponse } from "./jsonrpc.js";
 
 export interface AcpServerOptions {
   createAgent: (conn: AgentSideConnection) => Agent;
@@ -196,25 +196,14 @@ export class AcpServer {
     headers: Headers,
   ): Promise<ForwardResult> {
     if (isRequestMessage(message)) {
-      const route = determineRoute(message, headers);
-
-      if (!route.ok) {
-        return route;
-      }
-
-      if (route.value !== "connection") {
-        connection.ensureSession(route.value.session);
-      }
-
-      const key = messageIdKey(message.id);
-
-      if (key) {
-        connection.pendingRoutes.set(key, route.value);
-      }
+      return await forwardClientRequest(connection, message, headers);
     }
 
-    await writeInbound(connection, message);
-    return { ok: true };
+    if (isResponseMessage(message)) {
+      return await forwardClientResponse(connection, message);
+    }
+
+    return await forwardClientNotification(connection, message);
   }
 }
 
@@ -248,6 +237,12 @@ type RouteResult =
       message: string;
     };
 
+type ClientRequestMessage = AnyMessage & {
+  readonly id: string | number | null;
+  readonly method: string;
+  readonly params?: unknown;
+};
+
 async function readJson(req: Request): Promise<JsonResult> {
   try {
     return {
@@ -274,11 +269,49 @@ async function writeInbound(
   }
 }
 
+async function forwardClientRequest(
+  connection: ConnectionState,
+  message: ClientRequestMessage,
+  headers: Headers,
+): Promise<ForwardResult> {
+  const route = determineRoute(message, headers);
+
+  if (!route.ok) {
+    return route;
+  }
+
+  if (route.value !== "connection") {
+    connection.ensureSession(route.value.session);
+  }
+
+  const key = messageIdKey(message.id);
+
+  if (key) {
+    connection.pendingRoutes.set(key, route.value);
+  }
+
+  await writeInbound(connection, message);
+  return { ok: true };
+}
+
+async function forwardClientResponse(
+  connection: ConnectionState,
+  message: AnyResponse,
+): Promise<ForwardResult> {
+  await writeInbound(connection, message);
+  return { ok: true };
+}
+
+async function forwardClientNotification(
+  connection: ConnectionState,
+  message: AnyMessage,
+): Promise<ForwardResult> {
+  await writeInbound(connection, message);
+  return { ok: true };
+}
+
 function determineRoute(
-  message: AnyMessage & {
-    readonly method: string;
-    readonly params?: unknown;
-  },
+  message: ClientRequestMessage,
   headers: Headers,
 ): RouteResult {
   const headerSessionId = headers.get(HEADER_SESSION_ID);
@@ -321,12 +354,14 @@ function isJsonRpcMessage(value: unknown): value is AnyMessage {
   );
 }
 
-function isRequestMessage(message: AnyMessage): message is AnyMessage & {
-  readonly id: string | number | null;
-  readonly method: string;
-  readonly params?: unknown;
-} {
+function isRequestMessage(
+  message: AnyMessage,
+): message is ClientRequestMessage {
   return "method" in message && "id" in message;
+}
+
+function isResponseMessage(message: AnyMessage): message is AnyResponse {
+  return "id" in message && !("method" in message);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,11 +9,7 @@ import {
   methodRequiresSessionHeader,
   sessionIdFromParams,
 } from "./protocol.js";
-import {
-  isJsonRpcMessage,
-  isRequestMessage,
-  isResponseMessage,
-} from "./jsonrpc.js";
+import { isJsonRpcMessage, isResponseMessage } from "./jsonrpc.js";
 import { AGENT_METHODS } from "./schema/index.js";
 import { serializeSseEvent, serializeSseKeepAlive } from "./sse.js";
 import { handleWebSocketConnection } from "./ws-server.js";
@@ -25,7 +21,12 @@ import type {
   ResponseRoute,
 } from "./connection.js";
 import type { Agent, AgentSideConnection } from "./acp.js";
-import type { AnyMessage, AnyRequest, AnyResponse } from "./jsonrpc.js";
+import type {
+  AnyMessage,
+  AnyNotification,
+  AnyRequest,
+  AnyResponse,
+} from "./jsonrpc.js";
 
 /** Options for creating an ACP server transport. */
 export interface AcpServerOptions {
@@ -129,8 +130,12 @@ export class AcpServer {
 
     const connectionId = req.headers.get(HEADER_CONNECTION_ID);
 
-    if (isInitializeRequest(body.value) && !connectionId) {
-      return await this.handleInitialize(body.value);
+    if (isInitializeRequest(body.value)) {
+      if (!connectionId) {
+        return await this.handleInitialize(body.value);
+      }
+
+      return textResponse("Initialize not allowed on existing connection", 400);
     }
 
     if (!connectionId) {
@@ -180,7 +185,12 @@ export class AcpServer {
 
     const sessionId = req.headers.get(HEADER_SESSION_ID);
     if (sessionId) {
-      return sseResponse(connection.ensureSession(sessionId).subscribe());
+      const sessionStream = connection.sessionStreams.get(sessionId);
+      if (!sessionStream) {
+        return textResponse("Unknown Acp-Session-Id", 404);
+      }
+
+      return sseResponse(sessionStream.subscribe());
     }
 
     return sseResponse(connection.connectionStream.subscribe());
@@ -244,15 +254,11 @@ export class AcpServer {
     message: AnyMessage,
     headers: Headers,
   ): Promise<ForwardResult> {
-    if (isRequestMessage(message)) {
-      return await forwardClientRequest(connection, message, headers);
-    }
-
     if (isResponseMessage(message)) {
       return await forwardClientResponse(connection, message);
     }
 
-    return await forwardClientNotification(connection, message);
+    return await forwardClientMethodMessage(connection, message, headers);
   }
 }
 
@@ -286,7 +292,7 @@ type RouteResult =
       message: string;
     };
 
-type ClientRequestMessage = AnyRequest;
+type ClientMethodMessage = AnyRequest | AnyNotification;
 
 async function readJson(req: Request): Promise<JsonResult> {
   try {
@@ -314,9 +320,9 @@ async function writeInbound(
   }
 }
 
-async function forwardClientRequest(
+async function forwardClientMethodMessage(
   connection: ConnectionState,
-  message: ClientRequestMessage,
+  message: ClientMethodMessage,
   headers: Headers,
 ): Promise<ForwardResult> {
   const route = determineRoute(message, headers);
@@ -329,7 +335,7 @@ async function forwardClientRequest(
     connection.ensureSession(route.value.session);
   }
 
-  const key = messageIdKey(message.id);
+  const key = "id" in message ? messageIdKey(message.id) : undefined;
 
   if (key) {
     connection.pendingRoutes.set(
@@ -350,23 +356,15 @@ async function forwardClientResponse(
   return { ok: true };
 }
 
-async function forwardClientNotification(
-  connection: ConnectionState,
-  message: AnyMessage,
-): Promise<ForwardResult> {
-  await writeInbound(connection, message);
-  return { ok: true };
-}
-
 function pendingResponseRoute(
-  message: ClientRequestMessage,
+  message: ClientMethodMessage,
   route: ResponseRoute,
 ): ResponseRoute {
   return message.method === AGENT_METHODS.session_load ? "connection" : route;
 }
 
 function determineRoute(
-  message: ClientRequestMessage,
+  message: ClientMethodMessage,
   headers: Headers,
 ): RouteResult {
   const headerSessionId = headers.get(HEADER_SESSION_ID);

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,10 +28,20 @@ import type {
   AnyResponse,
 } from "./jsonrpc.js";
 
+export type AgentFactory = (conn: AgentSideConnection) => Agent;
+
 /** Options for creating an ACP server transport. */
 export interface AcpServerOptions {
   /** Creates the agent implementation for each accepted ACP connection. */
-  createAgent: (conn: AgentSideConnection) => Agent;
+  createAgent: AgentFactory;
+}
+
+export interface HandleRequestOptions {
+  readonly createAgent?: AgentFactory;
+}
+
+export interface PrepareWebSocketUpgradeOptions {
+  readonly createAgent?: AgentFactory;
 }
 
 export interface PreparedWebSocketUpgrade {
@@ -48,7 +58,7 @@ export interface PreparedWebSocketUpgrade {
  * the `101 Switching Protocols` response.
  */
 export class AcpServer {
-  private readonly createAgent: (conn: AgentSideConnection) => Agent;
+  private readonly createAgent: AgentFactory;
   private readonly registry = new ConnectionRegistry();
 
   constructor(options: AcpServerOptions) {
@@ -56,9 +66,12 @@ export class AcpServer {
   }
 
   /** Handles one Streamable HTTP ACP request. */
-  async handleRequest(req: Request): Promise<Response> {
+  async handleRequest(
+    req: Request,
+    options: HandleRequestOptions = {},
+  ): Promise<Response> {
     if (req.method === "POST") {
-      return await this.handlePost(req);
+      return await this.handlePost(req, options);
     }
 
     if (req.method === "GET") {
@@ -73,8 +86,11 @@ export class AcpServer {
   }
 
   /** Creates a WebSocket connection before accepting the HTTP upgrade. */
-  prepareWebSocketUpgrade(): PreparedWebSocketUpgrade {
-    const connection = this.registry.createConnection(this.createAgent);
+  prepareWebSocketUpgrade(
+    options: PrepareWebSocketUpgradeOptions = {},
+  ): PreparedWebSocketUpgrade {
+    const createAgent = options.createAgent ?? this.createAgent;
+    const connection = this.registry.createConnection(createAgent);
     let isSettled = false;
 
     return {
@@ -87,7 +103,7 @@ export class AcpServer {
         isSettled = true;
         handleWebSocketConnection(socket, {
           registry: this.registry,
-          createAgent: this.createAgent,
+          createAgent,
           connection,
         });
       },
@@ -107,7 +123,10 @@ export class AcpServer {
     this.registry.closeAll();
   }
 
-  private async handlePost(req: Request): Promise<Response> {
+  private async handlePost(
+    req: Request,
+    options: HandleRequestOptions,
+  ): Promise<Response> {
     const contentType = req.headers.get("Content-Type");
 
     if (!isJsonContentType(contentType)) {
@@ -132,7 +151,7 @@ export class AcpServer {
 
     if (isInitializeRequest(body.value)) {
       if (!connectionId) {
-        return await this.handleInitialize(body.value);
+        return await this.handleInitialize(body.value, options);
       }
 
       return textResponse("Initialize not allowed on existing connection", 400);
@@ -210,7 +229,10 @@ export class AcpServer {
     return emptyResponse(202);
   }
 
-  private async handleInitialize(message: AnyMessage): Promise<Response> {
+  private async handleInitialize(
+    message: AnyMessage,
+    options: HandleRequestOptions,
+  ): Promise<Response> {
     if (!("id" in message) || message.id === null) {
       return textResponse("Initialize request must include an ID", 400);
     }
@@ -220,7 +242,9 @@ export class AcpServer {
       | undefined;
 
     try {
-      connection = this.registry.createConnection(this.createAgent);
+      connection = this.registry.createConnection(
+        options.createAgent ?? this.createAgent,
+      );
       await writeInbound(connection, message);
 
       const initialResponse = await connection.recvInitial(message.id);

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,11 @@ import {
   methodRequiresSessionHeader,
   sessionIdFromParams,
 } from "./protocol.js";
+import {
+  isJsonRpcMessage,
+  isRequestMessage,
+  isResponseMessage,
+} from "./jsonrpc.js";
 
 import { serializeSseEvent, serializeSseKeepAlive } from "./sse.js";
 
@@ -18,7 +23,7 @@ import type {
   ResponseRoute,
 } from "./connection.js";
 import type { Agent, AgentSideConnection } from "./acp.js";
-import type { AnyMessage, AnyResponse } from "./jsonrpc.js";
+import type { AnyMessage, AnyRequest, AnyResponse } from "./jsonrpc.js";
 
 export interface AcpServerOptions {
   createAgent: (conn: AgentSideConnection) => Agent;
@@ -237,11 +242,7 @@ type RouteResult =
       message: string;
     };
 
-type ClientRequestMessage = AnyMessage & {
-  readonly id: string | number | null;
-  readonly method: string;
-  readonly params?: unknown;
-};
+type ClientRequestMessage = AnyRequest;
 
 async function readJson(req: Request): Promise<JsonResult> {
   try {
@@ -344,28 +345,6 @@ function determineRoute(
     ok: true,
     value: "connection",
   };
-}
-
-function isJsonRpcMessage(value: unknown): value is AnyMessage {
-  return (
-    isRecord(value) &&
-    value.jsonrpc === "2.0" &&
-    ("method" in value || "id" in value)
-  );
-}
-
-function isRequestMessage(
-  message: AnyMessage,
-): message is ClientRequestMessage {
-  return "method" in message && "id" in message;
-}
-
-function isResponseMessage(message: AnyMessage): message is AnyResponse {
-  return "id" in message && !("method" in message);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }
 
 function sseResponse(subscription: OutboundSubscription): Response {

--- a/src/server.ts
+++ b/src/server.ts
@@ -90,7 +90,7 @@ export class AcpServer {
     options: PrepareWebSocketUpgradeOptions = {},
   ): PreparedWebSocketUpgrade {
     const createAgent = options.createAgent ?? this.createAgent;
-    const connection = this.registry.createConnection(createAgent);
+    const connection = this.registry.createPendingConnection(createAgent);
     let isSettled = false;
 
     return {
@@ -113,7 +113,7 @@ export class AcpServer {
         }
 
         isSettled = true;
-        this.registry.remove(connection.connectionId);
+        this.registry.discard(connection.connectionId);
       },
     };
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -151,7 +151,7 @@ export class AcpServer {
 
     if (isInitializeRequest(body.value)) {
       if (!connectionId) {
-        return await this.handleInitialize(body.value, options);
+        return await this.handleInitialize(body.value, req.signal, options);
       }
 
       return textResponse("Initialize not allowed on existing connection", 400);
@@ -226,10 +226,15 @@ export class AcpServer {
 
   private async handleInitialize(
     message: AnyMessage,
+    signal: AbortSignal,
     options: HandleRequestOptions,
   ): Promise<Response> {
     if (!("id" in message) || message.id === null) {
       return textResponse("Initialize request must include an ID", 400);
+    }
+
+    if (signal.aborted) {
+      return textResponse("Request aborted", 499);
     }
 
     let connection:
@@ -240,9 +245,18 @@ export class AcpServer {
       connection = this.registry.createConnection(
         options.createAgent ?? this.createAgent,
       );
-      await writeInbound(connection, message);
+      const initialResponsePromise = writeAndReceiveInitial(
+        connection,
+        message,
+      );
+      initialResponsePromise.catch(() => undefined);
 
-      const initialResponse = await connection.recvInitial(message.id);
+      const initialResponse = await raceAbort(initialResponsePromise, signal);
+
+      if (signal.aborted) {
+        throw new RequestAbortedError();
+      }
+
       connection.startRouter();
 
       return jsonResponse(initialResponse, 200, {
@@ -251,6 +265,10 @@ export class AcpServer {
     } catch (error) {
       if (connection) {
         this.registry.remove(connection.connectionId);
+      }
+
+      if (error instanceof RequestAbortedError) {
+        return textResponse("Request aborted", 499);
       }
 
       return jsonResponse(
@@ -313,6 +331,13 @@ type RouteResult =
 
 type ClientMethodMessage = AnyRequest | AnyNotification;
 
+class RequestAbortedError extends Error {
+  constructor() {
+    super("Request aborted");
+    this.name = "RequestAbortedError";
+  }
+}
+
 async function readJson(req: Request): Promise<JsonResult> {
   try {
     return {
@@ -331,6 +356,46 @@ async function writeInbound(
   message: AnyMessage,
 ): Promise<void> {
   await connection.writeInbound(message);
+}
+
+async function writeAndReceiveInitial(
+  connection: ConnectionState,
+  message: AnyMessage,
+): Promise<AnyResponse> {
+  await writeInbound(connection, message);
+
+  if (!("id" in message) || message.id === null) {
+    throw new Error("Initialize request must include an ID");
+  }
+
+  return await connection.recvInitial(message.id);
+}
+
+async function raceAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) {
+    throw new RequestAbortedError();
+  }
+
+  let removeAbortListener: () => void = () => {};
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    const onAbort = (): void => {
+      reject(new RequestAbortedError());
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    removeAbortListener = () => {
+      signal.removeEventListener("abort", onAbort);
+    };
+  });
+
+  try {
+    return await Promise.race([promise, abortPromise]);
+  } finally {
+    removeAbortListener();
+  }
 }
 
 async function forwardClientMethodMessage(

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,8 +14,9 @@ import {
   isRequestMessage,
   isResponseMessage,
 } from "./jsonrpc.js";
-
 import { serializeSseEvent, serializeSseKeepAlive } from "./sse.js";
+import { handleWebSocketConnection } from "./ws-server.js";
+import type { WebSocketServerSocket } from "./ws-server.js";
 
 import type {
   ConnectionState,
@@ -51,6 +52,13 @@ export class AcpServer {
     }
 
     return textResponse("Method Not Allowed", 405);
+  }
+
+  handleWebSocket(socket: WebSocketServerSocket): void {
+    handleWebSocketConnection(socket, {
+      registry: this.registry,
+      createAgent: this.createAgent,
+    });
   }
 
   async close(): Promise<void> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -120,7 +120,7 @@ export class AcpServer {
 
   /** Closes all active ACP connections owned by this server. */
   async close(): Promise<void> {
-    this.registry.closeAll();
+    await this.registry.closeAll();
   }
 
   private async handlePost(

--- a/src/server.ts
+++ b/src/server.ts
@@ -204,12 +204,7 @@ export class AcpServer {
 
     const sessionId = req.headers.get(HEADER_SESSION_ID);
     if (sessionId) {
-      const sessionStream = connection.sessionStreams.get(sessionId);
-      if (!sessionStream) {
-        return textResponse("Unknown Acp-Session-Id", 404);
-      }
-
-      return sseResponse(sessionStream.subscribe());
+      return sseResponse(connection.ensureSession(sessionId).subscribe());
     }
 
     return sseResponse(connection.connectionStream.subscribe());

--- a/src/server.ts
+++ b/src/server.ts
@@ -467,8 +467,11 @@ function createSseBody(
   subscription: OutboundSubscription,
 ): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
+  const replay = [...subscription.replay];
   let keepAliveTimer: ReturnType<typeof setInterval> | undefined;
   let reader: ReadableStreamDefaultReader<AnyMessage> | undefined;
+  let pendingMessage: AnyMessage | undefined;
+  let isClosed = false;
 
   const clearKeepAlive = (): void => {
     if (keepAliveTimer) {
@@ -489,50 +492,110 @@ function createSseBody(
     }
   };
 
+  const hasDemand = (
+    controller: ReadableStreamDefaultController<Uint8Array>,
+  ): boolean => controller.desiredSize !== null && controller.desiredSize > 0;
+
+  const closeBody = (
+    controller: ReadableStreamDefaultController<Uint8Array>,
+  ): void => {
+    if (isClosed) {
+      return;
+    }
+
+    isClosed = true;
+    clearKeepAlive();
+
+    try {
+      controller.close();
+    } catch {
+      // Stream may already be cancelled by the consumer.
+    }
+  };
+
   return new ReadableStream<Uint8Array>({
-    async start(controller) {
-      for (const message of subscription.replay) {
-        if (!enqueueText(controller, serializeSseEvent(message))) {
+    start(controller) {
+      keepAliveTimer = setInterval(() => {
+        if (isClosed || pendingMessage || !hasDemand(controller)) {
           return;
         }
-      }
 
-      reader = subscription.stream.getReader();
-
-      keepAliveTimer = setInterval(() => {
         if (!enqueueText(controller, serializeSseKeepAlive())) {
-          clearKeepAlive();
+          closeBody(controller);
         }
       }, 15_000);
+    },
+    async pull(controller) {
+      if (isClosed || reader || !hasDemand(controller)) {
+        return;
+      }
+
+      const replayMessage = replay.shift();
+      if (replayMessage) {
+        if (!enqueueText(controller, serializeSseEvent(replayMessage))) {
+          closeBody(controller);
+        }
+
+        return;
+      }
+
+      if (pendingMessage) {
+        const message = pendingMessage;
+        pendingMessage = undefined;
+
+        if (!enqueueText(controller, serializeSseEvent(message))) {
+          closeBody(controller);
+        }
+
+        return;
+      }
+
+      const currentReader = subscription.stream.getReader();
+      reader = currentReader;
 
       try {
-        while (true) {
-          const result = await reader.read();
+        const result = await currentReader.read();
 
-          if (result.done) {
-            return;
-          }
+        if (isClosed) {
+          return;
+        }
 
-          if (!enqueueText(controller, serializeSseEvent(result.value))) {
-            return;
-          }
+        if (result.done) {
+          closeBody(controller);
+          return;
+        }
+
+        if (!hasDemand(controller)) {
+          pendingMessage = result.value;
+          return;
+        }
+
+        if (!enqueueText(controller, serializeSseEvent(result.value))) {
+          closeBody(controller);
         }
       } catch (error) {
-        controller.error(error);
-      } finally {
-        clearKeepAlive();
-        reader.releaseLock();
-
-        try {
-          controller.close();
-        } catch {
-          // Stream may already be cancelled by the consumer.
+        if (!isClosed) {
+          isClosed = true;
+          clearKeepAlive();
+          controller.error(error);
         }
+      } finally {
+        if (reader === currentReader) {
+          reader = undefined;
+        }
+
+        currentReader.releaseLock();
       }
     },
     cancel() {
+      isClosed = true;
       clearKeepAlive();
-      void reader?.cancel();
+
+      if (reader) {
+        void reader.cancel();
+      } else {
+        void subscription.stream.cancel();
+      }
     },
   });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,12 +32,18 @@ export interface AcpServerOptions {
   createAgent: (conn: AgentSideConnection) => Agent;
 }
 
+export interface PreparedWebSocketUpgrade {
+  readonly connectionId: string;
+  accept(socket: WebSocketServerSocket): void;
+  reject(): void;
+}
+
 /**
  * ACP server transport for Streamable HTTP and WebSocket connections.
  *
- * Route HTTP requests to {@link handleRequest}. For WebSocket upgrades, let your
- * framework perform the upgrade and pass the accepted socket to
- * {@link handleWebSocket}.
+ * Route HTTP requests to {@link handleRequest}. For WebSocket upgrades, use
+ * {@link prepareWebSocketUpgrade} so adapters can attach `Acp-Connection-Id` to
+ * the `101 Switching Protocols` response.
  */
 export class AcpServer {
   private readonly createAgent: (conn: AgentSideConnection) => Agent;
@@ -64,12 +70,34 @@ export class AcpServer {
     return textResponse("Method Not Allowed", 405);
   }
 
-  /** Handles one accepted ACP WebSocket connection. */
-  handleWebSocket(socket: WebSocketServerSocket): void {
-    handleWebSocketConnection(socket, {
-      registry: this.registry,
-      createAgent: this.createAgent,
-    });
+  /** Creates a WebSocket connection before accepting the HTTP upgrade. */
+  prepareWebSocketUpgrade(): PreparedWebSocketUpgrade {
+    const connection = this.registry.createConnection(this.createAgent);
+    let isSettled = false;
+
+    return {
+      connectionId: connection.connectionId,
+      accept: (socket) => {
+        if (isSettled) {
+          throw new Error("ACP WebSocket upgrade has already been settled");
+        }
+
+        isSettled = true;
+        handleWebSocketConnection(socket, {
+          registry: this.registry,
+          createAgent: this.createAgent,
+          connection,
+        });
+      },
+      reject: () => {
+        if (isSettled) {
+          return;
+        }
+
+        isSettled = true;
+        this.registry.remove(connection.connectionId);
+      },
+    };
   }
 
   /** Closes all active ACP connections owned by this server. */

--- a/src/server.ts
+++ b/src/server.ts
@@ -330,13 +330,7 @@ async function writeInbound(
   connection: ConnectionState,
   message: AnyMessage,
 ): Promise<void> {
-  const writer = connection.inboundTx.getWriter();
-
-  try {
-    await writer.write(message);
-  } finally {
-    writer.releaseLock();
-  }
+  await connection.writeInbound(message);
 }
 
 async function forwardClientMethodMessage(

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,10 @@ import { isJsonRpcMessage, isResponseMessage } from "./jsonrpc.js";
 import { AGENT_METHODS } from "./schema/index.js";
 import { serializeSseEvent, serializeSseKeepAlive } from "./sse.js";
 import { handleWebSocketConnection } from "./ws-server.js";
-import type { WebSocketServerSocket } from "./ws-server.js";
+import type {
+  WebSocketServerSessionHandle,
+  WebSocketServerSocket,
+} from "./ws-server.js";
 
 import type {
   ConnectionState,
@@ -60,6 +63,7 @@ export interface PreparedWebSocketUpgrade {
 export class AcpServer {
   private readonly createAgent: AgentFactory;
   private readonly registry = new ConnectionRegistry();
+  private readonly webSocketSessions = new Set<WebSocketServerSessionHandle>();
 
   constructor(options: AcpServerOptions) {
     this.createAgent = options.createAgent;
@@ -101,10 +105,14 @@ export class AcpServer {
         }
 
         isSettled = true;
-        handleWebSocketConnection(socket, {
+        const session = handleWebSocketConnection(socket, {
           registry: this.registry,
           createAgent,
           connection,
+        });
+        this.webSocketSessions.add(session);
+        void session.closed.finally(() => {
+          this.webSocketSessions.delete(session);
         });
       },
       reject: () => {
@@ -120,7 +128,12 @@ export class AcpServer {
 
   /** Closes all active ACP connections owned by this server. */
   async close(): Promise<void> {
-    await this.registry.closeAll();
+    const closeConnections = this.registry.closeAll();
+    const closeWebSockets = Promise.all(
+      Array.from(this.webSocketSessions, (session) => session.close()),
+    );
+
+    await Promise.all([closeConnections, closeWebSockets]);
   }
 
   private async handlePost(

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,172 @@
+import { ConnectionRegistry } from "./connection.js";
+import {
+  HEADER_CONNECTION_ID,
+  JSON_MIME_TYPE,
+  isInitializeRequest,
+} from "./protocol.js";
+
+import type { Agent, AgentSideConnection } from "./acp.js";
+import type { AnyMessage } from "./jsonrpc.js";
+
+export interface AcpServerOptions {
+  createAgent: (conn: AgentSideConnection) => Agent;
+}
+
+export class AcpServer {
+  private readonly createAgent: (conn: AgentSideConnection) => Agent;
+  private readonly registry = new ConnectionRegistry();
+
+  constructor(options: AcpServerOptions) {
+    this.createAgent = options.createAgent;
+  }
+
+  async handleRequest(req: Request): Promise<Response> {
+    if (req.method !== "POST") {
+      return textResponse("Method Not Allowed", 405);
+    }
+
+    const contentType = req.headers.get("Content-Type");
+
+    if (!contentType?.startsWith(JSON_MIME_TYPE)) {
+      return textResponse("Unsupported Media Type", 415);
+    }
+
+    const body = await readJson(req);
+
+    if (!body.ok) {
+      return textResponse("Invalid JSON", 400);
+    }
+
+    if (Array.isArray(body.value)) {
+      return textResponse("Batch JSON-RPC requests are not implemented", 501);
+    }
+
+    if (!isJsonRpcMessage(body.value)) {
+      return textResponse("Invalid JSON-RPC message", 400);
+    }
+
+    const connectionId = req.headers.get(HEADER_CONNECTION_ID);
+
+    if (isInitializeRequest(body.value) && !connectionId) {
+      return await this.handleInitialize(body.value);
+    }
+
+    if (!connectionId) {
+      return textResponse("Missing Acp-Connection-Id", 400);
+    }
+
+    if (!this.registry.get(connectionId)) {
+      return textResponse("Unknown Acp-Connection-Id", 404);
+    }
+
+    return textResponse(
+      "Connected POST handling is not implemented in Phase 1",
+      400,
+    );
+  }
+
+  async close(): Promise<void> {
+    this.registry.closeAll();
+  }
+
+  private async handleInitialize(message: AnyMessage): Promise<Response> {
+    if (!("id" in message) || message.id === null) {
+      return textResponse("Initialize request must include an ID", 400);
+    }
+
+    let connection:
+      | ReturnType<ConnectionRegistry["createConnection"]>
+      | undefined;
+
+    try {
+      connection = this.registry.createConnection(this.createAgent);
+      const writer = connection.inboundTx.getWriter();
+
+      try {
+        await writer.write(message);
+      } finally {
+        writer.releaseLock();
+      }
+
+      const initialResponse = await connection.recvInitial(message.id);
+
+      return jsonResponse(initialResponse, 200, {
+        [HEADER_CONNECTION_ID]: connection.connectionId,
+      });
+    } catch (error) {
+      if (connection) {
+        this.registry.remove(connection.connectionId);
+      }
+
+      return jsonResponse(
+        {
+          jsonrpc: "2.0",
+          id: message.id,
+          error: {
+            code: -32603,
+            message: "Initialize failed",
+            data: error instanceof Error ? error.message : undefined,
+          },
+        },
+        500,
+      );
+    }
+  }
+}
+
+type JsonResult =
+  | {
+      ok: true;
+      value: unknown;
+    }
+  | {
+      ok: false;
+    };
+
+async function readJson(req: Request): Promise<JsonResult> {
+  try {
+    return {
+      ok: true,
+      value: await req.json(),
+    };
+  } catch {
+    return {
+      ok: false,
+    };
+  }
+}
+
+function isJsonRpcMessage(value: unknown): value is AnyMessage {
+  return (
+    isRecord(value) &&
+    value.jsonrpc === "2.0" &&
+    ("method" in value || "id" in value)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function jsonResponse(
+  value: unknown,
+  status: number,
+  headers?: HeadersInit,
+): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: {
+      "Content-Type": JSON_MIME_TYPE,
+      ...headers,
+    },
+  });
+}
+
+function textResponse(body: string, status: number): Response {
+  return new Response(body, {
+    status,
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,10 @@ import {
   JSON_MIME_TYPE,
   isInitializeRequest,
   messageIdKey,
+  methodRequiresSessionHeader,
+  sessionIdFromParams,
 } from "./protocol.js";
+
 import { serializeSseEvent, serializeSseKeepAlive } from "./sse.js";
 
 import type {
@@ -86,7 +89,15 @@ export class AcpServer {
       return textResponse("Unknown Acp-Connection-Id", 404);
     }
 
-    await this.forwardConnectedMessage(connection, body.value);
+    const forwarded = await this.forwardConnectedMessage(
+      connection,
+      body.value,
+      req.headers,
+    );
+    if (!forwarded.ok) {
+      return textResponse(forwarded.message, forwarded.status);
+    }
+
     return emptyResponse(202);
   }
 
@@ -113,8 +124,14 @@ export class AcpServer {
       return textResponse("Unknown Acp-Connection-Id", 404);
     }
 
-    if (req.headers.get(HEADER_SESSION_ID)) {
-      return textResponse("Unknown Acp-Session-Id", 404);
+    const sessionId = req.headers.get(HEADER_SESSION_ID);
+    if (sessionId) {
+      const sessionStream = connection.sessionStreams.get(sessionId);
+      if (!sessionStream) {
+        return textResponse("Unknown Acp-Session-Id", 404);
+      }
+
+      return sseResponse(sessionStream.subscribe());
     }
 
     return sseResponse(connection.connectionStream.subscribe());
@@ -176,18 +193,40 @@ export class AcpServer {
   private async forwardConnectedMessage(
     connection: ConnectionState,
     message: AnyMessage,
-  ): Promise<void> {
+    headers: Headers,
+  ): Promise<ForwardResult> {
     if (isRequestMessage(message)) {
+      const route = determineRoute(message, headers);
+
+      if (!route.ok) {
+        return route;
+      }
+
+      if (route.value !== "connection") {
+        connection.ensureSession(route.value.session);
+      }
+
       const key = messageIdKey(message.id);
 
       if (key) {
-        connection.pendingRoutes.set(key, determineRoute());
+        connection.pendingRoutes.set(key, route.value);
       }
     }
 
     await writeInbound(connection, message);
+    return { ok: true };
   }
 }
+
+type ForwardResult =
+  | {
+      ok: true;
+    }
+  | {
+      ok: false;
+      status: number;
+      message: string;
+    };
 
 type JsonResult =
   | {
@@ -196,6 +235,17 @@ type JsonResult =
     }
   | {
       ok: false;
+    };
+
+type RouteResult =
+  | {
+      ok: true;
+      value: ResponseRoute;
+    }
+  | {
+      ok: false;
+      status: number;
+      message: string;
     };
 
 async function readJson(req: Request): Promise<JsonResult> {
@@ -224,8 +274,43 @@ async function writeInbound(
   }
 }
 
-function determineRoute(): ResponseRoute {
-  return "connection";
+function determineRoute(
+  message: AnyMessage & {
+    readonly method: string;
+    readonly params?: unknown;
+  },
+  headers: Headers,
+): RouteResult {
+  const headerSessionId = headers.get(HEADER_SESSION_ID);
+
+  if (headerSessionId) {
+    return {
+      ok: true,
+      value: { session: headerSessionId },
+    };
+  }
+
+  const paramsSessionId = sessionIdFromParams(message.params);
+
+  if (paramsSessionId) {
+    return {
+      ok: true,
+      value: { session: paramsSessionId },
+    };
+  }
+
+  if (methodRequiresSessionHeader(message.method)) {
+    return {
+      ok: false,
+      status: 400,
+      message: "Missing Acp-Session-Id",
+    };
+  }
+
+  return {
+    ok: true,
+    value: "connection",
+  };
 }
 
 function isJsonRpcMessage(value: unknown): value is AnyMessage {
@@ -236,9 +321,11 @@ function isJsonRpcMessage(value: unknown): value is AnyMessage {
   );
 }
 
-function isRequestMessage(
-  message: AnyMessage,
-): message is AnyMessage & { readonly id: string | number | null } {
+function isRequestMessage(message: AnyMessage): message is AnyMessage & {
+  readonly id: string | number | null;
+  readonly method: string;
+  readonly params?: unknown;
+} {
   return "method" in message && "id" in message;
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,10 +26,19 @@ import type {
 import type { Agent, AgentSideConnection } from "./acp.js";
 import type { AnyMessage, AnyRequest, AnyResponse } from "./jsonrpc.js";
 
+/** Options for creating an ACP server transport. */
 export interface AcpServerOptions {
+  /** Creates the agent implementation for each accepted ACP connection. */
   createAgent: (conn: AgentSideConnection) => Agent;
 }
 
+/**
+ * ACP server transport for Streamable HTTP and WebSocket connections.
+ *
+ * Route HTTP requests to {@link handleRequest}. For WebSocket upgrades, let your
+ * framework perform the upgrade and pass the accepted socket to
+ * {@link handleWebSocket}.
+ */
 export class AcpServer {
   private readonly createAgent: (conn: AgentSideConnection) => Agent;
   private readonly registry = new ConnectionRegistry();
@@ -38,6 +47,7 @@ export class AcpServer {
     this.createAgent = options.createAgent;
   }
 
+  /** Handles one Streamable HTTP ACP request. */
   async handleRequest(req: Request): Promise<Response> {
     if (req.method === "POST") {
       return await this.handlePost(req);
@@ -54,6 +64,7 @@ export class AcpServer {
     return textResponse("Method Not Allowed", 405);
   }
 
+  /** Handles one accepted ACP WebSocket connection. */
   handleWebSocket(socket: WebSocketServerSocket): void {
     handleWebSocketConnection(socket, {
       registry: this.registry,
@@ -61,6 +72,7 @@ export class AcpServer {
     });
   }
 
+  /** Closes all active ACP connections owned by this server. */
   async close(): Promise<void> {
     this.registry.closeAll();
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -108,7 +108,7 @@ export class AcpServer {
   private async handlePost(req: Request): Promise<Response> {
     const contentType = req.headers.get("Content-Type");
 
-    if (!contentType?.startsWith(JSON_MIME_TYPE)) {
+    if (!isJsonContentType(contentType)) {
       return textResponse("Unsupported Media Type", 415);
     }
 
@@ -364,6 +364,27 @@ function determineRoute(
   headers: Headers,
 ): RouteResult {
   const headerSessionId = headers.get(HEADER_SESSION_ID);
+  const paramsSessionId = sessionIdFromParams(message.params);
+
+  if (methodRequiresSessionHeader(message.method) && !headerSessionId) {
+    return {
+      ok: false,
+      status: 400,
+      message: "Missing Acp-Session-Id",
+    };
+  }
+
+  if (
+    headerSessionId !== null &&
+    paramsSessionId !== undefined &&
+    headerSessionId !== paramsSessionId
+  ) {
+    return {
+      ok: false,
+      status: 400,
+      message: "Mismatched Acp-Session-Id",
+    };
+  }
 
   if (headerSessionId) {
     return {
@@ -372,8 +393,6 @@ function determineRoute(
     };
   }
 
-  const paramsSessionId = sessionIdFromParams(message.params);
-
   if (paramsSessionId) {
     return {
       ok: true,
@@ -381,18 +400,14 @@ function determineRoute(
     };
   }
 
-  if (methodRequiresSessionHeader(message.method)) {
-    return {
-      ok: false,
-      status: 400,
-      message: "Missing Acp-Session-Id",
-    };
-  }
-
   return {
     ok: true,
     value: "connection",
   };
+}
+
+function isJsonContentType(contentType: string | null): boolean {
+  return contentType?.split(";", 1)[0]?.trim().toLowerCase() === JSON_MIME_TYPE;
 }
 
 function sseResponse(subscription: OutboundSubscription): Response {

--- a/src/server.ts
+++ b/src/server.ts
@@ -255,7 +255,7 @@ export class AcpServer {
     headers: Headers,
   ): Promise<ForwardResult> {
     if (isResponseMessage(message)) {
-      return await forwardClientResponse(connection, message);
+      return await forwardClientResponse(connection, message, headers);
     }
 
     return await forwardClientMethodMessage(connection, message, headers);
@@ -351,7 +351,32 @@ async function forwardClientMethodMessage(
 async function forwardClientResponse(
   connection: ConnectionState,
   message: AnyResponse,
+  headers: Headers,
 ): Promise<ForwardResult> {
+  const key = messageIdKey(message.id);
+  const route = key ? connection.clientResponseRoutes.get(key) : undefined;
+  const headerSessionId = headers.get(HEADER_SESSION_ID);
+
+  if (route && route !== "connection" && !headerSessionId) {
+    return {
+      ok: false,
+      status: 400,
+      message: "Missing Acp-Session-Id",
+    };
+  }
+
+  if (route && route !== "connection" && headerSessionId !== route.session) {
+    return {
+      ok: false,
+      status: 400,
+      message: "Mismatched Acp-Session-Id",
+    };
+  }
+
+  if (key) {
+    connection.clientResponseRoutes.delete(key);
+  }
+
   await writeInbound(connection, message);
   return { ok: true };
 }

--- a/src/sse.test.ts
+++ b/src/sse.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  parseSseStream,
+  serializeSseEvent,
+  serializeSseKeepAlive,
+} from "./sse.js";
+
+import type { AnyMessage } from "./jsonrpc.js";
+
+const encoder = new TextEncoder();
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+async function collectMessages(
+  body: ReadableStream<Uint8Array>,
+): Promise<AnyMessage[]> {
+  const messages: AnyMessage[] = [];
+  for await (const message of parseSseStream(body)) {
+    messages.push(message);
+  }
+  return messages;
+}
+
+describe("SSE transport helpers", () => {
+  it("serializes a message event", () => {
+    const message: AnyMessage = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: 1 },
+    };
+
+    expect(serializeSseEvent(message)).toBe(
+      `data: ${JSON.stringify(message)}\n\n`,
+    );
+  });
+
+  it("serializes a keepalive comment", () => {
+    expect(serializeSseKeepAlive()).toBe(":\n\n");
+  });
+
+  it("parses one event", async () => {
+    const message: AnyMessage = { jsonrpc: "2.0", id: 1, result: { ok: true } };
+
+    await expect(
+      collectMessages(streamFromChunks([serializeSseEvent(message)])),
+    ).resolves.toEqual([message]);
+  });
+
+  it("parses multiple events in one chunk", async () => {
+    const first: AnyMessage = { jsonrpc: "2.0", id: 1, result: { ok: true } };
+    const second: AnyMessage = {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: { sessionId: "s1" },
+    };
+
+    await expect(
+      collectMessages(
+        streamFromChunks([
+          serializeSseEvent(first) + serializeSseEvent(second),
+        ]),
+      ),
+    ).resolves.toEqual([first, second]);
+  });
+
+  it("parses events split across chunk boundaries", async () => {
+    const message: AnyMessage = {
+      jsonrpc: "2.0",
+      id: "abc",
+      result: { ok: true },
+    };
+    const serialized = serializeSseEvent(message);
+
+    await expect(
+      collectMessages(
+        streamFromChunks([
+          serialized.slice(0, 7),
+          serialized.slice(7, 18),
+          serialized.slice(18),
+        ]),
+      ),
+    ).resolves.toEqual([message]);
+  });
+
+  it("ignores comments, keepalives, and non-data fields", async () => {
+    const message: AnyMessage = { jsonrpc: "2.0", id: 1, result: { ok: true } };
+
+    await expect(
+      collectMessages(
+        streamFromChunks([
+          `:\n\nevent: message\nid: 1\ndata: ${JSON.stringify(message)}\nretry: 1000\n\n`,
+        ]),
+      ),
+    ).resolves.toEqual([message]);
+  });
+
+  it("joins multiline data fields", async () => {
+    const expected: AnyMessage = {
+      jsonrpc: "2.0",
+      id: 1,
+      result: { ok: true },
+    };
+    const body = [
+      'data: {"jsonrpc":"2.0",\n',
+      'data: "id":1,\n',
+      'data: "result":{"ok":true}}\n\n',
+    ];
+
+    await expect(collectMessages(streamFromChunks(body))).resolves.toEqual([
+      expected,
+    ]);
+  });
+
+  it("skips malformed JSON without throwing", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const message: AnyMessage = { jsonrpc: "2.0", id: 1, result: { ok: true } };
+
+    await expect(
+      collectMessages(
+        streamFromChunks(["data: {not-json}\n\n", serializeSseEvent(message)]),
+      ),
+    ).resolves.toEqual([message]);
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockRestore();
+  });
+});

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -1,4 +1,5 @@
 import type { AnyMessage } from "./jsonrpc.js";
+import { isJsonRpcMessage } from "./jsonrpc.js";
 
 export function serializeSseEvent(msg: AnyMessage): string {
   return `data: ${JSON.stringify(msg)}\n\n`;
@@ -76,7 +77,7 @@ function parseSseEvent(eventPart: string): AnyMessage | undefined {
 
   try {
     const parsed: unknown = JSON.parse(data);
-    if (isAnyMessage(parsed)) {
+    if (isJsonRpcMessage(parsed)) {
       return parsed;
     }
 
@@ -86,20 +87,4 @@ function parseSseEvent(eventPart: string): AnyMessage | undefined {
     console.warn("Failed to parse SSE JSON payload:", error);
     return undefined;
   }
-}
-
-function isAnyMessage(value: unknown): value is AnyMessage {
-  if (!isRecord(value) || value["jsonrpc"] !== "2.0") {
-    return false;
-  }
-
-  if ("method" in value) {
-    return typeof value["method"] === "string";
-  }
-
-  return "id" in value;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -1,0 +1,105 @@
+import type { AnyMessage } from "./jsonrpc.js";
+
+export function serializeSseEvent(msg: AnyMessage): string {
+  return `data: ${JSON.stringify(msg)}\n\n`;
+}
+
+export function serializeSseKeepAlive(): string {
+  return ":\n\n";
+}
+
+export async function* parseSseStream(
+  body: ReadableStream<Uint8Array>,
+): AsyncIterable<AnyMessage> {
+  const decoder = new TextDecoder();
+  const reader = body.getReader();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const chunk = await reader.read();
+
+      if (chunk.done) {
+        buffer += decoder.decode();
+        yield* parseBufferedEvents(buffer);
+        return;
+      }
+
+      buffer += decoder.decode(chunk.value, { stream: true });
+      const eventParts = buffer.split(/\r?\n\r?\n/);
+      buffer = eventParts.pop() ?? "";
+
+      for (const eventPart of eventParts) {
+        const msg = parseSseEvent(eventPart);
+        if (msg) {
+          yield msg;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function* parseBufferedEvents(buffer: string): Iterable<AnyMessage> {
+  if (!buffer.trim()) {
+    return;
+  }
+
+  const eventParts = buffer.split(/\r?\n\r?\n/);
+
+  for (const eventPart of eventParts) {
+    const msg = parseSseEvent(eventPart);
+    if (msg) {
+      yield msg;
+    }
+  }
+}
+
+function parseSseEvent(eventPart: string): AnyMessage | undefined {
+  const dataLines = eventPart
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => {
+      const value = line.slice("data:".length);
+      return value.startsWith(" ") ? value.slice(1) : value;
+    });
+
+  if (dataLines.length === 0) {
+    return undefined;
+  }
+
+  const data = dataLines.join("\n");
+  if (!data.trim()) {
+    return undefined;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(data);
+    if (isAnyMessage(parsed)) {
+      return parsed;
+    }
+
+    console.warn("Skipping SSE payload that is not a JSON-RPC message");
+    return undefined;
+  } catch (error) {
+    console.warn("Failed to parse SSE JSON payload:", error);
+    return undefined;
+  }
+}
+
+function isAnyMessage(value: unknown): value is AnyMessage {
+  if (!isRecord(value) || value["jsonrpc"] !== "2.0") {
+    return false;
+  }
+
+  if ("method" in value) {
+    return typeof value["method"] === "string";
+  }
+
+  return "id" in value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/stream.test.ts
+++ b/src/stream.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { ndJsonStream } from "./stream.js";
 import type { AnyMessage } from "./jsonrpc.js";
 
@@ -131,6 +131,9 @@ describe("ndJsonStream", () => {
   });
 
   it("skips malformed lines and continues parsing", async () => {
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
     const msg1 = { jsonrpc: "2.0" as const, id: 1, method: "before" };
     const msg2 = { jsonrpc: "2.0" as const, id: 2, method: "after" };
     const input = readableFromChunks([
@@ -147,5 +150,8 @@ describe("ndJsonStream", () => {
     const messages = await collectMessages(readable);
 
     expect(messages).toEqual([msg1, msg2]);
+    expect(error).toHaveBeenCalledOnce();
+
+    error.mockRestore();
   });
 });

--- a/src/test-support/test-agent.ts
+++ b/src/test-support/test-agent.ts
@@ -17,17 +17,20 @@ import type {
 export interface TestAgentOptions {
   readonly chunkCount?: number;
   readonly chunkDelayMs?: number;
+  readonly enablePermission?: boolean;
 }
 
 export class TestAgent implements Agent {
   private readonly connection: AgentSideConnection;
   private readonly chunkCount: number;
   private readonly chunkDelayMs: number;
+  private readonly enablePermission: boolean;
 
   constructor(connection: AgentSideConnection, options: TestAgentOptions = {}) {
     this.connection = connection;
     this.chunkCount = options.chunkCount ?? 1;
     this.chunkDelayMs = options.chunkDelayMs ?? 0;
+    this.enablePermission = options.enablePermission ?? false;
   }
 
   initialize(_params: InitializeRequest): Promise<InitializeResponse> {
@@ -65,6 +68,42 @@ export class TestAgent implements Agent {
           content: {
             type: "text",
             text: `chunk-${index + 1}`,
+          },
+        },
+      });
+    }
+
+    if (this.enablePermission) {
+      const permission = await this.connection.requestPermission({
+        sessionId: params.sessionId,
+        toolCall: {
+          toolCallId: "permission-tool",
+          title: "Permission tool",
+        },
+        options: [
+          {
+            kind: "allow_once",
+            name: "Allow once",
+            optionId: "allow",
+          },
+          {
+            kind: "reject_once",
+            name: "Reject once",
+            optionId: "reject",
+          },
+        ],
+      });
+
+      await this.connection.sessionUpdate({
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text:
+              permission.outcome.outcome === "selected"
+                ? `permission-selected-${permission.outcome.optionId}`
+                : "permission-cancelled",
           },
         },
       });

--- a/src/test-support/test-agent.ts
+++ b/src/test-support/test-agent.ts
@@ -1,0 +1,85 @@
+import { PROTOCOL_VERSION } from "../schema/index.js";
+
+import type {
+  Agent,
+  AgentSideConnection,
+  AuthenticateRequest,
+  AuthenticateResponse,
+  CancelNotification,
+  InitializeRequest,
+  InitializeResponse,
+  NewSessionRequest,
+  NewSessionResponse,
+  PromptRequest,
+  PromptResponse,
+} from "../acp.js";
+
+export interface TestAgentOptions {
+  readonly chunkCount?: number;
+  readonly chunkDelayMs?: number;
+}
+
+export class TestAgent implements Agent {
+  private readonly connection: AgentSideConnection;
+  private readonly chunkCount: number;
+  private readonly chunkDelayMs: number;
+
+  constructor(connection: AgentSideConnection, options: TestAgentOptions = {}) {
+    this.connection = connection;
+    this.chunkCount = options.chunkCount ?? 1;
+    this.chunkDelayMs = options.chunkDelayMs ?? 0;
+  }
+
+  initialize(_params: InitializeRequest): Promise<InitializeResponse> {
+    return Promise.resolve({
+      protocolVersion: PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: false,
+      },
+    });
+  }
+
+  newSession(_params: NewSessionRequest): Promise<NewSessionResponse> {
+    return Promise.resolve({ sessionId: globalThis.crypto.randomUUID() });
+  }
+
+  authenticate(
+    _params: AuthenticateRequest,
+  ): Promise<AuthenticateResponse | void> {
+    return Promise.resolve();
+  }
+
+  async prompt(params: PromptRequest): Promise<PromptResponse> {
+    for (const index of Array.from(
+      { length: this.chunkCount },
+      (_, item) => item,
+    )) {
+      if (this.chunkDelayMs > 0) {
+        await delay(this.chunkDelayMs);
+      }
+
+      await this.connection.sessionUpdate({
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: `chunk-${index + 1}`,
+          },
+        },
+      });
+    }
+
+    return { stopReason: "end_turn" };
+  }
+
+  cancel(_params: CancelNotification): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/src/test-support/test-http-server.ts
+++ b/src/test-support/test-http-server.ts
@@ -2,7 +2,10 @@ import http from "node:http";
 import { WebSocketServer } from "ws";
 
 import { AcpServer } from "../server.js";
-import { createNodeHttpHandler } from "../node-adapter.js";
+import {
+  createNodeHttpHandler,
+  createNodeWebSocketUpgradeHandler,
+} from "../node-adapter.js";
 import { TestAgent } from "./test-agent.js";
 
 import type { AddressInfo } from "node:net";
@@ -23,11 +26,10 @@ export async function startTestServer(
   const httpServer = http.createServer(createNodeHttpHandler(acpServer));
   const webSocketServer = new WebSocketServer({ noServer: true });
 
-  httpServer.on("upgrade", (req, socket, head) => {
-    webSocketServer.handleUpgrade(req, socket, head, (webSocket) => {
-      acpServer.handleWebSocket(webSocket);
-    });
-  });
+  httpServer.on(
+    "upgrade",
+    createNodeWebSocketUpgradeHandler(acpServer, webSocketServer),
+  );
 
   await listen(httpServer, options.port ?? 0);
 

--- a/src/test-support/test-http-server.ts
+++ b/src/test-support/test-http-server.ts
@@ -1,0 +1,74 @@
+import http from "node:http";
+
+import { AcpServer } from "../server.js";
+import { createNodeHttpHandler } from "../node-adapter.js";
+import { TestAgent } from "./test-agent.js";
+
+import type { AddressInfo } from "node:net";
+import type { Agent, AgentSideConnection } from "../acp.js";
+
+export interface TestHttpServer {
+  readonly url: string;
+  readonly close: () => Promise<void>;
+}
+
+export async function startTestServer(
+  agentFactory: (conn: AgentSideConnection) => Agent = (conn) =>
+    new TestAgent(conn),
+  options: { port?: number } = {},
+): Promise<TestHttpServer> {
+  const acpServer = new AcpServer({ createAgent: agentFactory });
+  const httpServer = http.createServer(createNodeHttpHandler(acpServer));
+
+  await listen(httpServer, options.port ?? 0);
+
+  const address = httpServer.address();
+
+  if (!isAddressInfo(address)) {
+    throw new Error("Test HTTP server did not bind to a TCP port");
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      await Promise.all([acpServer.close(), closeHttpServer(httpServer)]);
+    },
+  };
+}
+
+function listen(server: http.Server, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error): void => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+
+    const onListening = (): void => {
+      server.off("error", onError);
+      resolve();
+    };
+
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function isAddressInfo(
+  address: ReturnType<http.Server["address"]>,
+): address is AddressInfo {
+  return typeof address === "object" && address !== null;
+}

--- a/src/test-support/test-http-server.ts
+++ b/src/test-support/test-http-server.ts
@@ -1,4 +1,5 @@
 import http from "node:http";
+import { WebSocketServer } from "ws";
 
 import { AcpServer } from "../server.js";
 import { createNodeHttpHandler } from "../node-adapter.js";
@@ -9,6 +10,7 @@ import type { Agent, AgentSideConnection } from "../acp.js";
 
 export interface TestHttpServer {
   readonly url: string;
+  readonly wsUrl: string;
   readonly close: () => Promise<void>;
 }
 
@@ -19,6 +21,13 @@ export async function startTestServer(
 ): Promise<TestHttpServer> {
   const acpServer = new AcpServer({ createAgent: agentFactory });
   const httpServer = http.createServer(createNodeHttpHandler(acpServer));
+  const webSocketServer = new WebSocketServer({ noServer: true });
+
+  httpServer.on("upgrade", (req, socket, head) => {
+    webSocketServer.handleUpgrade(req, socket, head, (webSocket) => {
+      acpServer.handleWebSocket(webSocket);
+    });
+  });
 
   await listen(httpServer, options.port ?? 0);
 
@@ -30,8 +39,14 @@ export async function startTestServer(
 
   return {
     url: `http://127.0.0.1:${address.port}`,
+    wsUrl: `ws://127.0.0.1:${address.port}`,
     close: async () => {
-      await Promise.all([acpServer.close(), closeHttpServer(httpServer)]);
+      terminateWebSockets(webSocketServer);
+      await Promise.all([
+        acpServer.close(),
+        closeWebSocketServer(webSocketServer),
+        closeHttpServer(httpServer),
+      ]);
     },
   };
 }
@@ -51,6 +66,25 @@ function listen(server: http.Server, port: number): Promise<void> {
     server.once("error", onError);
     server.once("listening", onListening);
     server.listen(port, "127.0.0.1");
+  });
+}
+
+function terminateWebSockets(server: WebSocketServer): void {
+  for (const client of server.clients) {
+    client.terminate();
+  }
+}
+
+function closeWebSocketServer(server: WebSocketServer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
   });
 }
 

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -343,13 +343,7 @@ async function writeInbound(
   connection: ConnectionState,
   message: AnyMessage,
 ): Promise<void> {
-  const writer = connection.inboundTx.getWriter();
-
-  try {
-    await writer.write(message);
-  } finally {
-    writer.releaseLock();
-  }
+  await connection.writeInbound(message);
 }
 
 function determineWebSocketRoute(message: AnyRequest): ResponseRoute {

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -141,7 +141,7 @@ class WebSocketServerSession {
 
     const connection =
       this.preparedConnection ??
-      this.options.registry.createConnection(this.options.createAgent);
+      this.options.registry.createPendingConnection(this.options.createAgent);
     this.preparedConnection = connection;
 
     try {
@@ -150,19 +150,20 @@ class WebSocketServerSession {
       const initialResponse = await connection.recvInitial(message.id);
 
       if (this.isClosed) {
-        this.options.registry.remove(connection.connectionId);
+        this.options.registry.discard(connection.connectionId);
         return;
       }
 
       this.preparedConnection = undefined;
       this.connection = connection;
+      this.options.registry.register(connection);
       connection.startRouter();
 
       this.send(initialResponse);
       this.startOutboundPump(connection);
     } catch (error) {
       this.preparedConnection = undefined;
-      this.options.registry.remove(connection.connectionId);
+      this.options.registry.discard(connection.connectionId);
 
       this.send({
         jsonrpc: "2.0",
@@ -328,12 +329,12 @@ class WebSocketServerSession {
     }
 
     if (this.connection) {
-      this.options.registry.remove(this.connection.connectionId);
+      this.options.registry.discard(this.connection.connectionId);
       this.connection = undefined;
     }
 
     if (this.preparedConnection) {
-      this.options.registry.remove(this.preparedConnection.connectionId);
+      this.options.registry.discard(this.preparedConnection.connectionId);
       this.preparedConnection = undefined;
     }
   }

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -36,21 +36,29 @@ export interface WebSocketConnectionOptions {
   readonly connection?: ConnectionState;
 }
 
+export interface WebSocketServerSessionHandle {
+  readonly closed: Promise<void>;
+  close(code?: number, reason?: string): Promise<void>;
+}
+
 export function handleWebSocketConnection(
   socket: WebSocketLike,
   options: WebSocketConnectionOptions,
-): void {
+): WebSocketServerSessionHandle {
   const session = new WebSocketServerSession(socket, options);
   session.start();
+  return session;
 }
 
-class WebSocketServerSession {
+class WebSocketServerSession implements WebSocketServerSessionHandle {
   private connection: ConnectionState | undefined;
   private preparedConnection: ConnectionState | undefined;
   private outboundReader: ReadableStreamDefaultReader<AnyMessage> | undefined;
   private inboundWriteChain: Promise<void> = Promise.resolve();
   private messageChain: Promise<void> = Promise.resolve();
   private isClosed = false;
+  private readonly closedPromise: Promise<void>;
+  private resolveClosed: () => void = () => {};
   private readonly detachListeners: Array<() => void> = [];
 
   constructor(
@@ -58,6 +66,13 @@ class WebSocketServerSession {
     private readonly options: WebSocketConnectionOptions,
   ) {
     this.preparedConnection = options.connection;
+    this.closedPromise = new Promise((resolve) => {
+      this.resolveClosed = resolve;
+    });
+  }
+
+  get closed(): Promise<void> {
+    return this.closedPromise;
   }
 
   start(): void {
@@ -78,6 +93,10 @@ class WebSocketServerSession {
         void this.shutdown(1011, "WebSocket error");
       }),
     );
+  }
+
+  close(code = 1001, reason = "Server shutting down"): Promise<void> {
+    return this.shutdown(code, reason);
   }
 
   private enqueueSocketMessage(args: unknown[]): void {
@@ -349,25 +368,29 @@ class WebSocketServerSession {
 
     this.isClosed = true;
 
-    for (const detach of this.detachListeners.splice(0)) {
-      detach();
-    }
+    try {
+      for (const detach of this.detachListeners.splice(0)) {
+        detach();
+      }
 
-    const outboundReader = this.outboundReader;
-    this.outboundReader = undefined;
+      const outboundReader = this.outboundReader;
+      this.outboundReader = undefined;
 
-    if (outboundReader) {
-      await outboundReader.cancel();
-    }
+      if (outboundReader) {
+        await outboundReader.cancel();
+      }
 
-    if (this.connection) {
-      this.options.registry.discard(this.connection.connectionId);
-      this.connection = undefined;
-    }
+      if (this.connection) {
+        this.options.registry.discard(this.connection.connectionId);
+        this.connection = undefined;
+      }
 
-    if (this.preparedConnection) {
-      this.options.registry.discard(this.preparedConnection.connectionId);
-      this.preparedConnection = undefined;
+      if (this.preparedConnection) {
+        this.options.registry.discard(this.preparedConnection.connectionId);
+        this.preparedConnection = undefined;
+      }
+    } finally {
+      this.resolveClosed();
     }
   }
 }

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -49,6 +49,7 @@ class WebSocketServerSession {
   private preparedConnection: ConnectionState | undefined;
   private outboundReader: ReadableStreamDefaultReader<AnyMessage> | undefined;
   private inboundWriteChain: Promise<void> = Promise.resolve();
+  private messageChain: Promise<void> = Promise.resolve();
   private isClosed = false;
   private readonly detachListeners: Array<() => void> = [];
 
@@ -62,7 +63,7 @@ class WebSocketServerSession {
   start(): void {
     this.detachListeners.push(
       onWebSocket(this.socket, "message", (...args) => {
-        void this.handleSocketMessage(args);
+        this.enqueueSocketMessage(args);
       }),
     );
 
@@ -77,6 +78,18 @@ class WebSocketServerSession {
         void this.shutdown(1011, "WebSocket error");
       }),
     );
+  }
+
+  private enqueueSocketMessage(args: unknown[]): void {
+    const handled = this.messageChain.then(() =>
+      this.handleSocketMessage(args),
+    );
+    this.messageChain = handled.catch((error) => {
+      if (!this.isClosed) {
+        console.error("ACP WebSocket message handling failed:", error);
+        void this.shutdown(1011, "Message handling failed");
+      }
+    });
   }
 
   private async handleSocketMessage(args: unknown[]): Promise<void> {
@@ -207,6 +220,10 @@ class WebSocketServerSession {
     }
 
     if (isResponseMessage(message)) {
+      const key = messageIdKey(message.id);
+      if (key) {
+        connection.clientResponseRoutes.delete(key);
+      }
       await this.writeInbound(message);
       return { ok: true };
     }

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -18,6 +18,7 @@ import type {
 import type { AnyMessage, AnyRequest } from "./jsonrpc.js";
 import type { WebSocketLike } from "./ws-utils.js";
 
+/** WebSocket shape accepted by `AcpServer.handleWebSocket`. */
 export type WebSocketServerSocket = WebSocketLike;
 
 type ForwardResult =

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -18,7 +18,7 @@ import type {
 import type { AnyMessage, AnyRequest } from "./jsonrpc.js";
 import type { WebSocketLike } from "./ws-utils.js";
 
-/** WebSocket shape accepted by `AcpServer.handleWebSocket`. */
+/** WebSocket shape accepted by prepared ACP WebSocket upgrades. */
 export type WebSocketServerSocket = WebSocketLike;
 
 type ForwardResult =
@@ -33,6 +33,7 @@ type ForwardResult =
 export interface WebSocketConnectionOptions {
   readonly registry: ConnectionRegistry;
   readonly createAgent: (conn: AgentSideConnection) => Agent;
+  readonly connection?: ConnectionState;
 }
 
 export function handleWebSocketConnection(
@@ -45,6 +46,7 @@ export function handleWebSocketConnection(
 
 class WebSocketServerSession {
   private connection: ConnectionState | undefined;
+  private preparedConnection: ConnectionState | undefined;
   private outboundReader: ReadableStreamDefaultReader<AnyMessage> | undefined;
   private inboundWriteChain: Promise<void> = Promise.resolve();
   private isClosed = false;
@@ -53,7 +55,9 @@ class WebSocketServerSession {
   constructor(
     private readonly socket: WebSocketLike,
     private readonly options: WebSocketConnectionOptions,
-  ) {}
+  ) {
+    this.preparedConnection = options.connection;
+  }
 
   start(): void {
     this.detachListeners.push(
@@ -135,26 +139,30 @@ class WebSocketServerSession {
       return;
     }
 
-    let connection: ConnectionState | undefined;
+    const connection =
+      this.preparedConnection ??
+      this.options.registry.createConnection(this.options.createAgent);
+    this.preparedConnection = connection;
 
     try {
-      connection = this.options.registry.createConnection(
-        this.options.createAgent,
-      );
-
       await writeInbound(connection, message);
 
       const initialResponse = await connection.recvInitial(message.id);
 
+      if (this.isClosed) {
+        this.options.registry.remove(connection.connectionId);
+        return;
+      }
+
+      this.preparedConnection = undefined;
       this.connection = connection;
       connection.startRouter();
 
       this.send(initialResponse);
       this.startOutboundPump(connection);
     } catch (error) {
-      if (connection) {
-        this.options.registry.remove(connection.connectionId);
-      }
+      this.preparedConnection = undefined;
+      this.options.registry.remove(connection.connectionId);
 
       this.send({
         jsonrpc: "2.0",
@@ -322,6 +330,11 @@ class WebSocketServerSession {
     if (this.connection) {
       this.options.registry.remove(this.connection.connectionId);
       this.connection = undefined;
+    }
+
+    if (this.preparedConnection) {
+      this.options.registry.remove(this.preparedConnection.connectionId);
+      this.preparedConnection = undefined;
     }
   }
 }

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -202,6 +202,21 @@ class WebSocketServerSession {
       };
     }
 
+    if (isRequestMessage(message) && isInitializeRequest(message)) {
+      this.send({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: {
+          code: -32600,
+          message: "Initialize not allowed on existing connection",
+        },
+      });
+      return {
+        ok: false,
+        message: "Initialize not allowed on existing connection",
+      };
+    }
+
     if (isRequestMessage(message)) {
       const route = determineWebSocketRoute(message);
 

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -1,0 +1,425 @@
+import {
+  isJsonRpcMessage,
+  isRequestMessage,
+  isResponseMessage,
+} from "./jsonrpc.js";
+import {
+  isInitializeRequest,
+  messageIdKey,
+  sessionIdFromParams,
+} from "./protocol.js";
+
+import type { Agent, AgentSideConnection } from "./acp.js";
+import type {
+  ConnectionRegistry,
+  ConnectionState,
+  ResponseRoute,
+} from "./connection.js";
+import type { AnyMessage, AnyRequest } from "./jsonrpc.js";
+
+type ForwardResult =
+  | {
+      ok: true;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+export interface WebSocketServerSocket {
+  readonly readyState?: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  addEventListener?(type: string, listener: (event: unknown) => void): void;
+  removeEventListener?(type: string, listener: (event: unknown) => void): void;
+  on?(type: string, listener: (...args: unknown[]) => void): unknown;
+  off?(type: string, listener: (...args: unknown[]) => void): unknown;
+  removeListener?(
+    type: string,
+    listener: (...args: unknown[]) => void,
+  ): unknown;
+}
+
+export interface WebSocketConnectionOptions {
+  readonly registry: ConnectionRegistry;
+  readonly createAgent: (conn: AgentSideConnection) => Agent;
+}
+
+export function handleWebSocketConnection(
+  socket: WebSocketServerSocket,
+  options: WebSocketConnectionOptions,
+): void {
+  const session = new WebSocketServerSession(socket, options);
+  session.start();
+}
+
+class WebSocketServerSession {
+  private connection: ConnectionState | undefined;
+  private outboundReader: ReadableStreamDefaultReader<AnyMessage> | undefined;
+  private isClosed = false;
+  private readonly detachListeners: Array<() => void> = [];
+
+  constructor(
+    private readonly socket: WebSocketServerSocket,
+    private readonly options: WebSocketConnectionOptions,
+  ) {}
+
+  start(): void {
+    this.detachListeners.push(
+      onSocket(this.socket, "message", (...args) => {
+        void this.handleSocketMessage(args);
+      }),
+    );
+
+    this.detachListeners.push(
+      onSocket(this.socket, "close", () => {
+        void this.closeSession();
+      }),
+    );
+
+    this.detachListeners.push(
+      onSocket(this.socket, "error", () => {
+        void this.shutdown(1011, "WebSocket error");
+      }),
+    );
+  }
+
+  private async handleSocketMessage(args: unknown[]): Promise<void> {
+    if (this.isClosed) {
+      return;
+    }
+
+    const text = socketMessageToString(args);
+    if (text === undefined) {
+      console.warn("Ignoring non-text ACP WebSocket frame");
+      return;
+    }
+
+    let value: unknown;
+    try {
+      value = JSON.parse(text);
+    } catch (error) {
+      console.warn("Ignoring malformed ACP WebSocket JSON message:", error);
+      await this.shutdownIfUninitialized(1007, "Malformed JSON");
+
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      console.warn("Ignoring ACP WebSocket JSON-RPC batch message");
+      await this.shutdownIfUninitialized(
+        1002,
+        "JSON-RPC batch messages are not supported",
+      );
+      return;
+    }
+
+    if (!isJsonRpcMessage(value)) {
+      console.warn("Ignoring non-JSON-RPC ACP WebSocket message:", value);
+      await this.shutdownIfUninitialized(1002, "Invalid JSON-RPC message");
+      return;
+    }
+
+    if (!this.connection) {
+      await this.handleInitialize(value);
+      return;
+    }
+
+    const forwarded = await this.forwardMessage(value);
+    if (!forwarded.ok) {
+      console.warn("Ignoring ACP WebSocket message:", forwarded.message);
+    }
+  }
+
+  private async handleInitialize(message: AnyMessage): Promise<void> {
+    if (!isInitializeRequest(message)) {
+      console.warn("First ACP WebSocket message must be initialize");
+      await this.shutdown(1002, "First message must be initialize");
+      return;
+    }
+
+    if (!("id" in message) || message.id === null) {
+      console.warn("ACP WebSocket initialize request must include an ID");
+      await this.shutdown(1002, "Initialize request must include an ID");
+      return;
+    }
+
+    let connection: ConnectionState | undefined;
+
+    try {
+      connection = this.options.registry.createConnection(
+        this.options.createAgent,
+      );
+
+      await writeInbound(connection, message);
+
+      const initialResponse = await connection.recvInitial(message.id);
+
+      this.connection = connection;
+      connection.startRouter();
+
+      this.send(initialResponse);
+      this.startOutboundPump(connection);
+    } catch (error) {
+      if (connection) {
+        this.options.registry.remove(connection.connectionId);
+      }
+
+      this.send({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: {
+          code: -32603,
+          message: "Initialize failed",
+          data: error instanceof Error ? error.message : undefined,
+        },
+      });
+
+      await this.shutdown(1011, "Initialize failed");
+    }
+  }
+
+  private async forwardMessage(message: AnyMessage): Promise<ForwardResult> {
+    const connection = this.connection;
+
+    if (!connection) {
+      return {
+        ok: false,
+        message: "ACP WebSocket connection is not initialized",
+      };
+    }
+
+    if (isRequestMessage(message)) {
+      const route = determineWebSocketRoute(message);
+
+      if (route !== "connection") {
+        connection.ensureSession(route.session);
+      }
+
+      const key = messageIdKey(message.id);
+
+      if (key) {
+        connection.pendingRoutes.set(key, route);
+      }
+
+      await writeInbound(connection, message);
+      return { ok: true };
+    }
+
+    if (isResponseMessage(message)) {
+      await writeInbound(connection, message);
+      return { ok: true };
+    }
+
+    await writeInbound(connection, message);
+    return { ok: true };
+  }
+
+  private startOutboundPump(connection: ConnectionState): void {
+    const subscription = connection.allOutbound.subscribe();
+    const reader = subscription.stream.getReader();
+    this.outboundReader = reader;
+
+    void (async () => {
+      try {
+        for (const message of subscription.replay) {
+          if (!this.send(message)) {
+            return;
+          }
+        }
+
+        while (!this.isClosed) {
+          const result = await reader.read();
+
+          if (result.done) {
+            return;
+          }
+
+          if (!this.send(result.value)) {
+            return;
+          }
+        }
+      } catch (error) {
+        if (!this.isClosed) {
+          console.error("ACP WebSocket outbound pump failed:", error);
+        }
+      } finally {
+        if (this.outboundReader === reader) {
+          this.outboundReader = undefined;
+        }
+
+        reader.releaseLock();
+
+        if (!this.isClosed) {
+          void this.shutdown();
+        }
+      }
+    })();
+  }
+
+  private send(message: AnyMessage): boolean {
+    if (this.isClosed) {
+      return false;
+    }
+
+    try {
+      this.socket.send(JSON.stringify(message));
+      return true;
+    } catch (error) {
+      console.warn("Failed to send ACP WebSocket message:", error);
+      void this.shutdown(1011, "Failed to send message");
+      return false;
+    }
+  }
+
+  private async shutdownIfUninitialized(
+    code?: number,
+    reason?: string,
+  ): Promise<void> {
+    if (this.connection) {
+      return;
+    }
+
+    await this.shutdown(code, reason);
+  }
+
+  private async shutdown(code?: number, reason?: string): Promise<void> {
+    this.closeSocket(code, reason);
+    await this.closeSession();
+  }
+
+  private closeSocket(code?: number, reason?: string): void {
+    try {
+      this.socket.close(code, reason);
+    } catch (error) {
+      console.warn("Failed to close ACP WebSocket:", error);
+    }
+  }
+
+  private async closeSession(): Promise<void> {
+    if (this.isClosed) {
+      return;
+    }
+
+    this.isClosed = true;
+
+    for (const detach of this.detachListeners.splice(0)) {
+      detach();
+    }
+
+    const outboundReader = this.outboundReader;
+    this.outboundReader = undefined;
+
+    if (outboundReader) {
+      await outboundReader.cancel();
+    }
+
+    if (this.connection) {
+      this.options.registry.remove(this.connection.connectionId);
+      this.connection = undefined;
+    }
+  }
+}
+
+async function writeInbound(
+  connection: ConnectionState,
+  message: AnyMessage,
+): Promise<void> {
+  const writer = connection.inboundTx.getWriter();
+
+  try {
+    await writer.write(message);
+  } finally {
+    writer.releaseLock();
+  }
+}
+
+function determineWebSocketRoute(message: AnyRequest): ResponseRoute {
+  const sessionId = sessionIdFromParams(message.params);
+
+  if (sessionId) {
+    return {
+      session: sessionId,
+    };
+  }
+
+  return "connection";
+}
+
+function onSocket(
+  socket: WebSocketServerSocket,
+  type: string,
+  listener: (...args: unknown[]) => void,
+): () => void {
+  if (socket.addEventListener) {
+    const eventListener = (event: unknown) => listener(event);
+    socket.addEventListener(type, eventListener);
+
+    return () => {
+      socket.removeEventListener?.(type, eventListener);
+    };
+  }
+
+  if (socket.on) {
+    socket.on(type, listener);
+
+    return () => {
+      if (socket.off) {
+        socket.off(type, listener);
+        return;
+      }
+
+      socket.removeListener?.(type, listener);
+    };
+  }
+
+  throw new Error("WebSocket object does not support event listeners");
+}
+
+function socketMessageToString(args: unknown[]): string | undefined {
+  const data = extractMessageData(args);
+
+  if (typeof data === "string") {
+    return data;
+  }
+
+  if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(data);
+  }
+
+  if (Array.isArray(data) && data.every(ArrayBuffer.isView)) {
+    return decodeArrayBufferViews(data);
+  }
+
+  return undefined;
+}
+
+function extractMessageData(args: unknown[]): unknown {
+  const [first] = args;
+
+  if (isMessageEventLike(first)) {
+    return first.data;
+  }
+
+  return first;
+}
+
+function isMessageEventLike(value: unknown): value is { data: unknown } {
+  return typeof value === "object" && value !== null && "data" in value;
+}
+
+function decodeArrayBufferViews(views: ArrayBufferView[]): string {
+  const totalLength = views.reduce((sum, view) => sum + view.byteLength, 0);
+  const combined = new Uint8Array(totalLength);
+  let offset = 0;
+
+  for (const view of views) {
+    combined.set(
+      new Uint8Array(view.buffer, view.byteOffset, view.byteLength),
+      offset,
+    );
+    offset += view.byteLength;
+  }
+
+  return new TextDecoder().decode(combined);
+}

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -8,7 +8,7 @@ import {
   messageIdKey,
   sessionIdFromParams,
 } from "./protocol.js";
-
+import { onWebSocket, webSocketMessageToString } from "./ws-utils.js";
 import type { Agent, AgentSideConnection } from "./acp.js";
 import type {
   ConnectionRegistry,
@@ -16,6 +16,9 @@ import type {
   ResponseRoute,
 } from "./connection.js";
 import type { AnyMessage, AnyRequest } from "./jsonrpc.js";
+import type { WebSocketLike } from "./ws-utils.js";
+
+export type WebSocketServerSocket = WebSocketLike;
 
 type ForwardResult =
   | {
@@ -26,27 +29,13 @@ type ForwardResult =
       message: string;
     };
 
-export interface WebSocketServerSocket {
-  readonly readyState?: number;
-  send(data: string): void;
-  close(code?: number, reason?: string): void;
-  addEventListener?(type: string, listener: (event: unknown) => void): void;
-  removeEventListener?(type: string, listener: (event: unknown) => void): void;
-  on?(type: string, listener: (...args: unknown[]) => void): unknown;
-  off?(type: string, listener: (...args: unknown[]) => void): unknown;
-  removeListener?(
-    type: string,
-    listener: (...args: unknown[]) => void,
-  ): unknown;
-}
-
 export interface WebSocketConnectionOptions {
   readonly registry: ConnectionRegistry;
   readonly createAgent: (conn: AgentSideConnection) => Agent;
 }
 
 export function handleWebSocketConnection(
-  socket: WebSocketServerSocket,
+  socket: WebSocketLike,
   options: WebSocketConnectionOptions,
 ): void {
   const session = new WebSocketServerSession(socket, options);
@@ -56,29 +45,30 @@ export function handleWebSocketConnection(
 class WebSocketServerSession {
   private connection: ConnectionState | undefined;
   private outboundReader: ReadableStreamDefaultReader<AnyMessage> | undefined;
+  private inboundWriteChain: Promise<void> = Promise.resolve();
   private isClosed = false;
   private readonly detachListeners: Array<() => void> = [];
 
   constructor(
-    private readonly socket: WebSocketServerSocket,
+    private readonly socket: WebSocketLike,
     private readonly options: WebSocketConnectionOptions,
   ) {}
 
   start(): void {
     this.detachListeners.push(
-      onSocket(this.socket, "message", (...args) => {
+      onWebSocket(this.socket, "message", (...args) => {
         void this.handleSocketMessage(args);
       }),
     );
 
     this.detachListeners.push(
-      onSocket(this.socket, "close", () => {
+      onWebSocket(this.socket, "close", () => {
         void this.closeSession();
       }),
     );
 
     this.detachListeners.push(
-      onSocket(this.socket, "error", () => {
+      onWebSocket(this.socket, "error", () => {
         void this.shutdown(1011, "WebSocket error");
       }),
     );
@@ -89,7 +79,7 @@ class WebSocketServerSession {
       return;
     }
 
-    const text = socketMessageToString(args);
+    const text = webSocketMessageToString(args);
     if (text === undefined) {
       console.warn("Ignoring non-text ACP WebSocket frame");
       return;
@@ -202,17 +192,31 @@ class WebSocketServerSession {
         connection.pendingRoutes.set(key, route);
       }
 
-      await writeInbound(connection, message);
+      await this.writeInbound(message);
       return { ok: true };
     }
 
     if (isResponseMessage(message)) {
-      await writeInbound(connection, message);
+      await this.writeInbound(message);
       return { ok: true };
     }
 
-    await writeInbound(connection, message);
+    await this.writeInbound(message);
     return { ok: true };
+  }
+
+  private async writeInbound(message: AnyMessage): Promise<void> {
+    const connection = this.connection;
+
+    if (!connection) {
+      throw new Error("ACP WebSocket connection is not initialized");
+    }
+
+    const write = this.inboundWriteChain.then(() =>
+      writeInbound(connection, message),
+    );
+    this.inboundWriteChain = write.catch(() => undefined);
+    await write;
   }
 
   private startOutboundPump(connection: ConnectionState): void {
@@ -344,82 +348,4 @@ function determineWebSocketRoute(message: AnyRequest): ResponseRoute {
   }
 
   return "connection";
-}
-
-function onSocket(
-  socket: WebSocketServerSocket,
-  type: string,
-  listener: (...args: unknown[]) => void,
-): () => void {
-  if (socket.addEventListener) {
-    const eventListener = (event: unknown) => listener(event);
-    socket.addEventListener(type, eventListener);
-
-    return () => {
-      socket.removeEventListener?.(type, eventListener);
-    };
-  }
-
-  if (socket.on) {
-    socket.on(type, listener);
-
-    return () => {
-      if (socket.off) {
-        socket.off(type, listener);
-        return;
-      }
-
-      socket.removeListener?.(type, listener);
-    };
-  }
-
-  throw new Error("WebSocket object does not support event listeners");
-}
-
-function socketMessageToString(args: unknown[]): string | undefined {
-  const data = extractMessageData(args);
-
-  if (typeof data === "string") {
-    return data;
-  }
-
-  if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
-    return new TextDecoder().decode(data);
-  }
-
-  if (Array.isArray(data) && data.every(ArrayBuffer.isView)) {
-    return decodeArrayBufferViews(data);
-  }
-
-  return undefined;
-}
-
-function extractMessageData(args: unknown[]): unknown {
-  const [first] = args;
-
-  if (isMessageEventLike(first)) {
-    return first.data;
-  }
-
-  return first;
-}
-
-function isMessageEventLike(value: unknown): value is { data: unknown } {
-  return typeof value === "object" && value !== null && "data" in value;
-}
-
-function decodeArrayBufferViews(views: ArrayBufferView[]): string {
-  const totalLength = views.reduce((sum, view) => sum + view.byteLength, 0);
-  const combined = new Uint8Array(totalLength);
-  let offset = 0;
-
-  for (const view of views) {
-    combined.set(
-      new Uint8Array(view.buffer, view.byteOffset, view.byteLength),
-      offset,
-    );
-    offset += view.byteLength;
-  }
-
-  return new TextDecoder().decode(combined);
 }

--- a/src/ws-stream.test.ts
+++ b/src/ws-stream.test.ts
@@ -3,14 +3,23 @@ import { WebSocket } from "ws";
 
 import { ClientSideConnection, PROTOCOL_VERSION } from "./acp.js";
 import { HEADER_CONNECTION_ID } from "./protocol.js";
-import { createWebSocketStream } from "./ws-stream.js";
+import { MemoryAcpCookieStore, createWebSocketStream } from "./ws-stream.js";
 import { TestAgent } from "./test-support/test-agent.js";
 import { startTestServer } from "./test-support/test-http-server.js";
 
 import type { IncomingMessage } from "node:http";
 import type {
+  Agent,
   AgentSideConnection,
   Client,
+  InitializeRequest,
+  InitializeResponse,
+  LoadSessionRequest,
+  LoadSessionResponse,
+  NewSessionRequest,
+  NewSessionResponse,
+  PromptRequest,
+  PromptResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
   SessionNotification,
@@ -190,6 +199,107 @@ describe("createWebSocketStream", () => {
     }
   });
 
+  it("passes managed cookies and custom headers to custom WebSocket constructors", async () => {
+    const cookieStore = new MemoryAcpCookieStore();
+    cookieStore.store(headersWithSetCookie(["transport=alpha", "route=bravo"]));
+    const instances: FakeWebSocket[] = [];
+    const stream = createWebSocketStream("ws://agent.example/acp", {
+      WebSocket: createFakeWebSocketConstructor(instances),
+      cookieStore,
+      headers: {
+        Authorization: "Bearer token",
+        Cookie: "route=caller; caller=custom",
+      },
+    });
+
+    try {
+      const socket = fakeSocketAt(instances, 0);
+      expect(socket.options).toEqual({
+        headers: {
+          Authorization: "Bearer token",
+          Cookie: "transport=alpha; route=caller; caller=custom",
+        },
+      });
+      socket.open();
+    } finally {
+      await closeStream(stream);
+    }
+  });
+
+  it("stores upgrade cookies for reuse by later WebSocket streams", async () => {
+    const cookieStore = new MemoryAcpCookieStore();
+    const instances: FakeWebSocket[] = [];
+    const WebSocket = createFakeWebSocketConstructor(instances);
+    const firstStream = createWebSocketStream("ws://agent.example/acp", {
+      WebSocket,
+      cookieStore,
+    });
+
+    const firstSocket = fakeSocketAt(instances, 0);
+    firstSocket.upgrade({
+      headers: {
+        "set-cookie": ["transport=alpha; Path=/"],
+      },
+    });
+    firstSocket.open();
+    await closeStream(firstStream);
+
+    const secondStream = createWebSocketStream("ws://agent.example/acp", {
+      WebSocket,
+      cookieStore,
+    });
+
+    try {
+      const secondSocket = fakeSocketAt(instances, 1);
+      expect(secondSocket.options).toEqual({
+        headers: {
+          Cookie: "transport=alpha",
+        },
+      });
+      secondSocket.open();
+    } finally {
+      await closeStream(secondStream);
+    }
+  });
+
+  it("omits managed cookies and upgrade cookie storage when cookies are disabled", async () => {
+    const cookieStore = new MemoryAcpCookieStore();
+    const instances: FakeWebSocket[] = [];
+    const WebSocket = createFakeWebSocketConstructor(instances);
+    const firstStream = createWebSocketStream("ws://agent.example/acp", {
+      WebSocket,
+      cookieStore,
+      cookies: "omit",
+    });
+
+    const firstSocket = fakeSocketAt(instances, 0);
+    expect(firstSocket.options).toEqual({
+      headers: undefined,
+    });
+    firstSocket.upgrade({
+      headers: {
+        "set-cookie": ["transport=alpha; Path=/"],
+      },
+    });
+    firstSocket.open();
+    await closeStream(firstStream);
+
+    const secondStream = createWebSocketStream("ws://agent.example/acp", {
+      WebSocket,
+      cookieStore,
+    });
+
+    try {
+      const secondSocket = fakeSocketAt(instances, 1);
+      expect(secondSocket.options).toEqual({
+        headers: undefined,
+      });
+      secondSocket.open();
+    } finally {
+      await closeStream(secondStream);
+    }
+  });
+
   it("ignores binary, malformed JSON, and non-JSON-RPC messages", async () => {
     const instances: FakeWebSocket[] = [];
     const stream = createWebSocketStream("ws://agent.example/acp", {
@@ -348,6 +458,82 @@ describe("createWebSocketStream", () => {
     }
   });
 
+  it("loads durable sessions after a WebSocket reconnect", async () => {
+    const durableSessions = new Map<string, DurableSessionState>();
+    const connectionIds: string[] = [];
+    const WebSocket = createRecordingWebSocketConstructor(connectionIds);
+    const cookieStore = new MemoryAcpCookieStore();
+    const server = await startTestServer(
+      (conn: AgentSideConnection) =>
+        new DurableSessionAgent(conn, durableSessions),
+    );
+
+    try {
+      const firstUpdates: SessionNotification[] = [];
+      const firstStream = createWebSocketStream(server.wsUrl, {
+        WebSocket,
+        cookieStore,
+      });
+      const firstConn = new ClientSideConnection(
+        () => createTestClient({ updates: firstUpdates }),
+        firstStream,
+      );
+      const initialized = await firstConn.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      });
+      expect(initialized.agentCapabilities?.loadSession).toBe(true);
+      const session = await firstConn.newSession({
+        cwd: "/tmp",
+        mcpServers: [],
+      });
+      await expect(
+        firstConn.prompt({
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "Remember this" }],
+        }),
+      ).resolves.toEqual({ stopReason: "end_turn" });
+      await waitForUpdates(firstUpdates, 1);
+      await closeStream(firstStream);
+
+      expect(durableSessions.has(session.sessionId)).toBe(true);
+
+      const secondUpdates: SessionNotification[] = [];
+      const secondStream = createWebSocketStream(server.wsUrl, {
+        WebSocket,
+        cookieStore,
+      });
+      const secondConn = new ClientSideConnection(
+        () => createTestClient({ updates: secondUpdates }),
+        secondStream,
+      );
+      const reinitialized = await secondConn.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      });
+      expect(reinitialized.agentCapabilities?.loadSession).toBe(true);
+
+      // Production agents must authorize session/load against the authenticated
+      // principal. This SDK transport test omits auth because there is no
+      // generic auth layer in the SDK.
+      await expect(
+        secondConn.loadSession({
+          sessionId: session.sessionId,
+          cwd: "/tmp",
+          mcpServers: [],
+        }),
+      ).resolves.toEqual({});
+      await waitForUpdates(secondUpdates, firstUpdates.length);
+      await closeStream(secondStream);
+
+      expect(connectionIds).toHaveLength(2);
+      expect(connectionIds[0]).not.toBe(connectionIds[1]);
+      expect(secondUpdates).toEqual(firstUpdates);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("keeps multiple sessions isolated through the SDK client abstraction", async () => {
     const updates: SessionNotification[] = [];
     const server = await startTestServer();
@@ -405,6 +591,79 @@ describe("createWebSocketStream", () => {
   });
 });
 
+interface DurableSessionState {
+  readonly cwd: string;
+  readonly history: SessionNotification[];
+}
+
+class DurableSessionAgent implements Agent {
+  constructor(
+    private readonly connection: AgentSideConnection,
+    private readonly sessions: Map<string, DurableSessionState>,
+  ) {}
+
+  initialize(_params: InitializeRequest): Promise<InitializeResponse> {
+    return Promise.resolve({
+      protocolVersion: PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: true,
+      },
+    });
+  }
+
+  newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
+    const sessionId = globalThis.crypto.randomUUID();
+    this.sessions.set(sessionId, {
+      cwd: params.cwd,
+      history: [],
+    });
+    return Promise.resolve({ sessionId });
+  }
+
+  async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
+    const session = this.sessions.get(params.sessionId);
+    if (!session) {
+      throw new Error(`Unknown durable session: ${params.sessionId}`);
+    }
+
+    for (const update of session.history) {
+      await this.connection.sessionUpdate(update);
+    }
+
+    return {};
+  }
+
+  async prompt(params: PromptRequest): Promise<PromptResponse> {
+    const session = this.sessions.get(params.sessionId);
+    if (!session) {
+      throw new Error(`Unknown durable session: ${params.sessionId}`);
+    }
+
+    const update: SessionNotification = {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: `durable-history:${session.cwd}`,
+        },
+      },
+    };
+    session.history.push(update);
+    await this.connection.sessionUpdate(update);
+
+    return { stopReason: "end_turn" };
+  }
+
+  cancel(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  authenticate(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
 interface TestClientState {
   readonly updates: SessionNotification[];
   readonly permissionRequests?: RequestPermissionRequest[];
@@ -443,6 +702,41 @@ async function readMessage(
   return result.value;
 }
 
+async function waitForUpdates(
+  updates: readonly SessionNotification[],
+  count: number,
+): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (updates.length < count) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${count} session updates`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+
+function createRecordingWebSocketConstructor(
+  connectionIds: string[],
+): WebSocketConstructor {
+  return class RecordingWebSocket extends WebSocket {
+    constructor(
+      url: string,
+      protocols?: string | string[],
+      options?: { headers?: Record<string, string> },
+    ) {
+      super(url, protocols, options);
+      this.once("upgrade", (message: IncomingMessage) => {
+        const connectionId =
+          message.headers[HEADER_CONNECTION_ID.toLowerCase()];
+        if (typeof connectionId === "string") {
+          connectionIds.push(connectionId);
+        }
+      });
+    }
+  } as unknown as WebSocketConstructor;
+}
+
 function createFakeWebSocketConstructor(
   instances: FakeWebSocket[],
 ): WebSocketConstructor {
@@ -469,6 +763,16 @@ function fakeSocketAt(
   }
 
   return socket;
+}
+
+function headersWithSetCookie(values: readonly string[]): Headers {
+  const headers = new Headers();
+
+  Object.defineProperty(headers, "getSetCookie", {
+    value: () => values,
+  });
+
+  return headers;
 }
 
 class FakeWebSocket {
@@ -521,6 +825,10 @@ class FakeWebSocket {
 
   receive(data: unknown, isBinary = false): void {
     this.emit("message", { data, isBinary });
+  }
+
+  upgrade(message: unknown): void {
+    this.emit("upgrade", message);
   }
 
   private emit(type: string, event: unknown): void {

--- a/src/ws-stream.test.ts
+++ b/src/ws-stream.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import { WebSocket } from "ws";
 
 import { ClientSideConnection, PROTOCOL_VERSION } from "./acp.js";
+import { HEADER_CONNECTION_ID } from "./protocol.js";
 import { createWebSocketStream } from "./ws-stream.js";
 import { TestAgent } from "./test-support/test-agent.js";
 import { startTestServer } from "./test-support/test-http-server.js";
 
+import type { IncomingMessage } from "node:http";
 import type {
   AgentSideConnection,
   Client,
@@ -40,7 +42,76 @@ const initializeResponse = {
   },
 } satisfies AnyMessage;
 
+const sessionNewRequest = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "session/new",
+  params: {
+    cwd: "/tmp",
+    mcpServers: [],
+  },
+} satisfies AnyMessage;
+
 describe("createWebSocketStream", () => {
+  it("exposes the ACP connection ID during the WebSocket handshake", async () => {
+    const server = await startTestServer();
+    const socket = new WebSocket(server.wsUrl);
+    const upgrade = new Promise<IncomingMessage>((resolve, reject) => {
+      socket.once("upgrade", resolve);
+      socket.once("error", reject);
+    });
+
+    try {
+      const request = await upgrade;
+      expect(request.headers[HEADER_CONNECTION_ID.toLowerCase()]).toMatch(
+        /^[0-9a-f-]{36}$/,
+      );
+    } finally {
+      socket.close();
+      await server.close();
+    }
+  });
+
+  it("closes pre-created WebSocket connections when the first frame is not initialize", async () => {
+    const server = await startTestServer();
+    const socket = new WebSocket(server.wsUrl);
+    const upgrade = new Promise<IncomingMessage>((resolve, reject) => {
+      socket.once("upgrade", resolve);
+      socket.once("error", reject);
+    });
+    const close = new Promise<{ code: number; reason: string }>((resolve) => {
+      socket.once("close", (code: number, reason: Buffer) => {
+        resolve({ code, reason: reason.toString("utf8") });
+      });
+    });
+
+    try {
+      const request = await upgrade;
+      const connectionId = request.headers[HEADER_CONNECTION_ID.toLowerCase()];
+      expect(connectionId).toMatch(/^[0-9a-f-]{36}$/);
+
+      socket.send(JSON.stringify(sessionNewRequest));
+
+      await expect(close).resolves.toEqual({
+        code: 1002,
+        reason: "First message must be initialize",
+      });
+
+      const response = await fetch(server.url, {
+        method: "GET",
+        headers: {
+          Accept: "text/event-stream",
+          [HEADER_CONNECTION_ID]: String(connectionId),
+        },
+      });
+
+      expect(response.status).toBe(404);
+    } finally {
+      socket.close();
+      await server.close();
+    }
+  });
+
   it("uses the custom WebSocket constructor and queues writes until the socket opens", async () => {
     const instances: FakeWebSocket[] = [];
     const stream = createWebSocketStream("ws://agent.example/acp", {

--- a/src/ws-stream.test.ts
+++ b/src/ws-stream.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 
 import { ClientSideConnection, PROTOCOL_VERSION } from "./acp.js";
@@ -301,6 +301,7 @@ describe("createWebSocketStream", () => {
   });
 
   it("ignores binary, malformed JSON, and non-JSON-RPC messages", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const instances: FakeWebSocket[] = [];
     const stream = createWebSocketStream("ws://agent.example/acp", {
       WebSocket: createFakeWebSocketConstructor(instances),
@@ -322,8 +323,10 @@ describe("createWebSocketStream", () => {
       socket.receive(JSON.stringify(initializeResponse));
 
       expect(await readMessage(reader)).toEqual(initializeResponse);
+      expect(warn).toHaveBeenCalledTimes(2);
     } finally {
       reader.releaseLock();
+      warn.mockRestore();
       await closeStream(stream);
     }
   });

--- a/src/ws-stream.test.ts
+++ b/src/ws-stream.test.ts
@@ -199,6 +199,31 @@ describe("createWebSocketStream", () => {
     }
   });
 
+  it("does not emit unhandled rejections when the socket closes before the first write", async () => {
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown): void => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+    const instances: FakeWebSocket[] = [];
+    const stream = createWebSocketStream("ws://agent.example/acp", {
+      WebSocket: createFakeWebSocketConstructor(instances),
+    });
+    const reader = stream.readable.getReader();
+
+    try {
+      fakeSocketAt(instances, 0).close();
+
+      expect(await reader.read()).toEqual({ done: true, value: undefined });
+      await waitForUnhandledRejections();
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+      reader.releaseLock();
+      await closeStream(stream);
+    }
+  });
+
   it("passes managed cookies and custom headers to custom WebSocket constructors", async () => {
     const cookieStore = new MemoryAcpCookieStore();
     cookieStore.store(headersWithSetCookie(["transport=alpha", "route=bravo"]));
@@ -717,6 +742,10 @@ async function waitForUpdates(
 
     await new Promise((resolve) => setTimeout(resolve, 1));
   }
+}
+
+async function waitForUnhandledRejections(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 function createRecordingWebSocketConstructor(

--- a/src/ws-stream.test.ts
+++ b/src/ws-stream.test.ts
@@ -112,6 +112,49 @@ describe("createWebSocketStream", () => {
     }
   });
 
+  it("ignores binary WebSocket initialize frames", async () => {
+    const server = await startTestServer();
+    const socket = new WebSocket(server.wsUrl);
+    const upgrade = new Promise<IncomingMessage>((resolve, reject) => {
+      socket.once("upgrade", resolve);
+      socket.once("error", reject);
+    });
+    const close = new Promise<{ code: number; reason: string }>((resolve) => {
+      socket.once("close", (code: number, reason: Buffer) => {
+        resolve({ code, reason: reason.toString("utf8") });
+      });
+    });
+
+    try {
+      const request = await upgrade;
+      const connectionId = request.headers[HEADER_CONNECTION_ID.toLowerCase()];
+      expect(connectionId).toMatch(/^[0-9a-f-]{36}$/);
+
+      socket.send(Buffer.from(JSON.stringify(initializeRequest)), {
+        binary: true,
+      });
+      socket.send(JSON.stringify(sessionNewRequest));
+
+      await expect(close).resolves.toEqual({
+        code: 1002,
+        reason: "First message must be initialize",
+      });
+
+      const response = await fetch(server.url, {
+        method: "GET",
+        headers: {
+          Accept: "text/event-stream",
+          [HEADER_CONNECTION_ID]: String(connectionId),
+        },
+      });
+
+      expect(response.status).toBe(404);
+    } finally {
+      socket.close();
+      await server.close();
+    }
+  });
+
   it("uses the custom WebSocket constructor and queues writes until the socket opens", async () => {
     const instances: FakeWebSocket[] = [];
     const stream = createWebSocketStream("ws://agent.example/acp", {
@@ -158,6 +201,12 @@ describe("createWebSocketStream", () => {
       const socket = fakeSocketAt(instances, 0);
       socket.open();
       socket.receive(new Uint8Array([1, 2, 3]), true);
+      socket.receive(
+        new TextEncoder().encode(JSON.stringify(initializeResponse)),
+      );
+      socket.receive(
+        new TextEncoder().encode(JSON.stringify(initializeResponse)).buffer,
+      );
       socket.receive("not json");
       socket.receive(JSON.stringify({ hello: "world" }));
       socket.receive(JSON.stringify(initializeResponse));

--- a/src/ws-stream.test.ts
+++ b/src/ws-stream.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+
+import { ClientSideConnection, PROTOCOL_VERSION } from "./acp.js";
+import { createWebSocketStream } from "./ws-stream.js";
+import { TestAgent } from "./test-support/test-agent.js";
+import { startTestServer } from "./test-support/test-http-server.js";
+
+import type {
+  AgentSideConnection,
+  Client,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+  SessionNotification,
+} from "./acp.js";
+import type { AnyMessage } from "./jsonrpc.js";
+import type { Stream } from "./stream.js";
+import type { WebSocketConstructor } from "./ws-stream.js";
+
+const nodeWebSocket = WebSocket as unknown as WebSocketConstructor;
+
+const initializeRequest = {
+  jsonrpc: "2.0",
+  id: 0,
+  method: "initialize",
+  params: {
+    protocolVersion: PROTOCOL_VERSION,
+    clientCapabilities: {},
+  },
+} satisfies AnyMessage;
+
+const initializeResponse = {
+  jsonrpc: "2.0",
+  id: 0,
+  result: {
+    protocolVersion: PROTOCOL_VERSION,
+    agentCapabilities: {
+      loadSession: false,
+    },
+  },
+} satisfies AnyMessage;
+
+describe("createWebSocketStream", () => {
+  it("uses the custom WebSocket constructor and queues writes until the socket opens", async () => {
+    const instances: FakeWebSocket[] = [];
+    const stream = createWebSocketStream("ws://agent.example/acp", {
+      WebSocket: createFakeWebSocketConstructor(instances),
+      protocols: ["acp"],
+      headers: { Authorization: "Bearer token" },
+    });
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+
+    try {
+      const socket = fakeSocketAt(instances, 0);
+      expect(socket.url).toBe("ws://agent.example/acp");
+      expect(socket.protocols).toEqual(["acp"]);
+      expect(socket.options).toEqual({
+        headers: { Authorization: "Bearer token" },
+      });
+
+      const write = writer.write(initializeRequest);
+      await Promise.resolve();
+      expect(socket.sent).toEqual([]);
+
+      socket.open();
+      await write;
+      expect(socket.sent).toEqual([JSON.stringify(initializeRequest)]);
+
+      socket.receive(JSON.stringify(initializeResponse));
+      expect(await readMessage(reader)).toEqual(initializeResponse);
+    } finally {
+      reader.releaseLock();
+      await writer.close().catch(() => undefined);
+      writer.releaseLock();
+    }
+  });
+
+  it("ignores binary, malformed JSON, and non-JSON-RPC messages", async () => {
+    const instances: FakeWebSocket[] = [];
+    const stream = createWebSocketStream("ws://agent.example/acp", {
+      WebSocket: createFakeWebSocketConstructor(instances),
+    });
+    const reader = stream.readable.getReader();
+
+    try {
+      const socket = fakeSocketAt(instances, 0);
+      socket.open();
+      socket.receive(new Uint8Array([1, 2, 3]), true);
+      socket.receive("not json");
+      socket.receive(JSON.stringify({ hello: "world" }));
+      socket.receive(JSON.stringify(initializeResponse));
+
+      expect(await readMessage(reader)).toEqual(initializeResponse);
+    } finally {
+      reader.releaseLock();
+      await closeStream(stream);
+    }
+  });
+
+  it("closes the readable stream when the socket closes", async () => {
+    const instances: FakeWebSocket[] = [];
+    const stream = createWebSocketStream("ws://agent.example/acp", {
+      WebSocket: createFakeWebSocketConstructor(instances),
+    });
+    const reader = stream.readable.getReader();
+
+    try {
+      const socket = fakeSocketAt(instances, 0);
+      socket.open();
+      socket.close();
+
+      expect(await reader.read()).toEqual({ done: true, value: undefined });
+    } finally {
+      reader.releaseLock();
+    }
+  });
+
+  it("runs initialize, newSession, and prompt through ClientSideConnection", async () => {
+    const updates: SessionNotification[] = [];
+    const server = await startTestServer(
+      (conn: AgentSideConnection) => new TestAgent(conn, { chunkCount: 2 }),
+    );
+    const stream = createWebSocketStream(server.wsUrl, {
+      WebSocket: nodeWebSocket,
+    });
+    const conn = new ClientSideConnection(
+      () => createTestClient({ updates }),
+      stream,
+    );
+
+    try {
+      expect(
+        await conn.initialize({
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {},
+        }),
+      ).toMatchObject({
+        protocolVersion: PROTOCOL_VERSION,
+        agentCapabilities: { loadSession: false },
+      });
+
+      const session = await conn.newSession({ cwd: "/tmp", mcpServers: [] });
+      expect(session.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+
+      await expect(
+        conn.prompt({
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "Hello" }],
+        }),
+      ).resolves.toEqual({ stopReason: "end_turn" });
+      expect(updates).toHaveLength(2);
+      expect(updates).toMatchObject([
+        {
+          sessionId: session.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { text: "chunk-1" },
+          },
+        },
+        {
+          sessionId: session.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { text: "chunk-2" },
+          },
+        },
+      ]);
+    } finally {
+      await closeStream(stream);
+      await server.close();
+    }
+  });
+
+  it("round-trips permission requests through ClientSideConnection", async () => {
+    const updates: SessionNotification[] = [];
+    const permissionRequests: RequestPermissionRequest[] = [];
+    const server = await startTestServer(
+      (conn: AgentSideConnection) =>
+        new TestAgent(conn, { enablePermission: true }),
+    );
+    const stream = createWebSocketStream(server.wsUrl, {
+      WebSocket: nodeWebSocket,
+    });
+    const conn = new ClientSideConnection(
+      () => createTestClient({ updates, permissionRequests }),
+      stream,
+    );
+
+    try {
+      await conn.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      });
+      const session = await conn.newSession({ cwd: "/tmp", mcpServers: [] });
+
+      await expect(
+        conn.prompt({
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "Hello" }],
+        }),
+      ).resolves.toEqual({ stopReason: "end_turn" });
+
+      expect(permissionRequests).toHaveLength(1);
+      expect(permissionRequests[0]).toMatchObject({
+        sessionId: session.sessionId,
+        toolCall: {
+          toolCallId: "permission-tool",
+          title: "Permission tool",
+        },
+      });
+      expect(updates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            sessionId: session.sessionId,
+            update: expect.objectContaining({
+              sessionUpdate: "agent_message_chunk",
+              content: expect.objectContaining({
+                text: "permission-selected-allow",
+              }),
+            }),
+          }),
+        ]),
+      );
+    } finally {
+      await closeStream(stream);
+      await server.close();
+    }
+  });
+
+  it("keeps multiple sessions isolated through the SDK client abstraction", async () => {
+    const updates: SessionNotification[] = [];
+    const server = await startTestServer();
+    const stream = createWebSocketStream(server.wsUrl, {
+      WebSocket: nodeWebSocket,
+    });
+    const conn = new ClientSideConnection(
+      () => createTestClient({ updates }),
+      stream,
+    );
+
+    try {
+      await conn.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      });
+      const firstSession = await conn.newSession({
+        cwd: "/tmp",
+        mcpServers: [],
+      });
+      const secondSession = await conn.newSession({
+        cwd: "/tmp/other",
+        mcpServers: [],
+      });
+
+      await Promise.all([
+        conn.prompt({
+          sessionId: firstSession.sessionId,
+          prompt: [{ type: "text", text: "First" }],
+        }),
+        conn.prompt({
+          sessionId: secondSession.sessionId,
+          prompt: [{ type: "text", text: "Second" }],
+        }),
+      ]);
+
+      expect(updates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ sessionId: firstSession.sessionId }),
+          expect.objectContaining({ sessionId: secondSession.sessionId }),
+        ]),
+      );
+      expect(
+        updates.filter((update) => update.sessionId === firstSession.sessionId),
+      ).toHaveLength(1);
+      expect(
+        updates.filter(
+          (update) => update.sessionId === secondSession.sessionId,
+        ),
+      ).toHaveLength(1);
+    } finally {
+      await closeStream(stream);
+      await server.close();
+    }
+  });
+});
+
+interface TestClientState {
+  readonly updates: SessionNotification[];
+  readonly permissionRequests?: RequestPermissionRequest[];
+}
+
+function createTestClient(state: TestClientState): Client {
+  return {
+    requestPermission: (params): Promise<RequestPermissionResponse> => {
+      state.permissionRequests?.push(params);
+      return Promise.resolve({
+        outcome: {
+          outcome: "selected",
+          optionId: "allow",
+        },
+      });
+    },
+    sessionUpdate: (params): Promise<void> => {
+      state.updates.push(params);
+      return Promise.resolve();
+    },
+  };
+}
+
+async function closeStream(stream: Stream): Promise<void> {
+  await stream.writable.close().catch(() => undefined);
+}
+
+async function readMessage(
+  reader: ReadableStreamDefaultReader<AnyMessage>,
+): Promise<AnyMessage> {
+  const result = await reader.read();
+  if (result.done) {
+    throw new Error("Expected a message");
+  }
+
+  return result.value;
+}
+
+function createFakeWebSocketConstructor(
+  instances: FakeWebSocket[],
+): WebSocketConstructor {
+  return class extends FakeWebSocket {
+    constructor(
+      url: string,
+      protocols?: string | string[],
+      options?: { headers?: Record<string, string> },
+    ) {
+      super(url, protocols, options);
+      instances.push(this);
+    }
+  };
+}
+
+function fakeSocketAt(
+  instances: readonly FakeWebSocket[],
+  index: number,
+): FakeWebSocket {
+  const socket = instances[index];
+
+  if (!socket) {
+    throw new Error(`Expected fake WebSocket at index ${index}`);
+  }
+
+  return socket;
+}
+
+class FakeWebSocket {
+  readonly sent: string[] = [];
+  readonly listeners = new Map<string, Set<(event: unknown) => void>>();
+  readyState = 0;
+
+  constructor(
+    readonly url: string,
+    readonly protocols?: string | string[],
+    readonly options?: { headers?: Record<string, string> },
+  ) {}
+
+  send(data: string): void {
+    if (this.readyState !== 1) {
+      throw new Error("Fake WebSocket is not open");
+    }
+
+    this.sent.push(data);
+  }
+
+  close(): void {
+    if (this.readyState === 3) {
+      return;
+    }
+
+    this.readyState = 3;
+    this.emit("close", {});
+  }
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    let listeners = this.listeners.get(type);
+
+    if (!listeners) {
+      listeners = new Set();
+      this.listeners.set(type, listeners);
+    }
+
+    listeners.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  open(): void {
+    this.readyState = 1;
+    this.emit("open", {});
+  }
+
+  receive(data: unknown, isBinary = false): void {
+    this.emit("message", { data, isBinary });
+  }
+
+  private emit(type: string, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}

--- a/src/ws-stream.ts
+++ b/src/ws-stream.ts
@@ -1,5 +1,7 @@
+import { MemoryAcpCookieStore } from "./cookie-store.js";
 import { isJsonRpcMessage } from "./jsonrpc.js";
 import { onWebSocket, webSocketMessageToString } from "./ws-utils.js";
+import type { AcpCookieStore } from "./cookie-store.js";
 import type { WebSocketLike } from "./ws-utils.js";
 import type { AnyMessage } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
@@ -14,7 +16,19 @@ export interface WebSocketStreamOptions {
   readonly headers?: Record<string, string>;
   /** WebSocket constructor to use. Defaults to `globalThis.WebSocket`. */
   readonly WebSocket?: WebSocketConstructor;
+  /** Cookie handling policy for transport requests. Defaults to `include`. */
+  readonly cookies?: "include" | "omit";
+  /**
+   * Caller-owned affinity cookie store to reuse across reconnects.
+   *
+   * Browser WebSocket uses the platform cookie jar; Node/custom constructors
+   * that support headers receive cookies from this store.
+   */
+  readonly cookieStore?: AcpCookieStore;
 }
+
+export { MemoryAcpCookieStore } from "./cookie-store.js";
+export type { AcpCookieStore } from "./cookie-store.js";
 
 /** Constructor shape used by `createWebSocketStream`. */
 export interface WebSocketConstructor {
@@ -34,6 +48,15 @@ const SOCKET_OPEN = 1;
  *
  * Sends and receives ACP JSON-RPC messages as WebSocket text frames. In Node,
  * pass a WebSocket constructor such as `ws.WebSocket` via `options.WebSocket`.
+ * Browser WebSocket uses the platform cookie jar; Node/custom constructors
+ * receive merged `Cookie` headers when supported and can store upgrade
+ * `Set-Cookie` headers in a caller-owned `AcpCookieStore`.
+ *
+ * ACP v1 reconnect creates a new transport connection; callers should save the
+ * ACP `sessionId`, create a new stream with the same auth headers/cookie store,
+ * call `initialize`, verify `agentCapabilities.loadSession`, then call
+ * `session/load`. Agents must authorize `session/load`, and ACP v1 does not
+ * replay in-flight transport messages emitted while disconnected.
  */
 export function createWebSocketStream(
   serverUrl: string,
@@ -46,6 +69,8 @@ class WebSocketStreamTransport {
   readonly stream: Stream;
 
   private readonly socket: WebSocketLike;
+  private readonly cookieStore: AcpCookieStore;
+  private readonly ownsCookieStore: boolean;
   private readableController:
     | ReadableStreamDefaultController<AnyMessage>
     | undefined;
@@ -57,8 +82,15 @@ class WebSocketStreamTransport {
 
   constructor(serverUrl: string, options: WebSocketStreamOptions) {
     const WebSocketCtor = resolveWebSocket(options.WebSocket);
+    const cookiePolicy = options.cookies ?? "include";
+    this.cookieStore = options.cookieStore ?? new MemoryAcpCookieStore();
+    this.ownsCookieStore = options.cookieStore === undefined;
     this.socket = new WebSocketCtor(serverUrl, options.protocols, {
-      headers: options.headers,
+      headers: createConstructorHeaders(
+        options.headers,
+        cookiePolicy,
+        this.cookieStore,
+      ),
     });
 
     this.openPromise = new Promise<void>((resolve, reject) => {
@@ -92,6 +124,17 @@ class WebSocketStreamTransport {
         this.errorReadable(error);
       }),
     );
+
+    if (cookiePolicy === "include") {
+      this.detachListeners.push(
+        onWebSocket(this.socket, "upgrade", (message) => {
+          const headers = upgradeHeaders(message);
+          if (headers) {
+            this.cookieStore.store(headers);
+          }
+        }),
+      );
+    }
 
     this.stream = {
       readable: new ReadableStream<AnyMessage>({
@@ -180,12 +223,19 @@ class WebSocketStreamTransport {
     }
   }
 
+  private clearOwnedCookieStore(): void {
+    if (this.ownsCookieStore) {
+      this.cookieStore.clear();
+    }
+  }
+
   private closeReadable(): void {
     if (this.isClosed) {
       return;
     }
 
     this.isClosed = true;
+    this.clearOwnedCookieStore();
 
     for (const detach of this.detachListeners.splice(0)) {
       detach();
@@ -209,6 +259,7 @@ class WebSocketStreamTransport {
     }
 
     this.isClosed = true;
+    this.clearOwnedCookieStore();
 
     for (const detach of this.detachListeners.splice(0)) {
       detach();
@@ -221,6 +272,78 @@ class WebSocketStreamTransport {
 
     this.readableController?.error(error);
   }
+}
+
+function createConstructorHeaders(
+  headers: Record<string, string> | undefined,
+  cookiePolicy: "include" | "omit",
+  cookieStore: AcpCookieStore,
+): Record<string, string> | undefined {
+  const result: Record<string, string> = headers ? { ...headers } : {};
+
+  if (cookiePolicy === "include") {
+    const requestHeaders = new Headers(headers);
+    cookieStore.apply(requestHeaders);
+    const cookieHeader = requestHeaders.get("Cookie");
+
+    if (cookieHeader) {
+      result[findHeaderName(result, "Cookie") ?? "Cookie"] = cookieHeader;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function findHeaderName(
+  headers: Record<string, string>,
+  name: string,
+): string | undefined {
+  return Object.keys(headers).find(
+    (candidate) => candidate.toLowerCase() === name.toLowerCase(),
+  );
+}
+
+function upgradeHeaders(message: unknown): Headers | undefined {
+  if (message instanceof Headers) {
+    return message;
+  }
+
+  if (!isRecord(message) || !("headers" in message)) {
+    return undefined;
+  }
+
+  return headersFromRecord(message.headers);
+}
+
+function headersFromRecord(value: unknown): Headers | undefined {
+  if (value instanceof Headers) {
+    return value;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const headers = new Headers();
+
+  for (const [name, headerValue] of Object.entries(value)) {
+    if (Array.isArray(headerValue)) {
+      for (const item of headerValue) {
+        headers.append(name, String(item));
+      }
+      continue;
+    }
+
+    if (headerValue !== undefined) {
+      headers.set(name, String(headerValue));
+    }
+  }
+
+  return headers;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 function resolveWebSocket(

--- a/src/ws-stream.ts
+++ b/src/ws-stream.ts
@@ -5,18 +5,18 @@ import type { AnyMessage } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
 
 export interface WebSocketStreamOptions {
-  /** WebSocket subprotocols. */
+  /** WebSocket subprotocols to request. */
   readonly protocols?: string[];
   /**
-   * Custom headers for runtimes/constructors that support them, such as Node.js
-   * `ws`. Browsers ignore custom headers because the browser WebSocket API does
-   * not expose a headers option.
+   * Headers for WebSocket constructors that support them, such as Node `ws`.
+   * Browser WebSocket constructors ignore custom headers.
    */
   readonly headers?: Record<string, string>;
-  /** Custom WebSocket constructor, for example `ws.WebSocket` in Node.js. */
+  /** WebSocket constructor to use. Defaults to `globalThis.WebSocket`. */
   readonly WebSocket?: WebSocketConstructor;
 }
 
+/** Constructor shape used by `createWebSocketStream`. */
 export interface WebSocketConstructor {
   new (
     url: string,
@@ -25,14 +25,15 @@ export interface WebSocketConstructor {
   ): WebSocketLike;
 }
 
+export type { WebSocketLike };
+
 const SOCKET_OPEN = 1;
 
 /**
- * Creates an ACP Stream that speaks JSON-RPC over WebSocket text frames.
+ * Creates an ACP Stream over WebSocket.
  *
- * Browser WebSocket constructors do not support custom headers. The `headers`
- * option is passed as a best-effort third constructor argument for runtimes such
- * as Node.js `ws` that accept it.
+ * Sends and receives ACP JSON-RPC messages as WebSocket text frames. In Node,
+ * pass a WebSocket constructor such as `ws.WebSocket` via `options.WebSocket`.
  */
 export function createWebSocketStream(
   serverUrl: string,

--- a/src/ws-stream.ts
+++ b/src/ws-stream.ts
@@ -97,6 +97,7 @@ class WebSocketStreamTransport {
       this.resolveOpen = resolve;
       this.rejectOpen = reject;
     });
+    this.openPromise.catch(() => undefined);
 
     this.detachListeners.push(
       onWebSocket(this.socket, "open", () => {

--- a/src/ws-stream.ts
+++ b/src/ws-stream.ts
@@ -1,0 +1,239 @@
+import { isJsonRpcMessage } from "./jsonrpc.js";
+import { onWebSocket, webSocketMessageToString } from "./ws-utils.js";
+import type { WebSocketLike } from "./ws-utils.js";
+import type { AnyMessage } from "./jsonrpc.js";
+import type { Stream } from "./stream.js";
+
+export interface WebSocketStreamOptions {
+  /** WebSocket subprotocols. */
+  readonly protocols?: string[];
+  /**
+   * Custom headers for runtimes/constructors that support them, such as Node.js
+   * `ws`. Browsers ignore custom headers because the browser WebSocket API does
+   * not expose a headers option.
+   */
+  readonly headers?: Record<string, string>;
+  /** Custom WebSocket constructor, for example `ws.WebSocket` in Node.js. */
+  readonly WebSocket?: WebSocketConstructor;
+}
+
+export interface WebSocketConstructor {
+  new (
+    url: string,
+    protocols?: string | string[],
+    options?: { headers?: Record<string, string> },
+  ): WebSocketLike;
+}
+
+const SOCKET_OPEN = 1;
+
+/**
+ * Creates an ACP Stream that speaks JSON-RPC over WebSocket text frames.
+ *
+ * Browser WebSocket constructors do not support custom headers. The `headers`
+ * option is passed as a best-effort third constructor argument for runtimes such
+ * as Node.js `ws` that accept it.
+ */
+export function createWebSocketStream(
+  serverUrl: string,
+  options: WebSocketStreamOptions = {},
+): Stream {
+  return new WebSocketStreamTransport(serverUrl, options).stream;
+}
+
+class WebSocketStreamTransport {
+  readonly stream: Stream;
+
+  private readonly socket: WebSocketLike;
+  private readableController:
+    | ReadableStreamDefaultController<AnyMessage>
+    | undefined;
+  private isClosed = false;
+  private openPromise: Promise<void> | undefined;
+  private resolveOpen: (() => void) | undefined;
+  private rejectOpen: ((error: unknown) => void) | undefined;
+  private readonly detachListeners: Array<() => void> = [];
+
+  constructor(serverUrl: string, options: WebSocketStreamOptions) {
+    const WebSocketCtor = resolveWebSocket(options.WebSocket);
+    this.socket = new WebSocketCtor(serverUrl, options.protocols, {
+      headers: options.headers,
+    });
+
+    this.openPromise = new Promise<void>((resolve, reject) => {
+      this.resolveOpen = resolve;
+      this.rejectOpen = reject;
+    });
+
+    this.detachListeners.push(
+      onWebSocket(this.socket, "open", () => {
+        this.resolveOpen?.();
+        this.resolveOpen = undefined;
+        this.rejectOpen = undefined;
+        this.openPromise = undefined;
+      }),
+    );
+
+    this.detachListeners.push(
+      onWebSocket(this.socket, "message", (...args) => {
+        this.handleSocketMessage(args);
+      }),
+    );
+
+    this.detachListeners.push(
+      onWebSocket(this.socket, "close", () => {
+        this.closeReadable();
+      }),
+    );
+
+    this.detachListeners.push(
+      onWebSocket(this.socket, "error", (error) => {
+        this.errorReadable(error);
+      }),
+    );
+
+    this.stream = {
+      readable: new ReadableStream<AnyMessage>({
+        start: (controller) => {
+          this.readableController = controller;
+        },
+        cancel: () => {
+          this.close();
+        },
+      }),
+      writable: new WritableStream<AnyMessage>({
+        write: async (message) => {
+          await this.sendMessage(message);
+        },
+        close: () => {
+          this.close();
+        },
+        abort: () => {
+          this.close();
+        },
+      }),
+    };
+  }
+
+  private async sendMessage(message: AnyMessage): Promise<void> {
+    if (this.isClosed) {
+      throw new Error("ACP WebSocket stream is closed");
+    }
+
+    await this.waitForOpen();
+
+    if (this.isClosed) {
+      throw new Error("ACP WebSocket stream is closed");
+    }
+
+    this.socket.send(JSON.stringify(message));
+  }
+
+  private async waitForOpen(): Promise<void> {
+    if (
+      this.socket.readyState === undefined ||
+      this.socket.readyState === SOCKET_OPEN
+    ) {
+      return;
+    }
+
+    await this.openPromise;
+  }
+
+  private handleSocketMessage(args: unknown[]): void {
+    if (this.isClosed) {
+      return;
+    }
+
+    const text = webSocketMessageToString(args);
+    if (text === undefined) {
+      return;
+    }
+
+    let value: unknown;
+    try {
+      value = JSON.parse(text);
+    } catch (error) {
+      console.warn("Ignoring malformed ACP WebSocket JSON message:", error);
+      return;
+    }
+
+    if (!isJsonRpcMessage(value)) {
+      console.warn("Ignoring non-JSON-RPC ACP WebSocket message:", value);
+      return;
+    }
+
+    this.readableController?.enqueue(value);
+  }
+
+  private close(): void {
+    this.closeSocket();
+    this.closeReadable();
+  }
+
+  private closeSocket(): void {
+    try {
+      this.socket.close();
+    } catch (error) {
+      console.warn("Failed to close ACP WebSocket:", error);
+    }
+  }
+
+  private closeReadable(): void {
+    if (this.isClosed) {
+      return;
+    }
+
+    this.isClosed = true;
+
+    for (const detach of this.detachListeners.splice(0)) {
+      detach();
+    }
+
+    this.rejectOpen?.(new Error("ACP WebSocket stream closed before open"));
+    this.rejectOpen = undefined;
+    this.resolveOpen = undefined;
+    this.openPromise = undefined;
+
+    try {
+      this.readableController?.close();
+    } catch {
+      // Stream may already be closed/cancelled.
+    }
+  }
+
+  private errorReadable(error: unknown): void {
+    if (this.isClosed) {
+      return;
+    }
+
+    this.isClosed = true;
+
+    for (const detach of this.detachListeners.splice(0)) {
+      detach();
+    }
+
+    this.rejectOpen?.(error);
+    this.rejectOpen = undefined;
+    this.resolveOpen = undefined;
+    this.openPromise = undefined;
+
+    this.readableController?.error(error);
+  }
+}
+
+function resolveWebSocket(
+  WebSocketCtor: WebSocketConstructor | undefined,
+): WebSocketConstructor {
+  if (WebSocketCtor) {
+    return WebSocketCtor;
+  }
+
+  if (typeof globalThis.WebSocket === "function") {
+    return globalThis.WebSocket as unknown as WebSocketConstructor;
+  }
+
+  throw new Error(
+    "createWebSocketStream requires globalThis.WebSocket or options.WebSocket",
+  );
+}

--- a/src/ws-utils.test.ts
+++ b/src/ws-utils.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { onWebSocket, webSocketMessageToString } from "./ws-utils.js";
+
+describe("webSocketMessageToString", () => {
+  it("accepts only WebSocket text message payloads", () => {
+    expect(webSocketMessageToString(["text"])).toBe("text");
+    expect(webSocketMessageToString([{ data: "event text" }])).toBe(
+      "event text",
+    );
+    expect(
+      webSocketMessageToString([new TextEncoder().encode("binary text")]),
+    ).toBe(undefined);
+    expect(
+      webSocketMessageToString([
+        new TextEncoder().encode("binary text").buffer,
+      ]),
+    ).toBe(undefined);
+    expect(
+      webSocketMessageToString([[new TextEncoder().encode("binary text")]]),
+    ).toBe(undefined);
+  });
+});
+
+describe("onWebSocket", () => {
+  it("normalizes Node ws text frames before shared message parsing", () => {
+    const socket = new EventEmitterWebSocket();
+    const messages: Array<string | undefined> = [];
+
+    onWebSocket(socket, "message", (...args) => {
+      messages.push(webSocketMessageToString(args));
+    });
+
+    socket.emit("message", new TextEncoder().encode("text frame"), false);
+    socket.emit("message", new TextEncoder().encode("binary frame"), true);
+
+    expect(messages).toEqual(["text frame", undefined]);
+  });
+});
+
+class EventEmitterWebSocket {
+  private readonly listeners = new Map<
+    string,
+    Set<(...args: unknown[]) => void>
+  >();
+
+  send(): void {}
+
+  close(): void {}
+
+  on(type: string, listener: (...args: unknown[]) => void): void {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) ?? new Set()).add(listener),
+    );
+  }
+
+  off(type: string, listener: (...args: unknown[]) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(type: string, ...args: unknown[]): void {
+    this.listeners.get(type)?.forEach((listener) => {
+      listener(...args);
+    });
+  }
+}

--- a/src/ws-utils.ts
+++ b/src/ws-utils.ts
@@ -18,6 +18,22 @@ export function onWebSocket(
   type: string,
   listener: (...args: unknown[]) => void,
 ): () => void {
+  if (socket.on) {
+    const eventListener = (...args: unknown[]): void => {
+      listener(...normalizeEventEmitterMessageArgs(type, args));
+    };
+    socket.on(type, eventListener);
+
+    return () => {
+      if (socket.off) {
+        socket.off(type, eventListener);
+        return;
+      }
+
+      socket.removeListener?.(type, eventListener);
+    };
+  }
+
   if (socket.addEventListener) {
     const eventListener = (event: unknown): void => listener(event);
     socket.addEventListener(type, eventListener);
@@ -27,29 +43,35 @@ export function onWebSocket(
     };
   }
 
-  if (socket.on) {
-    socket.on(type, listener);
-
-    return () => {
-      if (socket.off) {
-        socket.off(type, listener);
-        return;
-      }
-
-      socket.removeListener?.(type, listener);
-    };
-  }
-
   throw new Error("WebSocket object does not support event listeners");
 }
 
 export function webSocketMessageToString(args: unknown[]): string | undefined {
-  if (args[1] === true || isBinaryMessageEvent(args[0])) {
-    return undefined;
-  }
-
   const data = extractMessageData(args);
 
+  if (typeof data === "string") {
+    return data;
+  }
+
+  return undefined;
+}
+
+function normalizeEventEmitterMessageArgs(
+  type: string,
+  args: unknown[],
+): unknown[] {
+  if (type !== "message" || typeof args[1] !== "boolean") {
+    return args;
+  }
+
+  if (args[1]) {
+    return [undefined];
+  }
+
+  return [decodeWebSocketTextData(args[0])];
+}
+
+function decodeWebSocketTextData(data: unknown): string | undefined {
   if (typeof data === "string") {
     return data;
   }
@@ -62,7 +84,7 @@ export function webSocketMessageToString(args: unknown[]): string | undefined {
     return new TextDecoder().decode(data);
   }
 
-  if (Array.isArray(data) && data.every(ArrayBuffer.isView)) {
+  if (isArrayBufferViewArray(data)) {
     return decodeArrayBufferViews(data);
   }
 
@@ -83,13 +105,8 @@ function isMessageEventLike(value: unknown): value is { data: unknown } {
   return typeof value === "object" && value !== null && "data" in value;
 }
 
-function isBinaryMessageEvent(value: unknown): boolean {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "isBinary" in value &&
-    value.isBinary === true
-  );
+function isArrayBufferViewArray(value: unknown): value is ArrayBufferView[] {
+  return Array.isArray(value) && value.every(ArrayBuffer.isView);
 }
 
 function decodeArrayBufferViews(views: ArrayBufferView[]): string {

--- a/src/ws-utils.ts
+++ b/src/ws-utils.ts
@@ -1,0 +1,108 @@
+export interface WebSocketLike {
+  readonly readyState?: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  addEventListener?(type: string, listener: (event: unknown) => void): void;
+  removeEventListener?(type: string, listener: (event: unknown) => void): void;
+  on?(type: string, listener: (...args: unknown[]) => void): unknown;
+  off?(type: string, listener: (...args: unknown[]) => void): unknown;
+  removeListener?(
+    type: string,
+    listener: (...args: unknown[]) => void,
+  ): unknown;
+}
+
+export function onWebSocket(
+  socket: WebSocketLike,
+  type: string,
+  listener: (...args: unknown[]) => void,
+): () => void {
+  if (socket.addEventListener) {
+    const eventListener = (event: unknown): void => listener(event);
+    socket.addEventListener(type, eventListener);
+
+    return () => {
+      socket.removeEventListener?.(type, eventListener);
+    };
+  }
+
+  if (socket.on) {
+    socket.on(type, listener);
+
+    return () => {
+      if (socket.off) {
+        socket.off(type, listener);
+        return;
+      }
+
+      socket.removeListener?.(type, listener);
+    };
+  }
+
+  throw new Error("WebSocket object does not support event listeners");
+}
+
+export function webSocketMessageToString(args: unknown[]): string | undefined {
+  if (args[1] === true || isBinaryMessageEvent(args[0])) {
+    return undefined;
+  }
+
+  const data = extractMessageData(args);
+
+  if (typeof data === "string") {
+    return data;
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data);
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(data);
+  }
+
+  if (Array.isArray(data) && data.every(ArrayBuffer.isView)) {
+    return decodeArrayBufferViews(data);
+  }
+
+  return undefined;
+}
+
+function extractMessageData(args: unknown[]): unknown {
+  const [first] = args;
+
+  if (isMessageEventLike(first)) {
+    return first.data;
+  }
+
+  return first;
+}
+
+function isMessageEventLike(value: unknown): value is { data: unknown } {
+  return typeof value === "object" && value !== null && "data" in value;
+}
+
+function isBinaryMessageEvent(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "isBinary" in value &&
+    value.isBinary === true
+  );
+}
+
+function decodeArrayBufferViews(views: ArrayBufferView[]): string {
+  const totalLength = views.reduce((sum, view) => sum + view.byteLength, 0);
+  const combined = new Uint8Array(totalLength);
+  let offset = 0;
+
+  for (const view of views) {
+    combined.set(
+      new Uint8Array(view.buffer, view.byteOffset, view.byteLength),
+      offset,
+    );
+    offset += view.byteLength;
+  }
+
+  return new TextDecoder().decode(combined);
+}

--- a/src/ws-utils.ts
+++ b/src/ws-utils.ts
@@ -1,3 +1,4 @@
+/** Minimal browser/Node-compatible WebSocket shape used by ACP transports. */
 export interface WebSocketLike {
   readonly readyState?: number;
   send(data: string): void;


### PR DESCRIPTION
Initial implementation of the experimental [Streamable HTTP & WebSocket Transport RFD](https://agentclientprotocol.com/rfds/streamable-http-websocket-transport).

Reference implementation aligns with the RFD and most of the proposed changes in the [Rust SDK](https://github.com/agentclientprotocol/rust-sdk/compare/main...alexhancock:rust-sdk:feat/http-ws-transport).