### PR TITLE
fix(node-adapter): Cap HTTP request body size

### DIFF
--- a/src/node-adapter.test.ts
+++ b/src/node-adapter.test.ts
@@ -1,5 +1,6 @@
 import http from "node:http";
 import { EventEmitter } from "node:events";
+import { PassThrough, Readable } from "node:stream";
 
 import { describe, expect, it } from "vitest";
 import { AcpServer } from "./server.js";
@@ -244,6 +245,78 @@ describe("createNodeHttpHandler", () => {
     expect(seenBodies).toEqual([body]);
   });
 
+  it("rejects request bodies when Content-Length exceeds the configured limit", async () => {
+    const acpServer = new AcpServer({
+      createAgent: () => createTestAgentApp(),
+    });
+    let forwarded = false;
+    const response = new CapturingServerResponse();
+
+    acpServer.handleRequest = () => {
+      forwarded = true;
+      return Promise.resolve(new Response("unexpected"));
+    };
+
+    const request = fakeOpenRequest({
+      method: "POST",
+      headers: {
+        "content-length": "5",
+      },
+    });
+
+    createNodeHttpHandler(acpServer, { maxRequestBodyBytes: 4 })(
+      request,
+      response as unknown as ServerResponse,
+    );
+
+    await response.finished;
+
+    expect(response.statusCode).toBe(413);
+    expect(response.chunks.join("")).toBe("Request body exceeds 4 bytes");
+    expect(forwarded).toBe(false);
+    expect(() => {
+      request.emit("error", new Error("client reset"));
+    }).not.toThrow();
+    expect(request.listenerCount("error")).toBe(0);
+  });
+
+  it("rejects chunked request bodies when they exceed the configured limit", async () => {
+    const acpServer = new AcpServer({
+      createAgent: () => createTestAgentApp(),
+    });
+    let forwarded = false;
+    const response = new CapturingServerResponse();
+
+    acpServer.handleRequest = () => {
+      forwarded = true;
+      return Promise.resolve(new Response("unexpected"));
+    };
+
+    const request = fakeRequest({
+      method: "POST",
+      bodyChunks: [
+        new TextEncoder().encode("123"),
+        new TextEncoder().encode("45"),
+      ],
+    });
+    let requestClosedBeforeResponse = false;
+    request.once("close", () => {
+      requestClosedBeforeResponse = !response.writableEnded;
+    });
+
+    createNodeHttpHandler(acpServer, { maxRequestBodyBytes: 4 })(
+      request,
+      response as unknown as ServerResponse,
+    );
+
+    await response.finished;
+
+    expect(response.statusCode).toBe(413);
+    expect(response.chunks.join("")).toBe("Request body exceeds 4 bytes");
+    expect(forwarded).toBe(false);
+    expect(requestClosedBeforeResponse).toBe(false);
+  });
+
   it("cancels streaming response bodies when the Node response closes while backpressured", async () => {
     const acpServer = new AcpServer({
       createAgent: () => createTestAgentApp(),
@@ -421,7 +494,7 @@ function fakeRequest(
     readonly bodyChunks?: readonly Uint8Array[];
   } = {},
 ): IncomingMessage {
-  const request = Object.assign(new EventEmitter(), {
+  const request = Object.assign(Readable.from(options.bodyChunks ?? []), {
     method: options.method ?? "GET",
     url: "/acp",
     headers: {
@@ -430,11 +503,21 @@ function fakeRequest(
     },
   });
 
-  Object.assign(request, {
-    async *[Symbol.asyncIterator]() {
-      for (const chunk of options.bodyChunks ?? []) {
-        yield chunk;
-      }
+  return request as unknown as IncomingMessage;
+}
+
+function fakeOpenRequest(
+  options: {
+    readonly method?: string;
+    readonly headers?: Record<string, string>;
+  } = {},
+): IncomingMessage {
+  const request = Object.assign(new PassThrough(), {
+    method: options.method ?? "GET",
+    url: "/acp",
+    headers: {
+      host: "127.0.0.1",
+      ...options.headers,
     },
   });
 

--- a/src/node-adapter.ts
+++ b/src/node-adapter.ts
@@ -9,6 +9,12 @@ type NodeWebSocketHeadersListener = (
   request: IncomingMessage,
 ) => void;
 
+export const DEFAULT_MAX_REQUEST_BODY_BYTES = 16 * 1024 * 1024;
+
+export interface NodeHttpHandlerOptions {
+  readonly maxRequestBodyBytes?: number;
+}
+
 export interface NodeWebSocketUpgradeServer {
   on(event: "headers", listener: NodeWebSocketHeadersListener): void;
   off(event: "headers", listener: NodeWebSocketHeadersListener): void;
@@ -22,9 +28,14 @@ export interface NodeWebSocketUpgradeServer {
 
 export function createNodeHttpHandler(
   server: AcpServer,
+  options: NodeHttpHandlerOptions = {},
 ): (req: IncomingMessage, res: ServerResponse) => void {
+  const maxRequestBodyBytes = resolveMaxRequestBodyBytes(
+    options.maxRequestBodyBytes,
+  );
+
   return (req, res) => {
-    void handleNodeRequest(server, req, res);
+    void handleNodeRequest(server, req, res, maxRequestBodyBytes);
   };
 }
 
@@ -82,23 +93,73 @@ async function handleNodeRequest(
   server: AcpServer,
   req: IncomingMessage,
   res: ServerResponse,
+  maxRequestBodyBytes: number,
 ): Promise<void> {
   const requestAbort = nodeRequestAbortSignal(req, res);
 
   try {
     await writeNodeResponse(
       res,
-      await server.handleRequest(await toWebRequest(req, requestAbort.signal)),
+      await server.handleRequest(
+        await toWebRequest(req, requestAbort.signal, maxRequestBodyBytes),
+      ),
     );
   } catch (error) {
-    if (!res.headersSent) {
-      res.statusCode = 500;
-      res.setHeader("Content-Type", "text/plain");
+    if (error instanceof RequestBodyTooLargeError) {
+      writePlainTextErrorResponse(res, 413, error.message);
+      drainRejectedRequest(req);
+      return;
     }
 
-    res.end(error instanceof Error ? error.message : "Internal Server Error");
+    writePlainTextErrorResponse(
+      res,
+      500,
+      error instanceof Error ? error.message : "Internal Server Error",
+    );
   } finally {
     requestAbort.cleanup();
+  }
+}
+
+function writePlainTextErrorResponse(
+  res: ServerResponse,
+  statusCode: number,
+  message: string,
+): void {
+  if (!res.headersSent) {
+    res.statusCode = statusCode;
+    res.setHeader("Content-Type", "text/plain");
+  }
+
+  res.end(message);
+}
+
+function drainRejectedRequest(req: IncomingMessage): void {
+  watchRejectedRequest(req, true);
+}
+
+function watchRejectedRequest(req: IncomingMessage, drain = false): void {
+  if (req.destroyed || req.readableEnded) {
+    return;
+  }
+
+  const cleanup = (): void => {
+    req.off("error", onError);
+    req.off("end", cleanup);
+    req.off("close", cleanup);
+    req.off("aborted", cleanup);
+  };
+
+  const onError = (): void => {
+    cleanup();
+  };
+
+  req.once("error", onError);
+  req.once("end", cleanup);
+  req.once("close", cleanup);
+  req.once("aborted", cleanup);
+  if (drain) {
+    req.resume();
   }
 }
 
@@ -144,11 +205,14 @@ function nodeRequestAbortSignal(
 async function toWebRequest(
   req: IncomingMessage,
   signal: AbortSignal,
+  maxRequestBodyBytes: number,
 ): Promise<Request> {
   return new Request(nodeRequestUrl(req), {
     method: req.method ?? "GET",
     headers: nodeHeaders(req),
-    body: hasRequestBody(req) ? await readRequestBody(req) : undefined,
+    body: hasRequestBody(req)
+      ? await readRequestBody(req, maxRequestBodyBytes)
+      : undefined,
     signal,
   });
 }
@@ -157,21 +221,160 @@ function hasRequestBody(req: IncomingMessage): boolean {
   return req.method !== "GET" && req.method !== "HEAD";
 }
 
-async function readRequestBody(req: IncomingMessage): Promise<string> {
-  const decoder = new TextDecoder();
-  let body = "";
+async function readRequestBody(
+  req: IncomingMessage,
+  maxRequestBodyBytes: number,
+): Promise<string> {
+  const contentLength = requestContentLength(req);
 
-  for await (const chunk of req) {
-    if (typeof chunk === "string") {
-      body += decoder.decode();
-      body += chunk;
-      continue;
-    }
-
-    body += decoder.decode(chunk, { stream: true });
+  if (contentLength !== undefined && contentLength > maxRequestBodyBytes) {
+    watchRejectedRequest(req);
+    throw new RequestBodyTooLargeError(maxRequestBodyBytes);
   }
 
-  return body + decoder.decode();
+  const decoder = new TextDecoder();
+
+  return new Promise((resolve, reject) => {
+    let body = "";
+    let receivedBytes = 0;
+    let settled = false;
+
+    const cleanup = (): void => {
+      req.off("data", onData);
+      req.off("end", onEnd);
+      req.off("error", onError);
+      req.off("aborted", onAborted);
+      req.off("close", onClose);
+    };
+
+    const settleRejected = (error: unknown, cleanupNow = true): void => {
+      if (settled) {
+        if (cleanupNow) {
+          cleanup();
+        }
+
+        return;
+      }
+
+      settled = true;
+      if (cleanupNow) {
+        cleanup();
+      }
+
+      reject(error);
+    };
+
+    const onData = (chunk: unknown): void => {
+      if (settled) {
+        return;
+      }
+
+      receivedBytes += requestBodyChunkByteLength(chunk);
+      if (receivedBytes > maxRequestBodyBytes) {
+        req.pause();
+        settleRejected(
+          new RequestBodyTooLargeError(maxRequestBodyBytes),
+          false,
+        );
+        return;
+      }
+
+      if (typeof chunk === "string") {
+        body += decoder.decode();
+        body += chunk;
+        return;
+      }
+
+      body += decoder.decode(requestBodyChunkBytes(chunk), { stream: true });
+    };
+
+    const onEnd = (): void => {
+      cleanup();
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      resolve(body + decoder.decode());
+    };
+
+    const onError = (error: Error): void => {
+      settleRejected(error);
+    };
+
+    const onAborted = (): void => {
+      settleRejected(new Error("Request aborted"));
+    };
+
+    const onClose = (): void => {
+      settleRejected(new Error("Request closed"));
+    };
+
+    req.once("end", onEnd);
+    req.once("error", onError);
+    req.once("aborted", onAborted);
+    req.once("close", onClose);
+    req.on("data", onData);
+  });
+}
+
+function resolveMaxRequestBodyBytes(value: number | undefined): number {
+  const maxRequestBodyBytes = value ?? DEFAULT_MAX_REQUEST_BODY_BYTES;
+
+  if (!Number.isSafeInteger(maxRequestBodyBytes) || maxRequestBodyBytes < 0) {
+    throw new RangeError(
+      "maxRequestBodyBytes must be a non-negative safe integer",
+    );
+  }
+
+  return maxRequestBodyBytes;
+}
+
+function requestContentLength(req: IncomingMessage): number | undefined {
+  const header = req.headers["content-length"];
+  const value = Array.isArray(header) ? header[0] : header;
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+
+  if (!/^\d+$/.test(normalized)) {
+    return undefined;
+  }
+
+  const contentLength = Number(normalized);
+
+  return Number.isSafeInteger(contentLength)
+    ? contentLength
+    : Number.POSITIVE_INFINITY;
+}
+
+function requestBodyChunkByteLength(chunk: unknown): number {
+  if (typeof chunk === "string") {
+    return Buffer.byteLength(chunk);
+  }
+
+  if (chunk instanceof Uint8Array) {
+    return chunk.byteLength;
+  }
+
+  return Buffer.byteLength(String(chunk));
+}
+
+function requestBodyChunkBytes(chunk: unknown): Uint8Array {
+  if (chunk instanceof Uint8Array) {
+    return chunk;
+  }
+
+  return Buffer.from(String(chunk));
+}
+
+class RequestBodyTooLargeError extends Error {
+  constructor(maxRequestBodyBytes: number) {
+    super(`Request body exceeds ${maxRequestBodyBytes} bytes`);
+  }
 }
 
 function nodeRequestUrl(req: IncomingMessage): string {


### PR DESCRIPTION
Reject oversized Node HTTP adapter requests with 413 responses before
forwarding them to AcpServer. Enforce both Content-Length and streamed
chunk limits.
