### PR TITLE
feat(schema): Stabilize addl dirs and remove unstable model selectors

### DIFF
--- a/schema/meta.json
+++ b/schema/meta.json
@@ -27,8 +27,7 @@
     "session_prompt": "session/prompt",
     "session_resume": "session/resume",
     "session_set_config_option": "session/set_config_option",
-    "session_set_mode": "session/set_mode",
-    "session_set_model": "session/set_model"
+    "session_set_mode": "session/set_mode"
   },
   "clientMethods": {
     "elicitation_complete": "elicitation/complete",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -43,7 +43,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent supports the logout method.\n\nBy supplying `{}` it means that the agent supports the logout method."
+          "description": "Whether the agent supports the logout method.\n\nBy supplying `{}` it means that the agent supports the logout method.",
+          "x-deserialize-default-on-error": true
         }
       },
       "type": "object"
@@ -92,7 +93,8 @@
               "type": "null"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the agent."
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the agent.",
+          "x-deserialize-default-on-error": true
         },
         "positionEncoding": {
           "anyOf": [
@@ -103,7 +105,8 @@
               "type": "null"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe position encoding selected by the agent from the client's supported encodings."
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe position encoding selected by the agent from the client's supported encodings.",
+          "x-deserialize-default-on-error": true
         },
         "promptCapabilities": {
           "allOf": [
@@ -127,7 +130,8 @@
               "type": "null"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProvider configuration capabilities supported by the agent.\n\nBy supplying `{}` it means that the agent supports provider configuration methods."
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProvider configuration capabilities supported by the agent.\n\nBy supplying `{}` it means that the agent supports provider configuration methods.",
+          "x-deserialize-default-on-error": true
         },
         "sessionCapabilities": {
           "allOf": [
@@ -480,14 +484,6 @@
                 {
                   "allOf": [
                     {
-                      "$ref": "#/$defs/SetSessionModelResponse"
-                    }
-                  ],
-                  "title": "SetSessionModelResponse"
-                },
-                {
-                  "allOf": [
-                    {
                       "$ref": "#/$defs/StartNesResponse"
                     }
                   ],
@@ -561,7 +557,9 @@
           "items": {
             "$ref": "#/$defs/Role"
           },
-          "type": ["array", "null"]
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "lastModified": {
           "type": ["string", "null"]
@@ -589,7 +587,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "x-deserialize-default-on-error": true
         },
         "data": {
           "type": "string"
@@ -842,7 +841,8 @@
               "type": "null"
             }
           ],
-          "description": "Input for the command if required"
+          "description": "Input for the command if required",
+          "x-deserialize-default-on-error": true
         },
         "name": {
           "description": "Command name (e.g., `create_plan`, `research_codebase`).",
@@ -879,7 +879,9 @@
           "items": {
             "$ref": "#/$defs/AvailableCommand"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         }
       },
       "required": ["availableCommands"],
@@ -996,7 +998,8 @@
               "type": "null"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nElicitation capabilities supported by the client.\nDetermines which elicitation modes the agent may use."
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nElicitation capabilities supported by the client.\nDetermines which elicitation modes the agent may use.",
+          "x-deserialize-default-on-error": true
         },
         "fs": {
           "allOf": [
@@ -1019,7 +1022,8 @@
               "type": "null"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the client."
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the client.",
+          "x-deserialize-default-on-error": true
         },
         "planCapabilities": {
           "anyOf": [
@@ -1030,14 +1034,17 @@
               "type": "null"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the client supports `plan_update` and `plan_removed` session updates.\n\nOptional. Omitted means the client does not advertise support.\nSupplying `{}` means the client can receive both update types."
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the client supports `plan_update` and `plan_removed` session updates.\n\nOptional. Omitted means the client does not advertise support.\nSupplying `{}` means the client can receive both update types.",
+          "x-deserialize-default-on-error": true
         },
         "positionEncodings": {
           "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe position encodings supported by the client, in order of preference.",
           "items": {
             "$ref": "#/$defs/PositionEncodingKind"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "terminal": {
           "default": false,
@@ -1064,7 +1071,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the client supports the `jump` suggestion kind."
+          "description": "Whether the client supports the `jump` suggestion kind.",
+          "x-deserialize-default-on-error": true
         },
         "rename": {
           "anyOf": [
@@ -1075,7 +1083,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the client supports the `rename` suggestion kind."
+          "description": "Whether the client supports the `rename` suggestion kind.",
+          "x-deserialize-default-on-error": true
         },
         "searchAndReplace": {
           "anyOf": [
@@ -1086,7 +1095,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the client supports the `searchAndReplace` suggestion kind."
+          "description": "Whether the client supports the `searchAndReplace` suggestion kind.",
+          "x-deserialize-default-on-error": true
         }
       },
       "type": "object"
@@ -1358,15 +1368,6 @@
                   ],
                   "description": "Processes a user prompt within a session.\n\nThis method handles the whole lifecycle of a prompt:\n- Receives user messages with optional context (files, images, etc.)\n- Processes the prompt using language models\n- Reports language model content and tool calls to the Clients\n- Requests permission to run tools\n- Executes any requested tool calls\n- Returns when the turn is complete with a stop reason\n\nSee protocol docs: [Prompt Turn](https://agentclientprotocol.com/protocol/prompt-turn)",
                   "title": "PromptRequest"
-                },
-                {
-                  "allOf": [
-                    {
-                      "$ref": "#/$defs/SetSessionModelRequest"
-                    }
-                  ],
-                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nSelect a model for a given session.",
-                  "title": "SetSessionModelRequest"
                 },
                 {
                   "allOf": [
@@ -1668,7 +1669,9 @@
           "items": {
             "$ref": "#/$defs/SessionConfigOption"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         }
       },
       "required": ["configOptions"],
@@ -2396,7 +2399,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the client supports form-based elicitation."
+          "description": "Whether the client supports form-based elicitation.",
+          "x-deserialize-default-on-error": true
         },
         "url": {
           "anyOf": [
@@ -2407,7 +2411,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the client supports URL-based elicitation."
+          "description": "Whether the client supports URL-based elicitation.",
+          "x-deserialize-default-on-error": true
         }
       },
       "type": "object"
@@ -2745,7 +2750,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "x-deserialize-default-on-error": true
         },
         "resource": {
           "$ref": "#/$defs/EmbeddedResourceResource"
@@ -2945,7 +2951,7 @@
           "type": ["object", "null"]
         },
         "additionalDirectories": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the forked\nsession.",
+          "description": "Additional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the forked\nsession.",
           "items": {
             "type": "string"
           },
@@ -2989,18 +2995,9 @@
           "items": {
             "$ref": "#/$defs/SessionConfigOption"
           },
-          "type": ["array", "null"]
-        },
-        "models": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SessionModelState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInitial model state if supported by the Agent"
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "modes": {
           "anyOf": [
@@ -3011,7 +3008,8 @@
               "type": "null"
             }
           ],
-          "description": "Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
+          "description": "Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)",
+          "x-deserialize-default-on-error": true
         },
         "sessionId": {
           "allOf": [
@@ -3063,7 +3061,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "x-deserialize-default-on-error": true
         },
         "data": {
           "type": "string"
@@ -3137,7 +3136,8 @@
               "type": "null"
             }
           ],
-          "description": "Information about the Client name and version sent to the Agent.\n\nNote: in future versions of the protocol, this will be required."
+          "description": "Information about the Client name and version sent to the Agent.\n\nNote: in future versions of the protocol, this will be required.",
+          "x-deserialize-default-on-error": true
         },
         "protocolVersion": {
           "allOf": [
@@ -3193,7 +3193,8 @@
               "type": "null"
             }
           ],
-          "description": "Information about the Agent name and version sent to the Client.\n\nNote: in future versions of the protocol, this will be required."
+          "description": "Information about the Agent name and version sent to the Client.\n\nNote: in future versions of the protocol, this will be required.",
+          "x-deserialize-default-on-error": true
         },
         "authMethods": {
           "default": [],
@@ -3201,7 +3202,9 @@
           "items": {
             "$ref": "#/$defs/AuthMethod"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "protocolVersion": {
           "allOf": [
@@ -3311,7 +3314,9 @@
           "items": {
             "$ref": "#/$defs/ProviderInfo"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         }
       },
       "required": ["providers"],
@@ -3357,7 +3362,9 @@
           "items": {
             "$ref": "#/$defs/SessionInfo"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         }
       },
       "required": ["sessions"],
@@ -3409,7 +3416,7 @@
           "type": ["object", "null"]
         },
         "additionalDirectories": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the loaded\nsession. It may differ from any previously used or reported list as long as\nthe request `cwd` matches the session's `cwd`.",
+          "description": "Additional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the loaded\nsession. It may differ from any previously used or reported list as long as\nthe request `cwd` matches the session's `cwd`.",
           "items": {
             "type": "string"
           },
@@ -3453,18 +3460,9 @@
           "items": {
             "$ref": "#/$defs/SessionConfigOption"
           },
-          "type": ["array", "null"]
-        },
-        "models": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SessionModelState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInitial model state if supported by the Agent"
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "modes": {
           "anyOf": [
@@ -3475,7 +3473,8 @@
               "type": "null"
             }
           ],
-          "description": "Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
+          "description": "Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)",
+          "x-deserialize-default-on-error": true
         }
       },
       "type": "object",
@@ -3794,38 +3793,6 @@
       "x-method": "mcp/message",
       "x-side": "both"
     },
-    "ModelId": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA unique identifier for a model.",
-      "type": "string"
-    },
-    "ModelInfo": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInformation about a selectable model.",
-      "properties": {
-        "_meta": {
-          "additionalProperties": true,
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-          "type": ["object", "null"]
-        },
-        "description": {
-          "description": "Optional description of the model.",
-          "type": ["string", "null"]
-        },
-        "modelId": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/ModelId"
-            }
-          ],
-          "description": "Unique identifier for the model."
-        },
-        "name": {
-          "description": "Human-readable name of the model.",
-          "type": "string"
-        }
-      },
-      "required": ["modelId", "name"],
-      "type": "object"
-    },
     "MultiSelectItems": {
       "anyOf": [
         {
@@ -3908,7 +3875,8 @@
               "type": "null"
             }
           ],
-          "description": "Context the agent wants attached to each suggestion request."
+          "description": "Context the agent wants attached to each suggestion request.",
+          "x-deserialize-default-on-error": true
         },
         "events": {
           "anyOf": [
@@ -3919,7 +3887,8 @@
               "type": "null"
             }
           ],
-          "description": "Events the agent wants to receive."
+          "description": "Events the agent wants to receive.",
+          "x-deserialize-default-on-error": true
         }
       },
       "type": "object"
@@ -3941,7 +3910,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent wants diagnostics context."
+          "description": "Whether the agent wants diagnostics context.",
+          "x-deserialize-default-on-error": true
         },
         "editHistory": {
           "anyOf": [
@@ -3952,7 +3922,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent wants edit history context."
+          "description": "Whether the agent wants edit history context.",
+          "x-deserialize-default-on-error": true
         },
         "openFiles": {
           "anyOf": [
@@ -3963,7 +3934,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent wants open files context."
+          "description": "Whether the agent wants open files context.",
+          "x-deserialize-default-on-error": true
         },
         "recentFiles": {
           "anyOf": [
@@ -3974,7 +3946,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent wants recent files context."
+          "description": "Whether the agent wants recent files context.",
+          "x-deserialize-default-on-error": true
         },
         "relatedSnippets": {
           "anyOf": [
@@ -3985,7 +3958,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent wants related snippets context."
+          "description": "Whether the agent wants related snippets context.",
+          "x-deserialize-default-on-error": true
         },
         "userActions": {
           "anyOf": [
@@ -3996,7 +3970,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent wants user actions context."
+          "description": "Whether the agent wants user actions context.",
+          "x-deserialize-default-on-error": true
         }
       },
       "type": "object"
@@ -4149,7 +4124,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent wants `document/didChange` events, and the sync kind."
+          "description": "Whether the agent wants `document/didChange` events, and the sync kind.",
+          "x-deserialize-default-on-error": true
         },
         "didClose": {
           "anyOf": [
@@ -4160,7 +4136,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent wants `document/didClose` events."
+          "description": "Whether the agent wants `document/didClose` events.",
+          "x-deserialize-default-on-error": true
         },
         "didFocus": {
           "anyOf": [
@@ -4171,7 +4148,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent wants `document/didFocus` events."
+          "description": "Whether the agent wants `document/didFocus` events.",
+          "x-deserialize-default-on-error": true
         },
         "didOpen": {
           "anyOf": [
@@ -4182,7 +4160,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent wants `document/didOpen` events."
+          "description": "Whether the agent wants `document/didOpen` events.",
+          "x-deserialize-default-on-error": true
         },
         "didSave": {
           "anyOf": [
@@ -4193,7 +4172,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent wants `document/didSave` events."
+          "description": "Whether the agent wants `document/didSave` events.",
+          "x-deserialize-default-on-error": true
         }
       },
       "type": "object"
@@ -4242,7 +4222,8 @@
               "type": "null"
             }
           ],
-          "description": "Optional suggested cursor position after applying edits."
+          "description": "Optional suggested cursor position after applying edits.",
+          "x-deserialize-default-on-error": true
         },
         "edits": {
           "description": "The text edits to apply.",
@@ -4280,7 +4261,8 @@
               "type": "null"
             }
           ],
-          "description": "Document event capabilities."
+          "description": "Document event capabilities.",
+          "x-deserialize-default-on-error": true
         }
       },
       "type": "object"
@@ -4353,7 +4335,8 @@
           "description": "Timestamp in milliseconds since epoch of when the file was last focused.",
           "format": "uint64",
           "minimum": 0,
-          "type": ["integer", "null"]
+          "type": ["integer", "null"],
+          "x-deserialize-default-on-error": true
         },
         "uri": {
           "description": "The URI of the file.",
@@ -4368,7 +4351,8 @@
               "type": "null"
             }
           ],
-          "description": "The visible range in the editor, if any."
+          "description": "The visible range in the editor, if any.",
+          "x-deserialize-default-on-error": true
         }
       },
       "required": ["uri", "languageId"],
@@ -4583,42 +4567,54 @@
           "items": {
             "$ref": "#/$defs/NesDiagnostic"
           },
-          "type": ["array", "null"]
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "editHistory": {
           "description": "Recent edit history.",
           "items": {
             "$ref": "#/$defs/NesEditHistoryEntry"
           },
-          "type": ["array", "null"]
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "openFiles": {
           "description": "Currently open files in the editor.",
           "items": {
             "$ref": "#/$defs/NesOpenFile"
           },
-          "type": ["array", "null"]
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "recentFiles": {
           "description": "Recently accessed files.",
           "items": {
             "$ref": "#/$defs/NesRecentFile"
           },
-          "type": ["array", "null"]
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "relatedSnippets": {
           "description": "Related code snippets.",
           "items": {
             "$ref": "#/$defs/NesRelatedSnippet"
           },
-          "type": ["array", "null"]
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "userActions": {
           "description": "Recent user actions (typing, navigation, etc.).",
           "items": {
             "$ref": "#/$defs/NesUserAction"
           },
-          "type": ["array", "null"]
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         }
       },
       "type": "object"
@@ -4789,7 +4785,7 @@
           "type": ["object", "null"]
         },
         "additionalDirectories": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots for this session. Each path must be absolute.\n\nThese expand the session's filesystem scope without changing `cwd`, which\nremains the base for relative paths. When omitted or empty, no\nadditional roots are activated for the new session.",
+          "description": "Additional workspace roots for this session. Each path must be absolute.\n\nThese expand the session's filesystem scope without changing `cwd`, which\nremains the base for relative paths. When omitted or empty, no\nadditional roots are activated for the new session.",
           "items": {
             "type": "string"
           },
@@ -4825,18 +4821,9 @@
           "items": {
             "$ref": "#/$defs/SessionConfigOption"
           },
-          "type": ["array", "null"]
-        },
-        "models": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SessionModelState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInitial model state if supported by the Agent"
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "modes": {
           "anyOf": [
@@ -4847,7 +4834,8 @@
               "type": "null"
             }
           ],
-          "description": "Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
+          "description": "Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)",
+          "x-deserialize-default-on-error": true
         },
         "sessionId": {
           "allOf": [
@@ -4966,7 +4954,9 @@
           "items": {
             "$ref": "#/$defs/PlanEntry"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         }
       },
       "required": ["entries"],
@@ -5096,7 +5086,9 @@
           "items": {
             "$ref": "#/$defs/PlanEntry"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "id": {
           "allOf": [
@@ -5353,7 +5345,8 @@
               "type": "null"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nToken usage for this turn (optional)."
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nToken usage for this turn (optional).",
+          "x-deserialize-default-on-error": true
         },
         "userMessageId": {
           "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe acknowledged user message ID.\n\nIf the client provided a `messageId` in the [`PromptRequest`], the agent echoes it here\nto confirm it was recorded. If the client did not provide one, the agent MAY assign one\nand return it here. Absence of this field indicates the agent did not record a message ID.",
@@ -5423,7 +5416,9 @@
           "items": {
             "$ref": "#/$defs/LlmProtocol"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         }
       },
       "required": ["id", "supported", "required"],
@@ -5539,7 +5534,8 @@
               "type": "null"
             }
           ],
-          "description": "The reason for rejection."
+          "description": "The reason for rejection.",
+          "x-deserialize-default-on-error": true
         },
         "sessionId": {
           "allOf": [
@@ -5722,7 +5718,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "x-deserialize-default-on-error": true
         },
         "description": {
           "type": ["string", "null"]
@@ -5756,7 +5753,7 @@
           "type": ["object", "null"]
         },
         "additionalDirectories": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the resumed\nsession. It may differ from any previously used or reported list as long as\nthe request `cwd` matches the session's `cwd`.",
+          "description": "Additional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the resumed\nsession. It may differ from any previously used or reported list as long as\nthe request `cwd` matches the session's `cwd`.",
           "items": {
             "type": "string"
           },
@@ -5800,18 +5797,9 @@
           "items": {
             "$ref": "#/$defs/SessionConfigOption"
           },
-          "type": ["array", "null"]
-        },
-        "models": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SessionModelState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInitial model state if supported by the Agent"
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "modes": {
           "anyOf": [
@@ -5822,7 +5810,8 @@
               "type": "null"
             }
           ],
-          "description": "Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)"
+          "description": "Initial mode state if supported by the Agent\n\nSee protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)",
+          "x-deserialize-default-on-error": true
         }
       },
       "type": "object",
@@ -5855,7 +5844,7 @@
       "type": "object"
     },
     "SessionAdditionalDirectoriesCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for additional session directories support.\n\nBy supplying `{}` it means that the agent supports the `additionalDirectories`\nfield on supported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` to report the\ncomplete ordered additional-root list associated with a listed session.",
+      "description": "Capabilities for additional session directories support.\n\nBy supplying `{}` it means that the agent supports the `additionalDirectories`\nfield on supported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` to report the\ncomplete ordered additional-root list associated with a listed session.",
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -5882,7 +5871,8 @@
               "type": "null"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` to report the complete ordered\nadditional-root list associated with a listed session."
+          "description": "Whether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` to report the complete ordered\nadditional-root list associated with a listed session.",
+          "x-deserialize-default-on-error": true
         },
         "close": {
           "anyOf": [
@@ -5893,7 +5883,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent supports `session/close`."
+          "description": "Whether the agent supports `session/close`.",
+          "x-deserialize-default-on-error": true
         },
         "delete": {
           "anyOf": [
@@ -5904,7 +5895,8 @@
               "type": "null"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/delete`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports deleting sessions from `session/list`."
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/delete`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports deleting sessions from `session/list`.",
+          "x-deserialize-default-on-error": true
         },
         "fork": {
           "anyOf": [
@@ -5915,7 +5907,8 @@
               "type": "null"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/fork`."
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/fork`.",
+          "x-deserialize-default-on-error": true
         },
         "list": {
           "anyOf": [
@@ -5926,7 +5919,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent supports `session/list`."
+          "description": "Whether the agent supports `session/list`.",
+          "x-deserialize-default-on-error": true
         },
         "resume": {
           "anyOf": [
@@ -5937,7 +5931,8 @@
               "type": "null"
             }
           ],
-          "description": "Whether the agent supports `session/resume`."
+          "description": "Whether the agent supports `session/resume`.",
+          "x-deserialize-default-on-error": true
         }
       },
       "type": "object"
@@ -6026,7 +6021,8 @@
               "type": "null"
             }
           ],
-          "description": "Optional semantic category for this option (UX only)."
+          "description": "Optional semantic category for this option (UX only).",
+          "x-deserialize-default-on-error": true
         },
         "description": {
           "description": "Optional description for the Client to display to the user.",
@@ -6215,7 +6211,7 @@
           "type": ["object", "null"]
         },
         "additionalDirectories": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots reported for this session. Each path must be absolute.\n\nWhen present, this is the complete ordered additional-root list reported\nby the Agent. Omitted and empty values are equivalent: the response\nreports no additional roots.",
+          "description": "Additional workspace roots reported for this session. Each path must be absolute.\n\nWhen present, this is the complete ordered additional-root list reported\nby the Agent. Omitted and empty values are equivalent: the response\nreports no additional roots.",
           "items": {
             "type": "string"
           },
@@ -6235,11 +6231,13 @@
         },
         "title": {
           "description": "Human-readable title for the session",
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
         },
         "updatedAt": {
           "description": "ISO 8601 timestamp of last activity",
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
         }
       },
       "required": ["sessionId", "cwd"],
@@ -6313,7 +6311,9 @@
           "items": {
             "$ref": "#/$defs/SessionMode"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "currentModeId": {
           "allOf": [
@@ -6325,33 +6325,6 @@
         }
       },
       "required": ["currentModeId", "availableModes"],
-      "type": "object"
-    },
-    "SessionModelState": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe set of models and the one currently active.",
-      "properties": {
-        "_meta": {
-          "additionalProperties": true,
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-          "type": ["object", "null"]
-        },
-        "availableModels": {
-          "description": "The set of models that the Agent can use",
-          "items": {
-            "$ref": "#/$defs/ModelInfo"
-          },
-          "type": "array"
-        },
-        "currentModelId": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/ModelId"
-            }
-          ],
-          "description": "The current model the Agent is in."
-        }
-      },
-      "required": ["currentModelId", "availableModels"],
       "type": "object"
     },
     "SessionNotification": {
@@ -6737,7 +6710,9 @@
           "items": {
             "$ref": "#/$defs/SessionConfigOption"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         }
       },
       "required": ["configOptions"],
@@ -6788,49 +6763,6 @@
       "x-method": "session/set_mode",
       "x-side": "agent"
     },
-    "SetSessionModelRequest": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest parameters for setting a session model.",
-      "properties": {
-        "_meta": {
-          "additionalProperties": true,
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-          "type": ["object", "null"]
-        },
-        "modelId": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/ModelId"
-            }
-          ],
-          "description": "The ID of the model to set."
-        },
-        "sessionId": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/SessionId"
-            }
-          ],
-          "description": "The ID of the session to set the model for."
-        }
-      },
-      "required": ["sessionId", "modelId"],
-      "type": "object",
-      "x-method": "session/set_model",
-      "x-side": "agent"
-    },
-    "SetSessionModelResponse": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nResponse to `session/set_model` method.",
-      "properties": {
-        "_meta": {
-          "additionalProperties": true,
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-          "type": ["object", "null"]
-        }
-      },
-      "type": "object",
-      "x-method": "session/set_model",
-      "x-side": "agent"
-    },
     "StartNesRequest": {
       "description": "Request to start an NES session.",
       "properties": {
@@ -6848,14 +6780,17 @@
               "type": "null"
             }
           ],
-          "description": "Repository metadata, if the workspace is a git repository."
+          "description": "Repository metadata, if the workspace is a git repository.",
+          "x-deserialize-default-on-error": true
         },
         "workspaceFolders": {
           "description": "The workspace folders.",
           "items": {
             "$ref": "#/$defs/WorkspaceFolder"
           },
-          "type": ["array", "null"]
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "workspaceUri": {
           "description": "The root URI of the workspace.",
@@ -7019,7 +6954,8 @@
               "type": "null"
             }
           ],
-          "description": "Context for the suggestion, included based on agent capabilities."
+          "description": "Context for the suggestion, included based on agent capabilities.",
+          "x-deserialize-default-on-error": true
         },
         "position": {
           "allOf": [
@@ -7038,7 +6974,8 @@
               "type": "null"
             }
           ],
-          "description": "The current text selection range, if any."
+          "description": "The current text selection range, if any.",
+          "x-deserialize-default-on-error": true
         },
         "sessionId": {
           "allOf": [
@@ -7084,7 +7021,9 @@
           "items": {
             "$ref": "#/$defs/NesSuggestion"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         }
       },
       "required": ["suggestions"],
@@ -7203,7 +7142,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "x-deserialize-default-on-error": true
         },
         "text": {
           "type": "string"
@@ -7297,7 +7237,9 @@
           "items": {
             "$ref": "#/$defs/ToolCallContent"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "kind": {
           "allOf": [
@@ -7312,7 +7254,9 @@
           "items": {
             "$ref": "#/$defs/ToolCallLocation"
           },
-          "type": "array"
+          "type": "array",
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "rawInput": {
           "description": "Raw input parameters sent to the tool."
@@ -7464,7 +7408,9 @@
           "items": {
             "$ref": "#/$defs/ToolCallContent"
           },
-          "type": ["array", "null"]
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "kind": {
           "anyOf": [
@@ -7475,14 +7421,17 @@
               "type": "null"
             }
           ],
-          "description": "Update the tool kind."
+          "description": "Update the tool kind.",
+          "x-deserialize-default-on-error": true
         },
         "locations": {
           "description": "Replace the locations collection.",
           "items": {
             "$ref": "#/$defs/ToolCallLocation"
           },
-          "type": ["array", "null"]
+          "type": ["array", "null"],
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "rawInput": {
           "description": "Update the raw input."
@@ -7499,7 +7448,8 @@
               "type": "null"
             }
           ],
-          "description": "Update the execution status."
+          "description": "Update the execution status.",
+          "x-deserialize-default-on-error": true
         },
         "title": {
           "description": "Update the human-readable title.",
@@ -7670,7 +7620,8 @@
               "type": "null"
             }
           ],
-          "description": "Cumulative session cost (optional)."
+          "description": "Cumulative session cost (optional).",
+          "x-deserialize-default-on-error": true
         },
         "size": {
           "description": "Total context window size in tokens.",

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -5,7 +5,7 @@ import * as fs from "fs/promises";
 import { dirname } from "path";
 import * as prettier from "prettier";
 
-const CURRENT_SCHEMA_RELEASE = "v0.13.4";
+const CURRENT_SCHEMA_RELEASE = "v0.13.5";
 
 await main();
 

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -164,15 +164,6 @@ export class AgentSideConnection {
           const validatedParams = validate.zPromptRequest.parse(params);
           return agent.prompt(validatedParams);
         }
-        case schema.AGENT_METHODS.session_set_model: {
-          if (!agent.unstable_setSessionModel) {
-            throw RequestError.methodNotFound(method);
-          }
-          const validatedParams =
-            validate.zSetSessionModelRequest.parse(params);
-          const result = await agent.unstable_setSessionModel(validatedParams);
-          return result ?? {};
-        }
         case schema.AGENT_METHODS.session_set_config_option: {
           if (!agent.setSessionConfigOption) {
             throw RequestError.methodNotFound(method);
@@ -914,24 +905,6 @@ export class ClientSideConnection implements Agent {
       schema.SetSessionModeRequest,
       schema.SetSessionModeResponse
     >(schema.AGENT_METHODS.session_set_mode, params, emptyObjectResponse);
-  }
-
-  /**
-   * **UNSTABLE**
-   *
-   * This capability is not part of the spec yet, and may be removed or changed at any point.
-   *
-   * Select a model for a given session.
-   *
-   * @experimental
-   */
-  unstable_setSessionModel(
-    params: schema.SetSessionModelRequest,
-  ): Promise<schema.SetSessionModelResponse> {
-    return this.connection.sendRequest<
-      schema.SetSessionModelRequest,
-      schema.SetSessionModelResponse
-    >(schema.AGENT_METHODS.session_set_model, params, emptyObjectResponse);
   }
 
   /**
@@ -2081,18 +2054,6 @@ export interface Agent {
   setSessionMode?(
     params: schema.SetSessionModeRequest,
   ): Promise<schema.SetSessionModeResponse | void>;
-  /**
-   * **UNSTABLE**
-   *
-   * This capability is not part of the spec yet, and may be removed or changed at any point.
-   *
-   * Select a model for a given session.
-   *
-   * @experimental
-   */
-  unstable_setSessionModel?(
-    params: schema.SetSessionModelRequest,
-  ): Promise<schema.SetSessionModelResponse | void>;
   /**
    * Set a configuration option for a given session.
    *

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -113,8 +113,6 @@ export type {
   MessageMcpNotification,
   MessageMcpRequest,
   MessageMcpResponse,
-  ModelId,
-  ModelInfo,
   MultiSelectItems,
   MultiSelectPropertySchema,
   NesCapabilities,
@@ -216,7 +214,6 @@ export type {
   SessionListCapabilities,
   SessionMode,
   SessionModeId,
-  SessionModelState,
   SessionModeState,
   SessionNotification,
   SessionResumeCapabilities,
@@ -225,8 +222,6 @@ export type {
   SetProviderResponse,
   SetSessionConfigOptionRequest,
   SetSessionConfigOptionResponse,
-  SetSessionModelRequest,
-  SetSessionModelResponse,
   SetSessionModeRequest,
   SetSessionModeResponse,
   StartNesRequest,
@@ -292,7 +287,6 @@ export const AGENT_METHODS = {
   session_resume: "session/resume",
   session_set_config_option: "session/set_config_option",
   session_set_mode: "session/set_mode",
-  session_set_model: "session/set_model",
 } as const;
 
 export const CLIENT_METHODS = {

--- a/src/schema/types.gen.ts
+++ b/src/schema/types.gen.ts
@@ -179,7 +179,6 @@ export type AgentResponse =
         | SetSessionModeResponse
         | SetSessionConfigOptionResponse
         | PromptResponse
-        | SetSessionModelResponse
         | StartNesResponse
         | SuggestNesResponse
         | CloseNesResponse
@@ -770,7 +769,6 @@ export type ClientRequest = {
     | SetSessionModeRequest
     | SetSessionConfigOptionRequest
     | PromptRequest
-    | SetSessionModelRequest
     | StartNesRequest
     | SuggestNesRequest
     | CloseNesRequest
@@ -2028,17 +2026,11 @@ export type ForkSessionRequest = {
     [key: string]: unknown;
   } | null;
   /**
-   * **UNSTABLE**
-   *
-   * This capability is not part of the spec yet, and may be removed or changed at any point.
-   *
    * Additional workspace roots to activate for this session. Each path must be absolute.
    *
    * When omitted or empty, no additional roots are activated. When non-empty,
    * this is the complete resulting additional-root list for the forked
    * session.
-   *
-   * @experimental
    */
   additionalDirectories?: Array<string>;
   /**
@@ -2079,16 +2071,6 @@ export type ForkSessionResponse = {
    * Initial session configuration options if supported by the Agent.
    */
   configOptions?: Array<SessionConfigOption> | null;
-  /**
-   * **UNSTABLE**
-   *
-   * This capability is not part of the spec yet, and may be removed or changed at any point.
-   *
-   * Initial model state if supported by the Agent
-   *
-   * @experimental
-   */
-  models?: SessionModelState | null;
   /**
    * Initial mode state if supported by the Agent
    *
@@ -2461,18 +2443,12 @@ export type LoadSessionRequest = {
     [key: string]: unknown;
   } | null;
   /**
-   * **UNSTABLE**
-   *
-   * This capability is not part of the spec yet, and may be removed or changed at any point.
-   *
    * Additional workspace roots to activate for this session. Each path must be absolute.
    *
    * When omitted or empty, no additional roots are activated. When non-empty,
    * this is the complete resulting additional-root list for the loaded
    * session. It may differ from any previously used or reported list as long as
    * the request `cwd` matches the session's `cwd`.
-   *
-   * @experimental
    */
   additionalDirectories?: Array<string>;
   /**
@@ -2507,16 +2483,6 @@ export type LoadSessionResponse = {
    * Initial session configuration options if supported by the Agent.
    */
   configOptions?: Array<SessionConfigOption> | null;
-  /**
-   * **UNSTABLE**
-   *
-   * This capability is not part of the spec yet, and may be removed or changed at any point.
-   *
-   * Initial model state if supported by the Agent
-   *
-   * @experimental
-   */
-  models?: SessionModelState | null;
   /**
    * Initial mode state if supported by the Agent
    *
@@ -2872,51 +2838,6 @@ export type MessageMcpRequest = {
  * @experimental
  */
 export type MessageMcpResponse = unknown;
-
-/**
- * **UNSTABLE**
- *
- * This capability is not part of the spec yet, and may be removed or changed at any point.
- *
- * A unique identifier for a model.
- *
- * @experimental
- */
-export type ModelId = string;
-
-/**
- * **UNSTABLE**
- *
- * This capability is not part of the spec yet, and may be removed or changed at any point.
- *
- * Information about a selectable model.
- *
- * @experimental
- */
-export type ModelInfo = {
-  /**
-   * The _meta property is reserved by ACP to allow clients and agents to attach additional
-   * metadata to their interactions. Implementations MUST NOT make assumptions about values at
-   * these keys.
-   *
-   * See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-   */
-  _meta?: {
-    [key: string]: unknown;
-  } | null;
-  /**
-   * Optional description of the model.
-   */
-  description?: string | null;
-  /**
-   * Unique identifier for the model.
-   */
-  modelId: ModelId;
-  /**
-   * Human-readable name of the model.
-   */
-  name: string;
-};
 
 /**
  * Items for a multi-select (array) property schema.
@@ -3658,17 +3579,11 @@ export type NewSessionRequest = {
     [key: string]: unknown;
   } | null;
   /**
-   * **UNSTABLE**
-   *
-   * This capability is not part of the spec yet, and may be removed or changed at any point.
-   *
    * Additional workspace roots for this session. Each path must be absolute.
    *
    * These expand the session's filesystem scope without changing `cwd`, which
    * remains the base for relative paths. When omitted or empty, no
    * additional roots are activated for the new session.
-   *
-   * @experimental
    */
   additionalDirectories?: Array<string>;
   /**
@@ -3701,16 +3616,6 @@ export type NewSessionResponse = {
    * Initial session configuration options if supported by the Agent.
    */
   configOptions?: Array<SessionConfigOption> | null;
-  /**
-   * **UNSTABLE**
-   *
-   * This capability is not part of the spec yet, and may be removed or changed at any point.
-   *
-   * Initial model state if supported by the Agent
-   *
-   * @experimental
-   */
-  models?: SessionModelState | null;
   /**
    * Initial mode state if supported by the Agent
    *
@@ -4581,18 +4486,12 @@ export type ResumeSessionRequest = {
     [key: string]: unknown;
   } | null;
   /**
-   * **UNSTABLE**
-   *
-   * This capability is not part of the spec yet, and may be removed or changed at any point.
-   *
    * Additional workspace roots to activate for this session. Each path must be absolute.
    *
    * When omitted or empty, no additional roots are activated. When non-empty,
    * this is the complete resulting additional-root list for the resumed
    * session. It may differ from any previously used or reported list as long as
    * the request `cwd` matches the session's `cwd`.
-   *
-   * @experimental
    */
   additionalDirectories?: Array<string>;
   /**
@@ -4628,16 +4527,6 @@ export type ResumeSessionResponse = {
    */
   configOptions?: Array<SessionConfigOption> | null;
   /**
-   * **UNSTABLE**
-   *
-   * This capability is not part of the spec yet, and may be removed or changed at any point.
-   *
-   * Initial model state if supported by the Agent
-   *
-   * @experimental
-   */
-  models?: SessionModelState | null;
-  /**
    * Initial mode state if supported by the Agent
    *
    * See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
@@ -4671,18 +4560,12 @@ export type SelectedPermissionOutcome = {
 };
 
 /**
- * **UNSTABLE**
- *
- * This capability is not part of the spec yet, and may be removed or changed at any point.
- *
  * Capabilities for additional session directories support.
  *
  * By supplying `{}` it means that the agent supports the `additionalDirectories`
  * field on supported session lifecycle requests. Agents that also support
  * `session/list` may return `SessionInfo.additionalDirectories` to report the
  * complete ordered additional-root list associated with a listed session.
- *
- * @experimental
  */
 export type SessionAdditionalDirectoriesCapabilities = {
   /**
@@ -4720,17 +4603,11 @@ export type SessionCapabilities = {
     [key: string]: unknown;
   } | null;
   /**
-   * **UNSTABLE**
-   *
-   * This capability is not part of the spec yet, and may be removed or changed at any point.
-   *
    * Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
    *
    * Agents that also support `session/list` may return
    * `SessionInfo.additionalDirectories` to report the complete ordered
    * additional-root list associated with a listed session.
-   *
-   * @experimental
    */
   additionalDirectories?: SessionAdditionalDirectoriesCapabilities | null;
   /**
@@ -5025,17 +4902,11 @@ export type SessionInfo = {
     [key: string]: unknown;
   } | null;
   /**
-   * **UNSTABLE**
-   *
-   * This capability is not part of the spec yet, and may be removed or changed at any point.
-   *
    * Additional workspace roots reported for this session. Each path must be absolute.
    *
    * When present, this is the complete ordered additional-root list reported
    * by the Agent. Omitted and empty values are equivalent: the response
    * reports no additional roots.
-   *
-   * @experimental
    */
   additionalDirectories?: Array<string>;
   /**
@@ -5149,36 +5020,6 @@ export type SessionModeState = {
    * The current mode the Agent is in.
    */
   currentModeId: SessionModeId;
-};
-
-/**
- * **UNSTABLE**
- *
- * This capability is not part of the spec yet, and may be removed or changed at any point.
- *
- * The set of models and the one currently active.
- *
- * @experimental
- */
-export type SessionModelState = {
-  /**
-   * The _meta property is reserved by ACP to allow clients and agents to attach additional
-   * metadata to their interactions. Implementations MUST NOT make assumptions about values at
-   * these keys.
-   *
-   * See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-   */
-  _meta?: {
-    [key: string]: unknown;
-  } | null;
-  /**
-   * The set of models that the Agent can use
-   */
-  availableModels: Array<ModelInfo>;
-  /**
-   * The current model the Agent is in.
-   */
-  currentModelId: ModelId;
 };
 
 /**
@@ -5426,58 +5267,6 @@ export type SetSessionModeRequest = {
  * Response to `session/set_mode` method.
  */
 export type SetSessionModeResponse = {
-  /**
-   * The _meta property is reserved by ACP to allow clients and agents to attach additional
-   * metadata to their interactions. Implementations MUST NOT make assumptions about values at
-   * these keys.
-   *
-   * See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-   */
-  _meta?: {
-    [key: string]: unknown;
-  } | null;
-};
-
-/**
- * **UNSTABLE**
- *
- * This capability is not part of the spec yet, and may be removed or changed at any point.
- *
- * Request parameters for setting a session model.
- *
- * @experimental
- */
-export type SetSessionModelRequest = {
-  /**
-   * The _meta property is reserved by ACP to allow clients and agents to attach additional
-   * metadata to their interactions. Implementations MUST NOT make assumptions about values at
-   * these keys.
-   *
-   * See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-   */
-  _meta?: {
-    [key: string]: unknown;
-  } | null;
-  /**
-   * The ID of the model to set.
-   */
-  modelId: ModelId;
-  /**
-   * The ID of the session to set the model for.
-   */
-  sessionId: SessionId;
-};
-
-/**
- * **UNSTABLE**
- *
- * This capability is not part of the spec yet, and may be removed or changed at any point.
- *
- * Response to `session/set_model` method.
- *
- * @experimental
- */
-export type SetSessionModelResponse = {
   /**
    * The _meta property is reserved by ACP to allow clients and agents to attach additional
    * metadata to their interactions. Implementations MUST NOT make assumptions about values at

--- a/src/schema/zod.gen.ts
+++ b/src/schema/zod.gen.ts
@@ -791,33 +791,6 @@ export const zMessageMcpRequest = z.object({
 export const zMessageMcpResponse = z.unknown();
 
 /**
- * **UNSTABLE**
- *
- * This capability is not part of the spec yet, and may be removed or changed at any point.
- *
- * A unique identifier for a model.
- *
- * @experimental
- */
-export const zModelId = z.string();
-
-/**
- * **UNSTABLE**
- *
- * This capability is not part of the spec yet, and may be removed or changed at any point.
- *
- * Information about a selectable model.
- *
- * @experimental
- */
-export const zModelInfo = z.object({
-  _meta: z.record(z.string(), z.unknown()).nullish(),
-  description: z.string().nullish(),
-  modelId: zModelId,
-  name: z.string(),
-});
-
-/**
  * Severity of a diagnostic.
  */
 export const zNesDiagnosticSeverity = z.union([
@@ -1675,18 +1648,12 @@ export const zRequestPermissionResponse = z.object({
 });
 
 /**
- * **UNSTABLE**
- *
- * This capability is not part of the spec yet, and may be removed or changed at any point.
- *
  * Capabilities for additional session directories support.
  *
  * By supplying `{}` it means that the agent supports the `additionalDirectories`
  * field on supported session lifecycle requests. Agents that also support
  * `session/list` may return `SessionInfo.additionalDirectories` to report the
  * complete ordered additional-root list associated with a listed session.
- *
- * @experimental
  */
 export const zSessionAdditionalDirectoriesCapabilities = z.object({
   _meta: z.record(z.string(), z.unknown()).nullish(),
@@ -2162,21 +2129,6 @@ export const zSessionModeState = z.object({
  *
  * This capability is not part of the spec yet, and may be removed or changed at any point.
  *
- * The set of models and the one currently active.
- *
- * @experimental
- */
-export const zSessionModelState = z.object({
-  _meta: z.record(z.string(), z.unknown()).nullish(),
-  availableModels: z.array(zModelInfo),
-  currentModelId: zModelId,
-});
-
-/**
- * **UNSTABLE**
- *
- * This capability is not part of the spec yet, and may be removed or changed at any point.
- *
  * Response from forking an existing session.
  *
  * @experimental
@@ -2184,7 +2136,6 @@ export const zSessionModelState = z.object({
 export const zForkSessionResponse = z.object({
   _meta: z.record(z.string(), z.unknown()).nullish(),
   configOptions: z.array(zSessionConfigOption).nullish(),
-  models: zSessionModelState.nullish(),
   modes: zSessionModeState.nullish(),
   sessionId: zSessionId,
 });
@@ -2195,7 +2146,6 @@ export const zForkSessionResponse = z.object({
 export const zLoadSessionResponse = z.object({
   _meta: z.record(z.string(), z.unknown()).nullish(),
   configOptions: z.array(zSessionConfigOption).nullish(),
-  models: zSessionModelState.nullish(),
   modes: zSessionModeState.nullish(),
 });
 
@@ -2207,7 +2157,6 @@ export const zLoadSessionResponse = z.object({
 export const zNewSessionResponse = z.object({
   _meta: z.record(z.string(), z.unknown()).nullish(),
   configOptions: z.array(zSessionConfigOption).nullish(),
-  models: zSessionModelState.nullish(),
   modes: zSessionModeState.nullish(),
   sessionId: zSessionId,
 });
@@ -2218,7 +2167,6 @@ export const zNewSessionResponse = z.object({
 export const zResumeSessionResponse = z.object({
   _meta: z.record(z.string(), z.unknown()).nullish(),
   configOptions: z.array(zSessionConfigOption).nullish(),
-  models: zSessionModelState.nullish(),
   modes: zSessionModeState.nullish(),
 });
 
@@ -2325,34 +2273,6 @@ export const zSetSessionModeRequest = z.object({
  * Response to `session/set_mode` method.
  */
 export const zSetSessionModeResponse = z.object({
-  _meta: z.record(z.string(), z.unknown()).nullish(),
-});
-
-/**
- * **UNSTABLE**
- *
- * This capability is not part of the spec yet, and may be removed or changed at any point.
- *
- * Request parameters for setting a session model.
- *
- * @experimental
- */
-export const zSetSessionModelRequest = z.object({
-  _meta: z.record(z.string(), z.unknown()).nullish(),
-  modelId: zModelId,
-  sessionId: zSessionId,
-});
-
-/**
- * **UNSTABLE**
- *
- * This capability is not part of the spec yet, and may be removed or changed at any point.
- *
- * Response to `session/set_model` method.
- *
- * @experimental
- */
-export const zSetSessionModelResponse = z.object({
   _meta: z.record(z.string(), z.unknown()).nullish(),
 });
 
@@ -3135,7 +3055,6 @@ export const zAgentResponse = z.union([
       zSetSessionModeResponse,
       zSetSessionConfigOptionResponse,
       zPromptResponse,
-      zSetSessionModelResponse,
       zStartNesResponse,
       zSuggestNesResponse,
       zCloseNesResponse,
@@ -3329,7 +3248,6 @@ export const zClientRequest = z.object({
       zSetSessionModeRequest,
       zSetSessionConfigOptionRequest,
       zPromptRequest,
-      zSetSessionModelRequest,
       zStartNesRequest,
       zSuggestNesRequest,
       zCloseNesRequest,


### PR DESCRIPTION
The model selectors have been replaced by session config options.
