### PR TITLE
fix: rename SetProviderRequest type

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1234,11 +1234,11 @@
                 {
                   "allOf": [
                     {
-                      "$ref": "#/$defs/SetProvidersRequest"
+                      "$ref": "#/$defs/SetProviderRequest"
                     }
                   ],
                   "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nReplaces the configuration for a provider.",
-                  "title": "SetProvidersRequest"
+                  "title": "SetProviderRequest"
                 },
                 {
                   "allOf": [
@@ -6382,7 +6382,7 @@
         }
       ]
     },
-    "SetProvidersRequest": {
+    "SetProviderRequest": {
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest parameters for `providers/set`.\n\nReplaces the full configuration for one provider id.",
       "properties": {
         "_meta": {

--- a/src/acp.test.ts
+++ b/src/acp.test.ts
@@ -49,7 +49,7 @@ import {
   ListSessionsResponse,
   ResumeSessionRequest,
   ResumeSessionResponse,
-  SetProvidersRequest,
+  SetProviderRequest,
   DisableProvidersRequest,
   DisableProvidersResponse,
   CreateElicitationRequest,
@@ -1867,7 +1867,7 @@ describe("Connection", () => {
   });
 
   it("handles providers request lifecycle", async () => {
-    let receivedSetRequest: SetProvidersRequest | undefined;
+    let receivedSetRequest: SetProviderRequest | undefined;
     let receivedDisableRequest: DisableProvidersRequest | undefined;
 
     class TestClient implements Client {
@@ -1935,7 +1935,7 @@ describe("Connection", () => {
         };
       }
 
-      async unstable_setProvider(params: SetProvidersRequest): Promise<void> {
+      async unstable_setProvider(params: SetProviderRequest): Promise<void> {
         receivedSetRequest = params;
       }
 

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -139,7 +139,7 @@ export class AgentSideConnection {
           if (!agent.unstable_setProvider) {
             throw RequestError.methodNotFound(method);
           }
-          const validatedParams = validate.zSetProvidersRequest.parse(params);
+          const validatedParams = validate.zSetProviderRequest.parse(params);
           const result = await agent.unstable_setProvider(validatedParams);
           return result ?? {};
         }
@@ -1001,10 +1001,10 @@ export class ClientSideConnection implements Agent {
    * @experimental
    */
   unstable_setProvider(
-    params: schema.SetProvidersRequest,
+    params: schema.SetProviderRequest,
   ): Promise<schema.SetProvidersResponse> {
     return this.connection.sendRequest<
-      schema.SetProvidersRequest,
+      schema.SetProviderRequest,
       schema.SetProvidersResponse
     >(schema.AGENT_METHODS.providers_set, params, emptyObjectResponse);
   }
@@ -2144,7 +2144,7 @@ export interface Agent {
    * @experimental
    */
   unstable_setProvider?(
-    params: schema.SetProvidersRequest,
+    params: schema.SetProviderRequest,
   ): Promise<schema.SetProvidersResponse | void>;
   /**
    * **UNSTABLE**

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -213,7 +213,7 @@ export type {
   SessionNotification,
   SessionResumeCapabilities,
   SessionUpdate,
-  SetProvidersRequest,
+  SetProviderRequest,
   SetProvidersResponse,
   SetSessionConfigOptionRequest,
   SetSessionConfigOptionResponse,

--- a/src/schema/types.gen.ts
+++ b/src/schema/types.gen.ts
@@ -756,7 +756,7 @@ export type ClientRequest = {
     | InitializeRequest
     | AuthenticateRequest
     | ListProvidersRequest
-    | SetProvidersRequest
+    | SetProviderRequest
     | DisableProvidersRequest
     | LogoutRequest
     | NewSessionRequest
@@ -5098,7 +5098,7 @@ export type SessionUpdate =
  *
  * @experimental
  */
-export type SetProvidersRequest = {
+export type SetProviderRequest = {
   /**
    * The _meta property is reserved by ACP to allow clients and agents to attach additional
    * metadata to their interactions. Implementations MUST NOT make assumptions about values at

--- a/src/schema/zod.gen.ts
+++ b/src/schema/zod.gen.ts
@@ -2162,7 +2162,7 @@ export const zSessionCapabilities = z.object({
  *
  * @experimental
  */
-export const zSetProvidersRequest = z.object({
+export const zSetProviderRequest = z.object({
   _meta: z.record(z.string(), z.unknown()).nullish(),
   apiType: zLlmProtocol,
   baseUrl: z.string(),
@@ -3205,7 +3205,7 @@ export const zClientRequest = z.object({
       zInitializeRequest,
       zAuthenticateRequest,
       zListProvidersRequest,
-      zSetProvidersRequest,
+      zSetProviderRequest,
       zDisableProvidersRequest,
       zLogoutRequest,
       zNewSessionRequest,


### PR DESCRIPTION
Fixes #156

## Summary
- rename the singular provider configuration request type from `SetProvidersRequest` to `SetProviderRequest`
- update the generated schema exports, zod schema, and ACP references to use the corrected name
- keep the request/response behavior unchanged while making the public type name match the docs