### PR TITLE
feat: proxy() — typed ACP proxies, the TS counterpart of the Rust Proxy role

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you're building an [Agent](https://agentclientprotocol.com/protocol/overview#
 
 If you're building a [Client](https://agentclientprotocol.com/protocol/overview#client), start with `client({ name })`, register client-side handlers such as `requestPermission(...)` and `sessionUpdate(...)`, then run your agent workflow with `connectWith(stream, async (ctx) => ...)`.
 
-If you're building something that sits between the two — a logger, an authorization gate, a message transformer — start with `proxy({ client, agent })`. It forwards all traffic in both directions by default, and handlers can observe, rewrite, answer, or drop messages before they're forwarded.
+If you're building something that sits between the two — a logger, an authorization gate, a message transformer — start with `proxy()`. Register typed handlers on `p.client` (traffic from the client) and `p.agent` (traffic from the agent) just like the agent/client builders, then call `p.connect({ client, agent })`. Anything you don't claim is forwarded untouched in both directions; handlers can rewrite, answer, or drop messages before they cross.
 
 ### Study a Production Implementation
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ If you're building an [Agent](https://agentclientprotocol.com/protocol/overview#
 
 If you're building a [Client](https://agentclientprotocol.com/protocol/overview#client), start with `client({ name })`, register client-side handlers such as `requestPermission(...)` and `sessionUpdate(...)`, then run your agent workflow with `connectWith(stream, async (ctx) => ...)`.
 
+If you're building something that sits between the two — a logger, an authorization gate, a message transformer — start with `proxy({ client, agent })`. It forwards all traffic in both directions by default, and handlers can observe, rewrite, answer, or drop messages before they're forwarded.
+
 ### Study a Production Implementation
 
 For a complete, production-ready implementation, check out the [Gemini CLI Agent](https://github.com/google-gemini/gemini-cli/blob/main/packages/cli/src/zed-integration/zedIntegration.ts).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you're building an [Agent](https://agentclientprotocol.com/protocol/overview#
 
 If you're building a [Client](https://agentclientprotocol.com/protocol/overview#client), start with `client({ name })`, register client-side handlers such as `requestPermission(...)` and `sessionUpdate(...)`, then run your agent workflow with `connectWith(stream, async (ctx) => ...)`.
 
-If you're building something that sits between the two — a logger, an authorization gate, a message transformer — start with `proxy()`. Register typed handlers on `p.client` (traffic from the client) and `p.agent` (traffic from the agent) just like the agent/client builders, then call `p.connect({ client, agent })`. Anything you don't claim is forwarded untouched in both directions; handlers can rewrite, answer, or drop messages before they cross.
+If you're building something that sits between the two — a logger, an authorization gate, a message transformer — start with `proxy()`. Register typed handlers with `onRequestFromClient(...)` / `onNotificationFromAgent(...)` (the method names say which direction they intercept) just like the agent/client builders, then call `connect({ client, agent })`. Anything you don't claim is forwarded untouched in both directions; handlers can rewrite, answer, or drop messages before they cross.
 
 ### Study a Production Implementation
 

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -52,15 +52,40 @@ export function ndJsonStream(
   return createJsonStream(output, input);
 }
 
-export { RequestError } from "./jsonrpc.js";
+export * from "./proxy.js";
+// The lower-level JSON-RPC peer layer. `agent(...)` and `client(...)` are
+// typed sugar over `Connection`; it is exported for integrations that need
+// message-level dispatch — proxies, routers, and middleware that intercept
+// traffic before a typed handler would see it.
+export {
+  Connection,
+  ConnectionBuilder,
+  ConnectionContext,
+  Handled,
+  HandlerRegistration,
+  RequestError,
+  RequestResponder,
+  isJsonRpcMessage,
+  isNotificationMessage,
+  isRequestMessage,
+  isResponseMessage,
+} from "./jsonrpc.js";
 export type {
   AnyMessage,
   AnyNotification,
   AnyRequest,
   AnyResponse,
+  ConnectionOptions,
   ErrorResponse,
+  HandleResult,
+  IncomingMessage,
+  IncomingNotification,
+  IncomingRequest,
+  JsonRpcHandler,
   JsonRpcId,
   MaybePromise,
+  NotificationCallback,
+  RequestCallback,
   Result,
   SendRequestOptions,
 } from "./jsonrpc.js";
@@ -68,7 +93,6 @@ export type {
 import type { WireStream } from "./stream.js";
 import { Connection, Handled, HandlerRegistration } from "./jsonrpc.js";
 import type {
-  AnyWireMessage,
   ConnectionBuilder,
   ConnectionContext,
   ConnectionOptions,
@@ -93,9 +117,16 @@ function isStream(value: unknown): value is WireStream {
   );
 }
 
-function memoryStreamPair(): [WireStream, WireStream] {
-  const leftToRight = new TransformStream<AnyWireMessage>();
-  const rightToLeft = new TransformStream<AnyWireMessage>();
+/**
+ * Creates a pair of in-memory streams wired back to back.
+ *
+ * Messages written to one stream are read from the other. Use this to
+ * connect ACP endpoints in the same process — for example an app to a
+ * `proxy(...)` side, or endpoints under test — without a transport.
+ */
+export function inMemoryStreamPair(): [Stream, Stream] {
+  const leftToRight = new TransformStream<AnyMessage>();
+  const rightToLeft = new TransformStream<AnyMessage>();
   return [
     {
       readable: rightToLeft.readable,
@@ -1806,8 +1837,22 @@ const runAgentConnectHandlers = Symbol("runAgentConnectHandlers");
 const runClientConnectHandlers = Symbol("runClientConnectHandlers");
 const stableConnectionOptions: ConnectionOptions = { allowBatches: false };
 
-type AppConnectOptions = {
+/**
+ * Options accepted by `AgentApp.connect(...)` and `ClientApp.connect(...)`.
+ */
+export type AppConnectOptions = {
+  /** @internal */
   readonly deferConnectHandlers?: boolean;
+  /**
+   * Raw JSON-RPC handlers to run before this app's typed handlers.
+   *
+   * Handlers see every incoming request and notification and can observe
+   * them, rewrite them with `Handled.no(message)`, or consume them with
+   * `Handled.yes()` before a typed handler runs. Use this for
+   * connection-level middleware — logging, authorization, or parameter
+   * rewriting — without changing the app's registered handlers.
+   */
+  readonly handlers?: JsonRpcHandler[];
 };
 
 type AgentConnectionState = {
@@ -1861,9 +1906,9 @@ export class AgentApp {
   /**
    * Connects this agent app to a transport stream.
    */
-  connect(stream: Stream): AgentConnection;
+  connect(stream: Stream, options?: AppConnectOptions): AgentConnection;
   /** @internal */
-  connect(stream: WireStream, options: AppConnectOptions): AgentConnection;
+  connect(stream: WireStream, options?: AppConnectOptions): AgentConnection;
   /**
    * Connects this agent app directly to a client app.
    *
@@ -2036,20 +2081,20 @@ export class AgentApp {
     options: AppConnectOptions = {},
   ): AgentConnectionState {
     if (isStream(target)) {
-      const state = this.openStreamConnection(target);
+      const state = this.openStreamConnection(target, options);
       if (!options.deferConnectHandlers) {
         this[runAgentConnectHandlers](state.connection);
       }
       return state;
     }
 
-    const [thisStream, peerStream] = memoryStreamPair();
+    const [thisStream, peerStream] = inMemoryStreamPair();
     const peerRawConnection = target[appBuilder]().connect(
       peerStream,
       stableConnectionOptions,
     );
     const peerConnection = clientConnection(peerRawConnection);
-    const state = this.openStreamConnection(thisStream);
+    const state = this.openStreamConnection(thisStream, options);
     void state.rawConnection.closed.then(() => peerConnection.close());
     void peerRawConnection.closed.then(() => state.connection.close());
     try {
@@ -2063,8 +2108,14 @@ export class AgentApp {
     return state;
   }
 
-  private openStreamConnection(stream: WireStream): AgentConnectionState {
-    const rawConnection = this.builder.connect(stream, stableConnectionOptions);
+  private openStreamConnection(
+    stream: WireStream,
+    options: AppConnectOptions = {},
+  ): AgentConnectionState {
+    const rawConnection = this.builder.connect(stream, {
+      ...stableConnectionOptions,
+      handlers: options.handlers,
+    });
     return {
       rawConnection,
       connection: agentConnection(rawConnection, this.connectHandlers),
@@ -2118,7 +2169,7 @@ export class ClientApp {
   /**
    * Connects this client app to a transport stream.
    */
-  connect(stream: Stream): ClientConnection;
+  connect(stream: Stream, options?: AppConnectOptions): ClientConnection;
   /**
    * Connects this client app directly to an agent app.
    *
@@ -2126,8 +2177,11 @@ export class ClientApp {
    * transport.
    */
   connect(agent: AgentApp): ClientConnection;
-  connect(target: WireStream | AgentApp): ClientConnection {
-    return this.connectConnection(target).connection;
+  connect(
+    target: WireStream | AgentApp,
+    options: AppConnectOptions = {},
+  ): ClientConnection {
+    return this.connectConnection(target, options).connection;
   }
 
   /**
@@ -2285,20 +2339,21 @@ export class ClientApp {
 
   private connectConnection(
     target: WireStream | AgentApp,
+    options: AppConnectOptions = {},
   ): ClientConnectionState {
     if (isStream(target)) {
-      const state = this.openStreamConnection(target);
+      const state = this.openStreamConnection(target, options);
       this[runClientConnectHandlers](state.connection);
       return state;
     }
 
-    const [thisStream, peerStream] = memoryStreamPair();
+    const [thisStream, peerStream] = inMemoryStreamPair();
     const peerRawConnection = target[appBuilder]().connect(
       peerStream,
       stableConnectionOptions,
     );
     const peerConnection = agentConnection(peerRawConnection);
-    const state = this.openStreamConnection(thisStream);
+    const state = this.openStreamConnection(thisStream, options);
     void state.rawConnection.closed.then(() => peerConnection.close());
     void peerRawConnection.closed.then(() => state.connection.close());
     try {
@@ -2312,8 +2367,14 @@ export class ClientApp {
     return state;
   }
 
-  private openStreamConnection(stream: WireStream): ClientConnectionState {
-    const rawConnection = this.builder.connect(stream, stableConnectionOptions);
+  private openStreamConnection(
+    stream: WireStream,
+    options: AppConnectOptions = {},
+  ): ClientConnectionState {
+    const rawConnection = this.builder.connect(stream, {
+      ...stableConnectionOptions,
+      handlers: options.handlers,
+    });
     return {
       rawConnection,
       connection: clientConnection(rawConnection, this.connectHandlers),

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -52,7 +52,8 @@ export function ndJsonStream(
   return createJsonStream(output, input);
 }
 
-export * from "./proxy.js";
+export { proxy } from "./proxy.js";
+export type { ProxyHandle, ProxyOptions } from "./proxy.js";
 // The lower-level JSON-RPC peer layer. `agent(...)` and `client(...)` are
 // typed sugar over `Connection`; it is exported for integrations that need
 // message-level dispatch — proxies, routers, and middleware that intercept
@@ -91,7 +92,12 @@ export type {
 } from "./jsonrpc.js";
 
 import type { WireStream } from "./stream.js";
-import { Connection, Handled, HandlerRegistration } from "./jsonrpc.js";
+import {
+  Connection,
+  Handled,
+  HandlerRegistration,
+  linkClosed,
+} from "./jsonrpc.js";
 import type {
   ConnectionBuilder,
   ConnectionContext,
@@ -2081,7 +2087,7 @@ export class AgentApp {
     options: AppConnectOptions = {},
   ): AgentConnectionState {
     if (isStream(target)) {
-      const state = this.openStreamConnection(target, options);
+      const state = this.openStreamConnection(target, options.handlers);
       if (!options.deferConnectHandlers) {
         this[runAgentConnectHandlers](state.connection);
       }
@@ -2094,9 +2100,8 @@ export class AgentApp {
       stableConnectionOptions,
     );
     const peerConnection = clientConnection(peerRawConnection);
-    const state = this.openStreamConnection(thisStream, options);
-    void state.rawConnection.closed.then(() => peerConnection.close());
-    void peerRawConnection.closed.then(() => state.connection.close());
+    const state = this.openStreamConnection(thisStream, options.handlers);
+    linkClosed(state.rawConnection, peerRawConnection);
     try {
       target[runClientConnectHandlers](peerConnection);
       this[runAgentConnectHandlers](state.connection);
@@ -2110,11 +2115,11 @@ export class AgentApp {
 
   private openStreamConnection(
     stream: WireStream,
-    options: AppConnectOptions = {},
+    handlers?: JsonRpcHandler[],
   ): AgentConnectionState {
     const rawConnection = this.builder.connect(stream, {
       ...stableConnectionOptions,
-      handlers: options.handlers,
+      handlers,
     });
     return {
       rawConnection,
@@ -2342,7 +2347,7 @@ export class ClientApp {
     options: AppConnectOptions = {},
   ): ClientConnectionState {
     if (isStream(target)) {
-      const state = this.openStreamConnection(target, options);
+      const state = this.openStreamConnection(target, options.handlers);
       this[runClientConnectHandlers](state.connection);
       return state;
     }
@@ -2353,9 +2358,8 @@ export class ClientApp {
       stableConnectionOptions,
     );
     const peerConnection = agentConnection(peerRawConnection);
-    const state = this.openStreamConnection(thisStream, options);
-    void state.rawConnection.closed.then(() => peerConnection.close());
-    void peerRawConnection.closed.then(() => state.connection.close());
+    const state = this.openStreamConnection(thisStream, options.handlers);
+    linkClosed(state.rawConnection, peerRawConnection);
     try {
       target[runAgentConnectHandlers](peerConnection);
       this[runClientConnectHandlers](state.connection);
@@ -2369,11 +2373,11 @@ export class ClientApp {
 
   private openStreamConnection(
     stream: WireStream,
-    options: AppConnectOptions = {},
+    handlers?: JsonRpcHandler[],
   ): ClientConnectionState {
     const rawConnection = this.builder.connect(stream, {
       ...stableConnectionOptions,
-      handlers: options.handlers,
+      handlers,
     });
     return {
       rawConnection,

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -52,48 +52,29 @@ export function ndJsonStream(
   return createJsonStream(output, input);
 }
 
-export { proxy, ProxyBuilder, ProxySideBuilder } from "./proxy.js";
+export { proxy } from "./proxy.js";
+// ProxyBuilder and ProxySideBuilder are type-only on purpose: proxy() is the
+// sole factory, so their constructors are not part of the public contract.
 export type {
+  ProxyBuilder,
   ProxyHandle,
   ProxyNotificationContext,
   ProxyNotificationHandler,
   ProxyRequestContext,
   ProxyRequestHandler,
+  ProxySideBuilder,
+  ProxySideConnection,
   ProxyStreams,
 } from "./proxy.js";
-// The lower-level JSON-RPC peer layer. `agent(...)` and `client(...)` are
-// typed sugar over `Connection`; it is exported for integrations that need
-// message-level dispatch — proxies, routers, and middleware that intercept
-// traffic before a typed handler would see it.
-export {
-  Connection,
-  ConnectionBuilder,
-  ConnectionContext,
-  Handled,
-  HandlerRegistration,
-  RequestError,
-  RequestResponder,
-  isJsonRpcMessage,
-  isNotificationMessage,
-  isRequestMessage,
-  isResponseMessage,
-} from "./jsonrpc.js";
+export { RequestError } from "./jsonrpc.js";
 export type {
   AnyMessage,
   AnyNotification,
   AnyRequest,
   AnyResponse,
-  ConnectionOptions,
   ErrorResponse,
-  HandleResult,
-  IncomingMessage,
-  IncomingNotification,
-  IncomingRequest,
-  JsonRpcHandler,
   JsonRpcId,
   MaybePromise,
-  NotificationCallback,
-  RequestCallback,
   Result,
   SendRequestOptions,
 } from "./jsonrpc.js";
@@ -1850,22 +1831,8 @@ const runAgentConnectHandlers = Symbol("runAgentConnectHandlers");
 const runClientConnectHandlers = Symbol("runClientConnectHandlers");
 const stableConnectionOptions: ConnectionOptions = { allowBatches: false };
 
-/**
- * Options accepted by `AgentApp.connect(...)` and `ClientApp.connect(...)`.
- */
-export type AppConnectOptions = {
-  /** @internal */
+type AppConnectOptions = {
   readonly deferConnectHandlers?: boolean;
-  /**
-   * Raw JSON-RPC handlers to run before this app's typed handlers.
-   *
-   * Handlers see every incoming request and notification and can observe
-   * them, rewrite them with `Handled.no(message)`, or consume them with
-   * `Handled.yes()` before a typed handler runs. Use this for
-   * connection-level middleware — logging, authorization, or parameter
-   * rewriting — without changing the app's registered handlers.
-   */
-  readonly handlers?: JsonRpcHandler[];
 };
 
 type AgentConnectionState = {
@@ -1919,9 +1886,9 @@ export class AgentApp {
   /**
    * Connects this agent app to a transport stream.
    */
-  connect(stream: Stream, options?: AppConnectOptions): AgentConnection;
+  connect(stream: Stream): AgentConnection;
   /** @internal */
-  connect(stream: WireStream, options?: AppConnectOptions): AgentConnection;
+  connect(stream: WireStream, options: AppConnectOptions): AgentConnection;
   /**
    * Connects this agent app directly to a client app.
    *
@@ -2094,7 +2061,7 @@ export class AgentApp {
     options: AppConnectOptions = {},
   ): AgentConnectionState {
     if (isStream(target)) {
-      const state = this.openStreamConnection(target, options.handlers);
+      const state = this.openStreamConnection(target);
       if (!options.deferConnectHandlers) {
         this[runAgentConnectHandlers](state.connection);
       }
@@ -2107,7 +2074,7 @@ export class AgentApp {
       stableConnectionOptions,
     );
     const peerConnection = clientConnection(peerRawConnection);
-    const state = this.openStreamConnection(thisStream, options.handlers);
+    const state = this.openStreamConnection(thisStream);
     linkClosed(state.rawConnection, peerRawConnection);
     try {
       target[runClientConnectHandlers](peerConnection);
@@ -2120,14 +2087,8 @@ export class AgentApp {
     return state;
   }
 
-  private openStreamConnection(
-    stream: WireStream,
-    handlers?: JsonRpcHandler[],
-  ): AgentConnectionState {
-    const rawConnection = this.builder.connect(stream, {
-      ...stableConnectionOptions,
-      handlers,
-    });
+  private openStreamConnection(stream: WireStream): AgentConnectionState {
+    const rawConnection = this.builder.connect(stream, stableConnectionOptions);
     return {
       rawConnection,
       connection: agentConnection(rawConnection, this.connectHandlers),
@@ -2181,7 +2142,7 @@ export class ClientApp {
   /**
    * Connects this client app to a transport stream.
    */
-  connect(stream: Stream, options?: AppConnectOptions): ClientConnection;
+  connect(stream: Stream): ClientConnection;
   /**
    * Connects this client app directly to an agent app.
    *
@@ -2189,11 +2150,8 @@ export class ClientApp {
    * transport.
    */
   connect(agent: AgentApp): ClientConnection;
-  connect(
-    target: WireStream | AgentApp,
-    options: AppConnectOptions = {},
-  ): ClientConnection {
-    return this.connectConnection(target, options).connection;
+  connect(target: WireStream | AgentApp): ClientConnection {
+    return this.connectConnection(target).connection;
   }
 
   /**
@@ -2351,10 +2309,9 @@ export class ClientApp {
 
   private connectConnection(
     target: WireStream | AgentApp,
-    options: AppConnectOptions = {},
   ): ClientConnectionState {
     if (isStream(target)) {
-      const state = this.openStreamConnection(target, options.handlers);
+      const state = this.openStreamConnection(target);
       this[runClientConnectHandlers](state.connection);
       return state;
     }
@@ -2365,7 +2322,7 @@ export class ClientApp {
       stableConnectionOptions,
     );
     const peerConnection = agentConnection(peerRawConnection);
-    const state = this.openStreamConnection(thisStream, options.handlers);
+    const state = this.openStreamConnection(thisStream);
     linkClosed(state.rawConnection, peerRawConnection);
     try {
       target[runAgentConnectHandlers](peerConnection);
@@ -2378,14 +2335,8 @@ export class ClientApp {
     return state;
   }
 
-  private openStreamConnection(
-    stream: WireStream,
-    handlers?: JsonRpcHandler[],
-  ): ClientConnectionState {
-    const rawConnection = this.builder.connect(stream, {
-      ...stableConnectionOptions,
-      handlers,
-    });
+  private openStreamConnection(stream: WireStream): ClientConnectionState {
+    const rawConnection = this.builder.connect(stream, stableConnectionOptions);
     return {
       rawConnection,
       connection: clientConnection(rawConnection, this.connectHandlers),

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -52,8 +52,15 @@ export function ndJsonStream(
   return createJsonStream(output, input);
 }
 
-export { proxy } from "./proxy.js";
-export type { ProxyHandle, ProxyOptions } from "./proxy.js";
+export { proxy, ProxyBuilder, ProxySideBuilder } from "./proxy.js";
+export type {
+  ProxyHandle,
+  ProxyNotificationContext,
+  ProxyNotificationHandler,
+  ProxyRequestContext,
+  ProxyRequestHandler,
+  ProxyStreams,
+} from "./proxy.js";
 // The lower-level JSON-RPC peer layer. `agent(...)` and `client(...)` are
 // typed sugar over `Connection`; it is exported for integrations that need
 // message-level dispatch — proxies, routers, and middleware that intercept

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -62,10 +62,8 @@ export type {
   ProxyNotificationHandler,
   ProxyRequestContext,
   ProxyRequestHandler,
-  ProxySideBuilder,
   ProxySideConnection,
   ProxyStreams,
-  ProxyTap,
 } from "./proxy.js";
 export { RequestError } from "./jsonrpc.js";
 export type {

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -65,6 +65,7 @@ export type {
   ProxySideBuilder,
   ProxySideConnection,
   ProxyStreams,
+  ProxyTap,
 } from "./proxy.js";
 export { RequestError } from "./jsonrpc.js";
 export type {
@@ -75,6 +76,7 @@ export type {
   ErrorResponse,
   JsonRpcId,
   MaybePromise,
+  ParamsParser,
   Result,
   SendRequestOptions,
 } from "./jsonrpc.js";
@@ -85,6 +87,7 @@ import {
   Handled,
   HandlerRegistration,
   linkClosed,
+  parseParams,
 } from "./jsonrpc.js";
 import type {
   ConnectionBuilder,
@@ -93,6 +96,7 @@ import type {
   HandleResult,
   IncomingMessage,
   JsonRpcId,
+  ParamsParser,
   JsonRpcHandler,
   MaybePromise,
   SendRequestOptions,
@@ -968,14 +972,6 @@ export type AppOptions = {
  * A Zod schema can be passed directly because schemas expose a compatible
  * `parse(...)` method.
  */
-export type ParamsParser<Params> =
-  | {
-      /**
-       * Parses raw JSON-RPC params into the handler's typed params.
-       */
-      parse: (params: unknown) => Params;
-    }
-  | ((params: unknown) => Params);
 
 /**
  * Common context passed to agent-side handlers.
@@ -1090,21 +1086,6 @@ export type AgentConnectHandler = (
 export type ClientConnectHandler = (
   connection: ClientConnection,
 ) => MaybePromise<void>;
-
-function parseParams<Params>(
-  parser: ParamsParser<Params> | undefined,
-  params: unknown,
-): Params {
-  if (!parser) {
-    return params as Params;
-  }
-
-  if (typeof parser === "function") {
-    return parser(params);
-  }
-
-  return parser.parse(params);
-}
 
 type AcpRequestSpec<Params, Response, WireResponse = Response> = {
   method: string;

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -105,14 +105,7 @@ function isStream(value: unknown): value is WireStream {
   );
 }
 
-/**
- * Creates a pair of in-memory streams wired back to back.
- *
- * Messages written to one stream are read from the other. Use this to
- * connect ACP endpoints in the same process — for example an app to a
- * `proxy(...)` side, or endpoints under test — without a transport.
- */
-export function inMemoryStreamPair(): [Stream, Stream] {
+function memoryStreamPair(): [Stream, Stream] {
   const leftToRight = new TransformStream<AnyMessage>();
   const rightToLeft = new TransformStream<AnyMessage>();
   return [
@@ -2062,7 +2055,7 @@ export class AgentApp {
       return state;
     }
 
-    const [thisStream, peerStream] = inMemoryStreamPair();
+    const [thisStream, peerStream] = memoryStreamPair();
     const peerRawConnection = target[appBuilder]().connect(
       peerStream,
       stableConnectionOptions,
@@ -2311,7 +2304,7 @@ export class ClientApp {
       return state;
     }
 
-    const [thisStream, peerStream] = inMemoryStreamPair();
+    const [thisStream, peerStream] = memoryStreamPair();
     const peerRawConnection = target[appBuilder]().connect(
       peerStream,
       stableConnectionOptions,

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -53,8 +53,8 @@ export function ndJsonStream(
 }
 
 export { proxy } from "./proxy.js";
-// ProxyBuilder and ProxySideBuilder are type-only on purpose: proxy() is the
-// sole factory, so their constructors are not part of the public contract.
+// ProxyBuilder is type-only on purpose: proxy() is the sole factory, so its
+// constructor is not part of the public contract.
 export type {
   ProxyBuilder,
   ProxyHandle,
@@ -74,19 +74,12 @@ export type {
   ErrorResponse,
   JsonRpcId,
   MaybePromise,
-  ParamsParser,
   Result,
   SendRequestOptions,
 } from "./jsonrpc.js";
 
 import type { WireStream } from "./stream.js";
-import {
-  Connection,
-  Handled,
-  HandlerRegistration,
-  linkClosed,
-  parseParams,
-} from "./jsonrpc.js";
+import { Connection, Handled, HandlerRegistration } from "./jsonrpc.js";
 import type {
   ConnectionBuilder,
   ConnectionContext,
@@ -94,7 +87,6 @@ import type {
   HandleResult,
   IncomingMessage,
   JsonRpcId,
-  ParamsParser,
   JsonRpcHandler,
   MaybePromise,
   SendRequestOptions,
@@ -970,6 +962,14 @@ export type AppOptions = {
  * A Zod schema can be passed directly because schemas expose a compatible
  * `parse(...)` method.
  */
+export type ParamsParser<Params> =
+  | {
+      /**
+       * Parses raw JSON-RPC params into the handler's typed params.
+       */
+      parse: (params: unknown) => Params;
+    }
+  | ((params: unknown) => Params);
 
 /**
  * Common context passed to agent-side handlers.
@@ -1084,6 +1084,21 @@ export type AgentConnectHandler = (
 export type ClientConnectHandler = (
   connection: ClientConnection,
 ) => MaybePromise<void>;
+
+function parseParams<Params>(
+  parser: ParamsParser<Params> | undefined,
+  params: unknown,
+): Params {
+  if (!parser) {
+    return params as Params;
+  }
+
+  if (typeof parser === "function") {
+    return parser(params);
+  }
+
+  return parser.parse(params);
+}
 
 type AcpRequestSpec<Params, Response, WireResponse = Response> = {
   method: string;
@@ -2054,7 +2069,8 @@ export class AgentApp {
     );
     const peerConnection = clientConnection(peerRawConnection);
     const state = this.openStreamConnection(thisStream);
-    linkClosed(state.rawConnection, peerRawConnection);
+    void state.rawConnection.closed.then(() => peerConnection.close());
+    void peerRawConnection.closed.then(() => state.connection.close());
     try {
       target[runClientConnectHandlers](peerConnection);
       this[runAgentConnectHandlers](state.connection);
@@ -2302,7 +2318,8 @@ export class ClientApp {
     );
     const peerConnection = agentConnection(peerRawConnection);
     const state = this.openStreamConnection(thisStream);
-    linkClosed(state.rawConnection, peerRawConnection);
+    void state.rawConnection.closed.then(() => peerConnection.close());
+    void peerRawConnection.closed.then(() => state.connection.close());
     try {
       target[runAgentConnectHandlers](peerConnection);
       this[runClientConnectHandlers](state.connection);

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -4,6 +4,7 @@ This directory contains examples using the [ACP](https://agentclientprotocol.com
 
 - [`agent.ts`](./agent.ts) - A minimal agent implementation that simulates LLM interaction
 - [`client.ts`](./client.ts) - A minimal client implementation that spawns the [`agent.ts`](./agent.ts) as a subprocess
+- [`proxy.ts`](./proxy.ts) - A pass-through proxy that wraps any agent command and logs the messages crossing it in both directions
 - [`http-server.ts`](./http-server.ts) - A minimal ACP Streamable HTTP server with WebSocket upgrade support
 - [`http-client.ts`](./http-client.ts) - A minimal client using `createHttpStream`
 - [`ws-client.ts`](./ws-client.ts) - A minimal client using `createWebSocketStream`

--- a/src/examples/proxy.ts
+++ b/src/examples/proxy.ts
@@ -65,6 +65,9 @@ const handle = acp
     ),
   });
 
-agentProcess.once("exit", () => handle.close());
+// Let stdout EOF drive graceful proxy shutdown so every message the child
+// wrote before exiting can be relayed. Spawn and process errors do not provide
+// that guarantee, so close both proxy sides immediately in that case.
+agentProcess.once("error", (error) => handle.close(error));
 await handle.closed;
 agentProcess.kill();

--- a/src/examples/proxy.ts
+++ b/src/examples/proxy.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { Readable, Writable } from "node:stream";
+import { fileURLToPath } from "node:url";
+
+import * as acp from "../acp.js";
+
+// A minimal ACP proxy: it presents as an agent on its own stdio, spawns the
+// real agent as a subprocess, and forwards every message between the two
+// while logging traffic to stderr. Point an ACP client (like Zed) at this
+// script exactly as it would run the agent directly — neither side needs to
+// know the proxy is there.
+//
+// Usage: proxy.ts [command args...]
+// Runs the example agent from this directory when no command is given.
+
+/** Logs each request and notification crossing the proxy, then passes it on. */
+function snoop(direction: string): acp.JsonRpcHandler {
+  return {
+    handleMessage(message) {
+      console.error(`[proxy] ${direction} ${message.kind}: ${message.method}`);
+      return acp.Handled.no(message);
+    },
+  };
+}
+
+// Spawn the wrapped agent: the command from argv, or the example agent.
+const npxCmd = process.platform === "win32" ? "npx.cmd" : "npx";
+const exampleAgent = join(dirname(fileURLToPath(import.meta.url)), "agent.ts");
+const [command, ...args] =
+  process.argv.length > 2
+    ? process.argv.slice(2)
+    : [npxCmd, "tsx", exampleAgent];
+const agentProcess = spawn(command, args, {
+  stdio: ["pipe", "pipe", "inherit"],
+});
+
+const handle = acp.proxy({
+  client: acp.ndJsonStream(
+    Writable.toWeb(process.stdout),
+    Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>,
+  ),
+  agent: acp.ndJsonStream(
+    Writable.toWeb(agentProcess.stdin!),
+    Readable.toWeb(agentProcess.stdout!) as ReadableStream<Uint8Array>,
+  ),
+  fromClient: [snoop("client → agent")],
+  fromAgent: [snoop("agent → client")],
+});
+
+agentProcess.once("exit", () => handle.close());
+await handle.closed;
+agentProcess.kill();

--- a/src/examples/proxy.ts
+++ b/src/examples/proxy.ts
@@ -37,7 +37,13 @@ const agentProcess = spawn(command, args, {
   stdio: ["pipe", "pipe", "inherit"],
 });
 
-const handle = acp.proxy({
+const p = acp.proxy();
+// Raw handlers see every message; typed interception is also available, e.g.
+// p.client.onRequest("session/prompt", async ({ params, forward }) => ...).
+p.client.withHandler(snoop("client → agent"));
+p.agent.withHandler(snoop("agent → client"));
+
+const handle = p.connect({
   client: acp.ndJsonStream(
     Writable.toWeb(process.stdout),
     Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>,
@@ -46,8 +52,6 @@ const handle = acp.proxy({
     Writable.toWeb(agentProcess.stdin!),
     Readable.toWeb(agentProcess.stdout!) as ReadableStream<Uint8Array>,
   ),
-  fromClient: [snoop("client → agent")],
-  fromAgent: [snoop("agent → client")],
 });
 
 agentProcess.once("exit", () => handle.close());

--- a/src/examples/proxy.ts
+++ b/src/examples/proxy.ts
@@ -16,14 +16,21 @@ import * as acp from "../acp.js";
 // Usage: proxy.ts [command args...]
 // Runs the example agent from this directory when no command is given.
 
-/** Logs each request and notification crossing the proxy, then passes it on. */
-function snoop(direction: string): acp.JsonRpcHandler {
-  return {
-    handleMessage(message) {
-      console.error(`[proxy] ${direction} ${message.kind}: ${message.method}`);
-      return acp.Handled.no(message);
-    },
-  };
+/** Registers wildcard handlers that log traffic from one peer, then forward. */
+function snoop<
+  R extends Record<string, unknown>,
+  S extends Record<string, unknown>,
+  N extends Record<string, unknown>,
+>(side: acp.ProxySideBuilder<R, S, N>, direction: string): void {
+  side
+    .onRequest("*", ({ method, params, forward }) => {
+      console.error(`[proxy] ${direction} request: ${method}`);
+      return forward(params);
+    })
+    .onNotification("*", async ({ method, params, forward }) => {
+      console.error(`[proxy] ${direction} notification: ${method}`);
+      await forward(params);
+    });
 }
 
 // Spawn the wrapped agent: the command from argv, or the example agent.
@@ -38,10 +45,11 @@ const agentProcess = spawn(command, args, {
 });
 
 const p = acp.proxy();
-// Raw handlers see every message; typed interception is also available, e.g.
+// "*" catches anything without an exact registration; typed interception is
+// also available, e.g.
 // p.client.onRequest("session/prompt", async ({ params, forward }) => ...).
-p.client.withHandler(snoop("client → agent"));
-p.agent.withHandler(snoop("agent → client"));
+snoop(p.client, "client → agent");
+snoop(p.agent, "agent → client");
 
 const handle = p.connect({
   client: acp.ndJsonStream(

--- a/src/examples/proxy.ts
+++ b/src/examples/proxy.ts
@@ -17,11 +17,7 @@ import * as acp from "../acp.js";
 // Runs the example agent from this directory when no command is given.
 
 /** Registers wildcard handlers that log traffic from one peer, then forward. */
-function snoop<
-  R extends Record<string, unknown>,
-  S extends Record<string, unknown>,
-  N extends Record<string, unknown>,
->(side: acp.ProxySideBuilder<R, S, N>, direction: string): void {
+function snoop(side: acp.ProxyTap, direction: string): void {
   side
     .onRequest("*", ({ method, params, forward }) => {
       console.error(`[proxy] ${direction} request: ${method}`);

--- a/src/examples/proxy.ts
+++ b/src/examples/proxy.ts
@@ -16,17 +16,22 @@ import * as acp from "../acp.js";
 // Usage: proxy.ts [command args...]
 // Runs the example agent from this directory when no command is given.
 
-/** Registers wildcard handlers that log traffic from one peer, then forward. */
-function snoop(side: acp.ProxyTap, direction: string): void {
-  side
-    .onRequest("*", ({ method, params, forward }) => {
-      console.error(`[proxy] ${direction} request: ${method}`);
-      return forward(params);
-    })
-    .onNotification("*", async ({ method, params, forward }) => {
-      console.error(`[proxy] ${direction} notification: ${method}`);
-      await forward(params);
-    });
+function logAndForward(
+  direction: string,
+): acp.ProxyRequestHandler<unknown, unknown> {
+  return ({ method, params, forward }) => {
+    console.error(`[proxy] ${direction} request: ${method}`);
+    return forward(params);
+  };
+}
+
+function logAndForwardNotification(
+  direction: string,
+): acp.ProxyNotificationHandler<unknown> {
+  return async ({ method, params, forward }) => {
+    console.error(`[proxy] ${direction} notification: ${method}`);
+    await forward(params);
+  };
 }
 
 // Spawn the wrapped agent: the command from argv, or the example agent.
@@ -40,23 +45,25 @@ const agentProcess = spawn(command, args, {
   stdio: ["pipe", "pipe", "inherit"],
 });
 
-const p = acp.proxy();
 // "*" catches anything without an exact registration; typed interception is
 // also available, e.g.
-// p.client.onRequest("session/prompt", async ({ params, forward }) => ...).
-snoop(p.client, "client → agent");
-snoop(p.agent, "agent → client");
-
-const handle = p.connect({
-  client: acp.ndJsonStream(
-    Writable.toWeb(process.stdout),
-    Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>,
-  ),
-  agent: acp.ndJsonStream(
-    Writable.toWeb(agentProcess.stdin!),
-    Readable.toWeb(agentProcess.stdout!) as ReadableStream<Uint8Array>,
-  ),
-});
+// .onRequestFromClient("session/prompt", async ({ params, forward }) => ...).
+const handle = acp
+  .proxy()
+  .onRequestFromClient("*", logAndForward("client → agent"))
+  .onNotificationFromClient("*", logAndForwardNotification("client → agent"))
+  .onRequestFromAgent("*", logAndForward("agent → client"))
+  .onNotificationFromAgent("*", logAndForwardNotification("agent → client"))
+  .connect({
+    client: acp.ndJsonStream(
+      Writable.toWeb(process.stdout),
+      Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>,
+    ),
+    agent: acp.ndJsonStream(
+      Writable.toWeb(agentProcess.stdin!),
+      Readable.toWeb(agentProcess.stdout!) as ReadableStream<Uint8Array>,
+    ),
+  });
 
 agentProcess.once("exit", () => handle.close());
 await handle.closed;

--- a/src/jsonrpc.test.ts
+++ b/src/jsonrpc.test.ts
@@ -19,8 +19,24 @@ import type { Stream } from "./stream.js";
 
 type ConnectionInternals = {
   pendingResponses: Map<string | number | null, unknown>;
-  incomingEof: boolean;
 };
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  message = "operation timed out",
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), 500);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
 
 describe("JSON-RPC envelope validation", () => {
   it.each([
@@ -1012,230 +1028,69 @@ describe("JSON-RPC request cancellation", () => {
 });
 
 describe("JSON-RPC connection lifecycle", () => {
-  it("lets runUntil drain accepted work after EOF rejects its operation", async () => {
-    const handlerStarted = Promise.withResolvers<void>();
-    const releaseHandler = Promise.withResolvers<void>();
-    const operationRejected = Promise.withResolvers<void>();
-    const writes: AnyWireMessage[] = [];
+  it("aborts ordinary handler signals promptly on EOF", async () => {
+    const requestStarted = Promise.withResolvers<void>();
+    const notificationStarted = Promise.withResolvers<void>();
+    const requestAborted = Promise.withResolvers<void>();
+    const notificationAborted = Promise.withResolvers<void>();
     let incoming!: ReadableStreamDefaultController<AnyWireMessage>;
-    const stream: Stream<AnyWireMessage> = {
-      readable: new ReadableStream<AnyWireMessage>({
-        start(controller) {
-          incoming = controller;
-        },
-      }),
-      writable: new WritableStream<AnyWireMessage>({
-        write(message) {
-          writes.push(message);
-        },
-      }),
-    };
-
-    const running = Connection.builder()
-      .onReceiveNotification(
-        "example/final",
+    let notificationSignal: AbortSignal | undefined;
+    const waitForAbort = (signal: AbortSignal): Promise<void> =>
+      signal.aborted
+        ? Promise.resolve()
+        : new Promise((resolve) =>
+            signal.addEventListener("abort", () => resolve(), { once: true }),
+          );
+    const connection = Connection.builder()
+      .onReceiveRequest(
+        "example/wait",
         (params) => params,
-        async (_params, cx) => {
-          handlerStarted.resolve();
-          await releaseHandler.promise;
-          await cx.sendNotification("example/drained", { ok: true });
+        async (_params, responder) => {
+          requestStarted.resolve();
+          await waitForAbort(responder.signal);
+          requestAborted.resolve();
         },
       )
-      .connectWith(stream, async (cx) => {
-        try {
-          return await cx.sendRequest("example/pending", {});
-        } catch (error) {
-          operationRejected.resolve();
-          throw error;
-        }
+      .onReceiveNotification(
+        "example/wait",
+        (params) => params,
+        async (_params, cx) => {
+          notificationSignal = cx.signal;
+          notificationStarted.resolve();
+          await waitForAbort(cx.signal);
+          notificationAborted.resolve();
+        },
+      )
+      .connect({
+        readable: new ReadableStream<AnyWireMessage>({
+          start(controller) {
+            incoming = controller;
+          },
+        }),
+        writable: new WritableStream<AnyWireMessage>(),
       });
-    void running.catch(() => {});
-
-    await vi.waitFor(() => expect(writes).toHaveLength(1));
-    incoming.enqueue({ jsonrpc: "2.0", method: "example/final" });
-    await handlerStarted.promise;
-    incoming.close();
-    await operationRejected.promise;
-    releaseHandler.resolve();
-
-    await expect(running).rejects.toThrow("ACP connection closed");
-    expect(writes).toEqual([
-      expect.objectContaining({
-        jsonrpc: "2.0",
-        method: "example/pending",
-      }),
-      {
-        jsonrpc: "2.0",
-        method: "example/drained",
-        params: { ok: true },
-      },
-    ]);
-  });
-
-  it("rejects runUntil when EOF starts before its operation settles", async () => {
-    const handlerStarted = Promise.withResolvers<void>();
-    const releaseHandler = Promise.withResolvers<void>();
-    const releaseOperation = Promise.withResolvers<void>();
-    let incoming!: ReadableStreamDefaultController<AnyWireMessage>;
-    const stream: Stream<AnyWireMessage> = {
-      readable: new ReadableStream<AnyWireMessage>({
-        start(controller) {
-          incoming = controller;
-        },
-      }),
-      writable: new WritableStream<AnyWireMessage>(),
-    };
-    const connection = Connection.builder()
-      .onReceiveNotification(
-        "example/final",
-        (params) => params,
-        async () => {
-          handlerStarted.resolve();
-          await releaseHandler.promise;
-        },
-      )
-      .connect(stream);
-    const running = connection.runUntil(async () => {
-      await releaseOperation.promise;
-      return 42;
-    });
-    void running.catch(() => {});
-
-    incoming.enqueue({ jsonrpc: "2.0", method: "example/final" });
-    await handlerStarted.promise;
-    incoming.close();
-    await vi.waitFor(() =>
-      expect((connection as unknown as ConnectionInternals).incomingEof).toBe(
-        true,
-      ),
-    );
-    releaseOperation.resolve();
-    releaseHandler.resolve();
-
-    await expect(running).rejects.toThrow("ACP connection closed");
-  });
-
-  it("reports an error that preempts an EOF drain from runUntil", async () => {
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    const handlerStarted = Promise.withResolvers<void>();
-    const releaseHandler = Promise.withResolvers<void>();
-    const writeError = new Error("write exploded");
-    let incoming!: ReadableStreamDefaultController<AnyWireMessage>;
-    let writes = 0;
-    const stream: Stream<AnyWireMessage> = {
-      readable: new ReadableStream<AnyWireMessage>({
-        start(controller) {
-          incoming = controller;
-        },
-      }),
-      writable: new WritableStream<AnyWireMessage>({
-        write() {
-          writes += 1;
-          if (writes === 2) throw writeError;
-        },
-      }),
-    };
-    const connection = Connection.builder()
-      .onReceiveNotification(
-        "example/final",
-        (params) => params,
-        async (_params, cx) => {
-          handlerStarted.resolve();
-          await releaseHandler.promise;
-          await cx.sendNotification("example/drained", {});
-        },
-      )
-      .connect(stream);
-    const running = connection.runUntil((cx) =>
-      cx.sendRequest("example/pending", {}),
-    );
-    void running.catch(() => {});
 
     try {
-      await vi.waitFor(() => expect(writes).toBe(1));
-      incoming.enqueue({ jsonrpc: "2.0", method: "example/final" });
-      await handlerStarted.promise;
+      incoming.enqueue({
+        jsonrpc: "2.0",
+        id: 17,
+        method: "example/wait",
+      });
+      incoming.enqueue({ jsonrpc: "2.0", method: "example/wait" });
+      await Promise.all([requestStarted.promise, notificationStarted.promise]);
       incoming.close();
-      await vi.waitFor(() =>
-        expect((connection as unknown as ConnectionInternals).incomingEof).toBe(
-          true,
-        ),
-      );
-      releaseHandler.resolve();
 
-      await expect(running).rejects.toBe(writeError);
-      expect(connection.signal.reason).toBe(writeError);
+      await withTimeout(connection.closed, "connection did not close on EOF");
+      await withTimeout(
+        Promise.all([requestAborted.promise, notificationAborted.promise]),
+        "EOF did not abort handler signals",
+      );
+      expect(connection.signal.aborted).toBe(true);
+      expect(notificationSignal).toBe(connection.signal);
     } finally {
-      releaseHandler.resolve();
       connection.close();
       await connection.closed;
-      consoleError.mockRestore();
     }
-  });
-
-  it("allows notification-only batches while draining clean EOF", async () => {
-    const handlerStarted = Promise.withResolvers<void>();
-    const releaseHandler = Promise.withResolvers<void>();
-    const writes: AnyWireMessage[] = [];
-    let incoming!: ReadableStreamDefaultController<AnyWireMessage>;
-    let requestBatch: Promise<unknown> | undefined;
-    const stream: Stream<AnyWireMessage> = {
-      readable: new ReadableStream<AnyWireMessage>({
-        start(controller) {
-          incoming = controller;
-        },
-      }),
-      writable: new WritableStream<AnyWireMessage>({
-        write(message) {
-          writes.push(message);
-        },
-      }),
-    };
-    const connection = Connection.builder()
-      .onReceiveNotification(
-        "example/final",
-        (params) => params,
-        async (_params, cx) => {
-          handlerStarted.resolve();
-          await releaseHandler.promise;
-          requestBatch = cx.sendBatch([
-            batchRequest<Record<string, never>, unknown>(
-              "example/too-late",
-              {},
-            ),
-          ]);
-          void requestBatch.catch(() => {});
-          await cx.sendBatch([
-            batchNotification("example/drained", { ok: true }),
-          ]);
-        },
-      )
-      .connect(stream);
-
-    incoming.enqueue({ jsonrpc: "2.0", method: "example/final" });
-    await handlerStarted.promise;
-    incoming.close();
-    await vi.waitFor(() =>
-      expect((connection as unknown as ConnectionInternals).incomingEof).toBe(
-        true,
-      ),
-    );
-    releaseHandler.resolve();
-
-    await connection.closed;
-    expect(requestBatch).toBeDefined();
-    await expect(requestBatch!).rejects.toThrow("ACP connection closed");
-    expect(writes).toEqual([
-      [
-        {
-          jsonrpc: "2.0",
-          method: "example/drained",
-          params: { ok: true },
-        },
-      ],
-    ]);
   });
 });
 

--- a/src/jsonrpc.test.ts
+++ b/src/jsonrpc.test.ts
@@ -8,6 +8,7 @@ import {
   isJsonRpcBatchMessage,
   isJsonRpcMessage,
   isJsonRpcWireMessage,
+  linkClosed,
 } from "./jsonrpc.js";
 import type {
   AnyMessage,
@@ -16,6 +17,7 @@ import type {
   RequestResponder,
 } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
+import { inMemoryStreamPair } from "./acp.js";
 
 type ConnectionInternals = {
   pendingResponses: Map<string | number | null, unknown>;
@@ -1152,3 +1154,19 @@ function memoryStreamPair(): [Stream<AnyWireMessage>, Stream<AnyWireMessage>] {
     },
   ];
 }
+
+describe("linkClosed", () => {
+  it("closes the paired connection with the same reason", async () => {
+    const [aStream] = inMemoryStreamPair();
+    const [bStream] = inMemoryStreamPair();
+    const a = new Connection(aStream, []);
+    const b = new Connection(bStream, []);
+    linkClosed(a, b);
+
+    const pendingOnB = b.sendRequest("anything", {});
+    a.close(new Error("a went away"));
+
+    await expect(pendingOnB).rejects.toThrow("a went away");
+    await b.closed;
+  });
+});

--- a/src/jsonrpc.test.ts
+++ b/src/jsonrpc.test.ts
@@ -19,6 +19,7 @@ import type { Stream } from "./stream.js";
 
 type ConnectionInternals = {
   pendingResponses: Map<string | number | null, unknown>;
+  incomingEof: boolean;
 };
 
 describe("JSON-RPC envelope validation", () => {
@@ -1007,6 +1008,234 @@ describe("JSON-RPC request cancellation", () => {
       server.close();
       await Promise.all([client.closed, server.closed]);
     }
+  });
+});
+
+describe("JSON-RPC connection lifecycle", () => {
+  it("lets runUntil drain accepted work after EOF rejects its operation", async () => {
+    const handlerStarted = Promise.withResolvers<void>();
+    const releaseHandler = Promise.withResolvers<void>();
+    const operationRejected = Promise.withResolvers<void>();
+    const writes: AnyWireMessage[] = [];
+    let incoming!: ReadableStreamDefaultController<AnyWireMessage>;
+    const stream: Stream<AnyWireMessage> = {
+      readable: new ReadableStream<AnyWireMessage>({
+        start(controller) {
+          incoming = controller;
+        },
+      }),
+      writable: new WritableStream<AnyWireMessage>({
+        write(message) {
+          writes.push(message);
+        },
+      }),
+    };
+
+    const running = Connection.builder()
+      .onReceiveNotification(
+        "example/final",
+        (params) => params,
+        async (_params, cx) => {
+          handlerStarted.resolve();
+          await releaseHandler.promise;
+          await cx.sendNotification("example/drained", { ok: true });
+        },
+      )
+      .connectWith(stream, async (cx) => {
+        try {
+          return await cx.sendRequest("example/pending", {});
+        } catch (error) {
+          operationRejected.resolve();
+          throw error;
+        }
+      });
+    void running.catch(() => {});
+
+    await vi.waitFor(() => expect(writes).toHaveLength(1));
+    incoming.enqueue({ jsonrpc: "2.0", method: "example/final" });
+    await handlerStarted.promise;
+    incoming.close();
+    await operationRejected.promise;
+    releaseHandler.resolve();
+
+    await expect(running).rejects.toThrow("ACP connection closed");
+    expect(writes).toEqual([
+      expect.objectContaining({
+        jsonrpc: "2.0",
+        method: "example/pending",
+      }),
+      {
+        jsonrpc: "2.0",
+        method: "example/drained",
+        params: { ok: true },
+      },
+    ]);
+  });
+
+  it("rejects runUntil when EOF starts before its operation settles", async () => {
+    const handlerStarted = Promise.withResolvers<void>();
+    const releaseHandler = Promise.withResolvers<void>();
+    const releaseOperation = Promise.withResolvers<void>();
+    let incoming!: ReadableStreamDefaultController<AnyWireMessage>;
+    const stream: Stream<AnyWireMessage> = {
+      readable: new ReadableStream<AnyWireMessage>({
+        start(controller) {
+          incoming = controller;
+        },
+      }),
+      writable: new WritableStream<AnyWireMessage>(),
+    };
+    const connection = Connection.builder()
+      .onReceiveNotification(
+        "example/final",
+        (params) => params,
+        async () => {
+          handlerStarted.resolve();
+          await releaseHandler.promise;
+        },
+      )
+      .connect(stream);
+    const running = connection.runUntil(async () => {
+      await releaseOperation.promise;
+      return 42;
+    });
+    void running.catch(() => {});
+
+    incoming.enqueue({ jsonrpc: "2.0", method: "example/final" });
+    await handlerStarted.promise;
+    incoming.close();
+    await vi.waitFor(() =>
+      expect((connection as unknown as ConnectionInternals).incomingEof).toBe(
+        true,
+      ),
+    );
+    releaseOperation.resolve();
+    releaseHandler.resolve();
+
+    await expect(running).rejects.toThrow("ACP connection closed");
+  });
+
+  it("reports an error that preempts an EOF drain from runUntil", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const handlerStarted = Promise.withResolvers<void>();
+    const releaseHandler = Promise.withResolvers<void>();
+    const writeError = new Error("write exploded");
+    let incoming!: ReadableStreamDefaultController<AnyWireMessage>;
+    let writes = 0;
+    const stream: Stream<AnyWireMessage> = {
+      readable: new ReadableStream<AnyWireMessage>({
+        start(controller) {
+          incoming = controller;
+        },
+      }),
+      writable: new WritableStream<AnyWireMessage>({
+        write() {
+          writes += 1;
+          if (writes === 2) throw writeError;
+        },
+      }),
+    };
+    const connection = Connection.builder()
+      .onReceiveNotification(
+        "example/final",
+        (params) => params,
+        async (_params, cx) => {
+          handlerStarted.resolve();
+          await releaseHandler.promise;
+          await cx.sendNotification("example/drained", {});
+        },
+      )
+      .connect(stream);
+    const running = connection.runUntil((cx) =>
+      cx.sendRequest("example/pending", {}),
+    );
+    void running.catch(() => {});
+
+    try {
+      await vi.waitFor(() => expect(writes).toBe(1));
+      incoming.enqueue({ jsonrpc: "2.0", method: "example/final" });
+      await handlerStarted.promise;
+      incoming.close();
+      await vi.waitFor(() =>
+        expect((connection as unknown as ConnectionInternals).incomingEof).toBe(
+          true,
+        ),
+      );
+      releaseHandler.resolve();
+
+      await expect(running).rejects.toBe(writeError);
+      expect(connection.signal.reason).toBe(writeError);
+    } finally {
+      releaseHandler.resolve();
+      connection.close();
+      await connection.closed;
+      consoleError.mockRestore();
+    }
+  });
+
+  it("allows notification-only batches while draining clean EOF", async () => {
+    const handlerStarted = Promise.withResolvers<void>();
+    const releaseHandler = Promise.withResolvers<void>();
+    const writes: AnyWireMessage[] = [];
+    let incoming!: ReadableStreamDefaultController<AnyWireMessage>;
+    let requestBatch: Promise<unknown> | undefined;
+    const stream: Stream<AnyWireMessage> = {
+      readable: new ReadableStream<AnyWireMessage>({
+        start(controller) {
+          incoming = controller;
+        },
+      }),
+      writable: new WritableStream<AnyWireMessage>({
+        write(message) {
+          writes.push(message);
+        },
+      }),
+    };
+    const connection = Connection.builder()
+      .onReceiveNotification(
+        "example/final",
+        (params) => params,
+        async (_params, cx) => {
+          handlerStarted.resolve();
+          await releaseHandler.promise;
+          requestBatch = cx.sendBatch([
+            batchRequest<Record<string, never>, unknown>(
+              "example/too-late",
+              {},
+            ),
+          ]);
+          void requestBatch.catch(() => {});
+          await cx.sendBatch([
+            batchNotification("example/drained", { ok: true }),
+          ]);
+        },
+      )
+      .connect(stream);
+
+    incoming.enqueue({ jsonrpc: "2.0", method: "example/final" });
+    await handlerStarted.promise;
+    incoming.close();
+    await vi.waitFor(() =>
+      expect((connection as unknown as ConnectionInternals).incomingEof).toBe(
+        true,
+      ),
+    );
+    releaseHandler.resolve();
+
+    await connection.closed;
+    expect(requestBatch).toBeDefined();
+    await expect(requestBatch!).rejects.toThrow("ACP connection closed");
+    expect(writes).toEqual([
+      [
+        {
+          jsonrpc: "2.0",
+          method: "example/drained",
+          params: { ok: true },
+        },
+      ],
+    ]);
   });
 });
 

--- a/src/jsonrpc.test.ts
+++ b/src/jsonrpc.test.ts
@@ -8,7 +8,6 @@ import {
   isJsonRpcBatchMessage,
   isJsonRpcMessage,
   isJsonRpcWireMessage,
-  linkClosed,
 } from "./jsonrpc.js";
 import type {
   AnyMessage,
@@ -17,7 +16,6 @@ import type {
   RequestResponder,
 } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
-import { inMemoryStreamPair } from "./acp.js";
 
 type ConnectionInternals = {
   pendingResponses: Map<string | number | null, unknown>;
@@ -1154,19 +1152,3 @@ function memoryStreamPair(): [Stream<AnyWireMessage>, Stream<AnyWireMessage>] {
     },
   ];
 }
-
-describe("linkClosed", () => {
-  it("closes the paired connection with the same reason", async () => {
-    const [aStream] = inMemoryStreamPair();
-    const [bStream] = inMemoryStreamPair();
-    const a = new Connection(aStream, []);
-    const b = new Connection(bStream, []);
-    linkClosed(a, b);
-
-    const pendingOnB = b.sendRequest("anything", {});
-    a.close(new Error("a went away"));
-
-    await expect(pendingOnB).rejects.toThrow("a went away");
-    await b.closed;
-  });
-});

--- a/src/jsonrpc.ts
+++ b/src/jsonrpc.ts
@@ -854,8 +854,9 @@ export type ConnectionOptions = {
    */
   allowBatches?: boolean;
   /**
-   * Finishes connection-specific response continuations after accepted input
-   * has drained but before clean EOF freezes the outgoing queue.
+   * Enables graceful EOF handling and finishes connection-specific response
+   * continuations after accepted input has drained but before the outgoing
+   * queue freezes.
    *
    * @internal
    */
@@ -872,6 +873,7 @@ export class Connection {
   private pendingResponses: Map<JsonRpcId, ConnectionPendingResponse> =
     new Map();
   private incomingRequests: Map<JsonRpcId, AbortController> = new Map();
+  private incomingRequestControllers = new Set<AbortController>();
   private incomingWork = new Set<Promise<void>>();
   private nextRequestId = 0;
   private staticHandlers: JsonRpcHandler[] = [];
@@ -880,8 +882,6 @@ export class Connection {
   private writeQueue: Promise<void> = Promise.resolve();
   private abortController = new AbortController();
   private closedPromise!: Promise<void>;
-  private incomingEofPromise!: Promise<void>;
-  private resolveIncomingEof!: () => void;
   private retryQueue: IncomingMessage[] = [];
   private context = new ConnectionContext(this);
   private receiveReader?: ReadableStreamDefaultReader<AnyWireMessage>;
@@ -957,10 +957,7 @@ export class Connection {
       .finally(() => {
         opSettled = true;
       });
-    const closeStartedPromise = Promise.race([
-      this.closed,
-      this.incomingEofPromise,
-    ]).then(() => {
+    const closedPromise = this.closed.then(() => {
       if (opSettled) {
         return new Promise<never>(() => {});
       }
@@ -968,19 +965,8 @@ export class Connection {
       throw this.closedReason();
     });
 
-    return Promise.race([opPromise, closeStartedPromise]).finally(async () => {
+    return Promise.race([opPromise, closedPromise]).finally(() => {
       opSettled = true;
-      // Incoming EOF rejects requests that can no longer receive a response,
-      // which may settle op while accepted handlers and writes are still
-      // draining. Do not turn that graceful close into an explicit one, but
-      // let an error that preempts the drain become the authoritative reason.
-      if (this.incomingEof) {
-        await this.closed;
-        if (!this.closedByEof) {
-          throw this.closedReason();
-        }
-        return;
-      }
       this.close();
     });
   }
@@ -1022,7 +1008,7 @@ export class Connection {
   }
 
   /**
-   * Whether this connection closed after cleanly draining an incoming EOF.
+   * Whether this connection closed because its incoming stream reached EOF.
    *
    * @internal
    */
@@ -1049,7 +1035,6 @@ export class Connection {
     const closeError = error ?? new Error("ACP connection closed");
     this.acceptingIncoming = false;
     this.incomingEof = true;
-    this.resolveIncomingEof();
     this.acceptingOutgoing = false;
     this.closingReason = closeError;
     this.rejectPendingResponses(closeError);
@@ -1261,11 +1246,21 @@ export class Connection {
     this.closedByEofValue = closedByEof;
     this.abortController.abort(error);
     this.rejectPendingResponses(error);
-    for (const controller of this.incomingRequests.values()) {
+    this.abortIncomingRequests(error);
+    this.incomingRequests.clear();
+    this.incomingRequestControllers.clear();
+    void this.receiveReader?.cancel(error).catch(() => {});
+  }
+
+  /**
+   * Aborts request-scoped work without closing the transport.
+   *
+   * @internal
+   */
+  abortIncomingRequests(error: unknown): void {
+    for (const controller of this.incomingRequestControllers) {
       controller.abort(error);
     }
-    this.incomingRequests.clear();
-    void this.receiveReader?.cancel(error).catch(() => {});
   }
 
   private rejectPendingResponses(error: unknown): void {
@@ -1277,6 +1272,10 @@ export class Connection {
   }
 
   private trackIncoming(work: Promise<void>): Promise<void> {
+    if (!this.drainOnEof) {
+      return work;
+    }
+
     const settled = work.then(
       () => {},
       () => {},
@@ -1300,9 +1299,19 @@ export class Connection {
     const closeError = new Error("ACP connection closed");
     this.acceptingIncoming = false;
     this.incomingEof = true;
-    this.resolveIncomingEof();
     this.closingReason = closeError;
     this.rejectPendingResponses(closeError);
+
+    const drainOnEof = this.drainOnEof;
+    if (!drainOnEof) {
+      this.finishClose(closeError, true);
+      return;
+    }
+
+    // Proxy request handlers commonly wait on their request signal to stop
+    // long-running work. Abort it before awaiting accepted dispatches, while
+    // keeping the transport open long enough to flush their final writes.
+    this.abortIncomingRequests(closeError);
 
     await this.drainIncoming();
     if (this.abortController.signal.aborted || this.drainingClose) {
@@ -1310,9 +1319,7 @@ export class Connection {
     }
 
     try {
-      if (this.drainOnEof) {
-        await Promise.race([this.drainOnEof(), this.closedPromise]);
-      }
+      await Promise.race([drainOnEof(), this.closedPromise]);
     } catch (error) {
       this.close(error);
       return;
@@ -1344,9 +1351,6 @@ export class Connection {
     this.staticHandlers = handlers;
     this.allowBatches = options?.allowBatches ?? true;
     this.drainOnEof = options?.drainOnEof;
-    this.incomingEofPromise = new Promise((resolve) => {
-      this.resolveIncomingEof = resolve;
-    });
     this.closedPromise = new Promise((resolve) => {
       this.abortController.signal.addEventListener("abort", () => resolve());
     });
@@ -1498,11 +1502,9 @@ export class Connection {
       }
 
       if (!isRequestMessage(message) && !isNotificationMessage(message)) {
-        this.trackIncoming(
-          collectResponse(
-            protocolErrorResponse(RequestError.invalidRequest(message)),
-          ).catch((error) => this.close(error)),
-        );
+        void collectResponse(
+          protocolErrorResponse(RequestError.invalidRequest(message)),
+        ).catch(() => {});
         continue;
       }
 
@@ -1512,14 +1514,10 @@ export class Connection {
         batch.length,
       );
       if (isNotificationMessage(message)) {
-        this.trackIncoming(
-          processing
-            .finally(async () => {
-              remainingNotifications -= 1;
-              await sendResponsesIfReady();
-            })
-            .catch((error) => this.close(error)),
-        );
+        void processing.finally(() => {
+          remainingNotifications -= 1;
+          void sendResponsesIfReady().catch((error) => this.close(error));
+        });
       }
     }
   }
@@ -1625,7 +1623,9 @@ export class Connection {
     if ("id" in message) {
       const abortController = new AbortController();
       this.incomingRequests.set(message.id, abortController);
+      this.incomingRequestControllers.add(abortController);
       const finishRequest = () => {
+        this.incomingRequestControllers.delete(abortController);
         if (this.incomingRequests.get(message.id) === abortController) {
           this.incomingRequests.delete(message.id);
         }

--- a/src/jsonrpc.ts
+++ b/src/jsonrpc.ts
@@ -433,6 +433,40 @@ type PreparedRequest<Output> = {
 export type MaybePromise<T> = T | Promise<T>;
 
 /**
+ * Parser converting raw JSON-RPC params into a handler's typed params.
+ *
+ * Accepts either a plain function or an object with a `parse` method (such
+ * as a Zod schema).
+ */
+export type ParamsParser<Params> =
+  | {
+      /**
+       * Parses raw JSON-RPC params into the handler's typed params.
+       */
+      parse: (params: unknown) => Params;
+    }
+  | ((params: unknown) => Params);
+
+/**
+ * Runs a {@link ParamsParser} over raw params; without a parser the params
+ * pass through untouched.
+ */
+export function parseParams<Params>(
+  parser: ParamsParser<Params> | undefined,
+  params: unknown,
+): Params {
+  if (!parser) {
+    return params as Params;
+  }
+
+  if (typeof parser === "function") {
+    return parser(params);
+  }
+
+  return parser.parse(params);
+}
+
+/**
  * Incoming request passed to JSON-RPC handlers.
  */
 export type IncomingRequest = {
@@ -605,12 +639,7 @@ function isZodError(error: unknown): error is { format(): unknown } {
   );
 }
 
-/**
- * Maps a thrown error to a JSON-RPC result payload: `RequestError` keeps its
- * code/message/data, Zod errors become invalid-params, anything else becomes
- * a generic internal error.
- */
-export function errorToResult<T>(error: unknown): Result<T> {
+function errorToResult<T>(error: unknown): Result<T> {
   if (error instanceof RequestError) {
     return error.toResult();
   }
@@ -712,6 +741,16 @@ export class RequestResponder<Resp = unknown> {
     const errorResponse =
       error instanceof RequestError ? error.toErrorResponse() : error;
     return this.respondWithResult({ error: errorResponse });
+  }
+
+  /**
+   * Sends the JSON-RPC response for an error thrown while handling the
+   * request: `RequestError` keeps its code/message/data, an abort after
+   * cancellation maps to request-cancelled, anything else becomes a generic
+   * internal error.
+   */
+  respondWithThrown(error: unknown): Promise<void> {
+    return this.respondWithResult(errorToRequestResult(error, this.signal));
   }
 
   /**
@@ -1424,9 +1463,7 @@ export class Connection {
       }
 
       if (current.kind === "request" && !current.responder.responded) {
-        await current.responder.respondWithResult(
-          errorToRequestResult(error, current.responder.signal),
-        );
+        await current.responder.respondWithThrown(error);
       } else {
         const response = errorToResult(error);
         if ("error" in response) {

--- a/src/jsonrpc.ts
+++ b/src/jsonrpc.ts
@@ -605,7 +605,12 @@ function isZodError(error: unknown): error is { format(): unknown } {
   );
 }
 
-function errorToResult<T>(error: unknown): Result<T> {
+/**
+ * Maps a thrown error to a JSON-RPC result payload: `RequestError` keeps its
+ * code/message/data, Zod errors become invalid-params, anything else becomes
+ * a generic internal error.
+ */
+export function errorToResult<T>(error: unknown): Result<T> {
   if (error instanceof RequestError) {
     return error.toResult();
   }

--- a/src/jsonrpc.ts
+++ b/src/jsonrpc.ts
@@ -433,40 +433,6 @@ type PreparedRequest<Output> = {
 export type MaybePromise<T> = T | Promise<T>;
 
 /**
- * Parser converting raw JSON-RPC params into a handler's typed params.
- *
- * Accepts either a plain function or an object with a `parse` method (such
- * as a Zod schema).
- */
-export type ParamsParser<Params> =
-  | {
-      /**
-       * Parses raw JSON-RPC params into the handler's typed params.
-       */
-      parse: (params: unknown) => Params;
-    }
-  | ((params: unknown) => Params);
-
-/**
- * Runs a {@link ParamsParser} over raw params; without a parser the params
- * pass through untouched.
- */
-export function parseParams<Params>(
-  parser: ParamsParser<Params> | undefined,
-  params: unknown,
-): Params {
-  if (!parser) {
-    return params as Params;
-  }
-
-  if (typeof parser === "function") {
-    return parser(params);
-  }
-
-  return parser.parse(params);
-}
-
-/**
  * Incoming request passed to JSON-RPC handlers.
  */
 export type IncomingRequest = {
@@ -667,7 +633,12 @@ function requestCancelledError(reason?: unknown): RequestError {
   return RequestError.requestCancelled(reason);
 }
 
-function errorToRequestResult<T>(
+/**
+ * Maps an error thrown while handling a request to a JSON-RPC result:
+ * `RequestError` keeps its code/message/data, an abort after cancellation
+ * maps to request-cancelled, anything else becomes a generic internal error.
+ */
+export function errorToRequestResult<T>(
   error: unknown,
   signal: AbortSignal,
 ): Result<T> {
@@ -741,16 +712,6 @@ export class RequestResponder<Resp = unknown> {
     const errorResponse =
       error instanceof RequestError ? error.toErrorResponse() : error;
     return this.respondWithResult({ error: errorResponse });
-  }
-
-  /**
-   * Sends the JSON-RPC response for an error thrown while handling the
-   * request: `RequestError` keeps its code/message/data, an abort after
-   * cancellation maps to request-cancelled, anything else becomes a generic
-   * internal error.
-   */
-  respondWithThrown(error: unknown): Promise<void> {
-    return this.respondWithResult(errorToRequestResult(error, this.signal));
   }
 
   /**
@@ -1463,7 +1424,9 @@ export class Connection {
       }
 
       if (current.kind === "request" && !current.responder.responded) {
-        await current.responder.respondWithThrown(error);
+        await current.responder.respondWithResult(
+          errorToRequestResult(error, current.responder.signal),
+        );
       } else {
         const response = errorToResult(error);
         if ("error" in response) {
@@ -1595,17 +1558,6 @@ export class Connection {
       });
     return this.writeQueue;
   }
-}
-
-/**
- * Closes each connection when the other closes.
- *
- * The close reason is propagated so pending requests on the surviving side
- * reject with the true cause rather than a generic connection-closed error.
- */
-export function linkClosed(a: Connection, b: Connection): void {
-  void a.closed.then(() => b.close(a.signal.reason));
-  void b.closed.then(() => a.close(b.signal.reason));
 }
 
 /**

--- a/src/jsonrpc.ts
+++ b/src/jsonrpc.ts
@@ -1556,6 +1556,17 @@ export class Connection {
 }
 
 /**
+ * Closes each connection when the other closes.
+ *
+ * The close reason is propagated so pending requests on the surviving side
+ * reject with the true cause rather than a generic connection-closed error.
+ */
+export function linkClosed(a: Connection, b: Connection): void {
+  void a.closed.then(() => b.close(a.signal.reason));
+  void b.closed.then(() => a.close(b.signal.reason));
+}
+
+/**
  * Builder for a lower-level handler-based JSON-RPC connection.
  */
 export class ConnectionBuilder {

--- a/src/jsonrpc.ts
+++ b/src/jsonrpc.ts
@@ -853,6 +853,13 @@ export type ConnectionOptions = {
    * @internal
    */
   allowBatches?: boolean;
+  /**
+   * Finishes connection-specific response continuations after accepted input
+   * has drained but before clean EOF freezes the outgoing queue.
+   *
+   * @internal
+   */
+  drainOnEof?: () => Promise<void>;
 };
 
 /**
@@ -865,6 +872,7 @@ export class Connection {
   private pendingResponses: Map<JsonRpcId, ConnectionPendingResponse> =
     new Map();
   private incomingRequests: Map<JsonRpcId, AbortController> = new Map();
+  private incomingWork = new Set<Promise<void>>();
   private nextRequestId = 0;
   private staticHandlers: JsonRpcHandler[] = [];
   private dynamicHandlers: Set<JsonRpcHandler> = new Set();
@@ -872,10 +880,19 @@ export class Connection {
   private writeQueue: Promise<void> = Promise.resolve();
   private abortController = new AbortController();
   private closedPromise!: Promise<void>;
+  private incomingEofPromise!: Promise<void>;
+  private resolveIncomingEof!: () => void;
   private retryQueue: IncomingMessage[] = [];
   private context = new ConnectionContext(this);
   private receiveReader?: ReadableStreamDefaultReader<AnyWireMessage>;
   private allowBatches = true;
+  private drainOnEof?: () => Promise<void>;
+  private acceptingIncoming = true;
+  private acceptingOutgoing = true;
+  private incomingEof = false;
+  private closedByEofValue = false;
+  private closingReason: unknown;
+  private drainingClose?: Promise<void>;
 
   constructor(
     requestHandler: RequestHandler,
@@ -940,7 +957,10 @@ export class Connection {
       .finally(() => {
         opSettled = true;
       });
-    const closedPromise = this.closed.then(() => {
+    const closeStartedPromise = Promise.race([
+      this.closed,
+      this.incomingEofPromise,
+    ]).then(() => {
       if (opSettled) {
         return new Promise<never>(() => {});
       }
@@ -948,8 +968,19 @@ export class Connection {
       throw this.closedReason();
     });
 
-    return Promise.race([opPromise, closedPromise]).finally(() => {
+    return Promise.race([opPromise, closeStartedPromise]).finally(async () => {
       opSettled = true;
+      // Incoming EOF rejects requests that can no longer receive a response,
+      // which may settle op while accepted handlers and writes are still
+      // draining. Do not turn that graceful close into an explicit one, but
+      // let an error that preempts the drain become the authoritative reason.
+      if (this.incomingEof) {
+        await this.closed;
+        if (!this.closedByEof) {
+          throw this.closedReason();
+        }
+        return;
+      }
       this.close();
     });
   }
@@ -964,8 +995,10 @@ export class Connection {
     this.dynamicHandlers.add(handler);
     if (this.retryQueue.length > 0) {
       for (const message of this.retryQueue.splice(0)) {
-        void this.processIncomingMessage(message).catch((error) =>
-          this.close(error),
+        void this.trackIncoming(
+          this.processIncomingMessage(message).catch((error) =>
+            this.close(error),
+          ),
         );
       }
     }
@@ -988,6 +1021,46 @@ export class Connection {
     return this.closedPromise;
   }
 
+  /**
+   * Whether this connection closed after cleanly draining an incoming EOF.
+   *
+   * @internal
+   */
+  get closedByEof(): boolean {
+    return this.closedByEofValue;
+  }
+
+  /**
+   * Stops accepting new work, drains writes already accepted by the queue,
+   * then closes the connection. An explicit or error close still preempts the
+   * drain.
+   *
+   * @internal
+   */
+  closeAfterDraining(error?: unknown): Promise<void> {
+    if (this.abortController.signal.aborted) {
+      return Promise.resolve();
+    }
+
+    if (this.drainingClose) {
+      return this.drainingClose;
+    }
+
+    const closeError = error ?? new Error("ACP connection closed");
+    this.acceptingIncoming = false;
+    this.incomingEof = true;
+    this.resolveIncomingEof();
+    this.acceptingOutgoing = false;
+    this.closingReason = closeError;
+    this.rejectPendingResponses(closeError);
+    void this.receiveReader?.cancel(closeError).catch(() => {});
+
+    this.drainingClose = this.writeQueue
+      .catch(() => {})
+      .then(() => this.finishClose(closeError, false));
+    return this.drainingClose;
+  }
+
   /** @internal */
   getContext(): ConnectionContext {
     return this.context;
@@ -1005,7 +1078,11 @@ export class Connection {
     mapResponse?: (response: Resp) => Output,
     options: SendRequestOptions = {},
   ): Promise<Output> {
-    if (this.abortController.signal.aborted) {
+    if (
+      this.abortController.signal.aborted ||
+      this.incomingEof ||
+      !this.acceptingOutgoing
+    ) {
       return rejectedPromise(this.closedReason());
     }
 
@@ -1028,7 +1105,11 @@ export class Connection {
   sendBatch<const Entries extends readonly BatchEntry[]>(
     entries: Entries & { readonly 0: BatchEntry },
   ): Promise<BatchOutputs<Entries>> {
-    if (this.abortController.signal.aborted) {
+    if (
+      this.abortController.signal.aborted ||
+      !this.acceptingOutgoing ||
+      (this.incomingEof && entries.some((entry) => entry.kind === "request"))
+    ) {
       return rejectedPromise(this.closedReason());
     }
 
@@ -1102,7 +1183,7 @@ export class Connection {
    * Sends a JSON-RPC notification.
    */
   sendNotification<N>(method: string, params?: N): Promise<void> {
-    if (this.abortController.signal.aborted) {
+    if (this.abortController.signal.aborted || !this.acceptingOutgoing) {
       return rejectedPromise(this.closedReason());
     }
 
@@ -1166,18 +1247,92 @@ export class Connection {
       return;
     }
 
-    const closeError: unknown = error ?? new Error("ACP connection closed");
-    this.abortController.abort(closeError);
-    for (const pendingResponse of this.pendingResponses.values()) {
-      pendingResponse.cleanup?.();
-      pendingResponse.reject(closeError);
+    this.finishClose(error ?? new Error("ACP connection closed"), false);
+  }
+
+  private finishClose(error: unknown, closedByEof: boolean): void {
+    if (this.abortController.signal.aborted) {
+      return;
     }
-    this.pendingResponses.clear();
+
+    this.acceptingIncoming = false;
+    this.acceptingOutgoing = false;
+    this.closingReason = error;
+    this.closedByEofValue = closedByEof;
+    this.abortController.abort(error);
+    this.rejectPendingResponses(error);
     for (const controller of this.incomingRequests.values()) {
-      controller.abort(closeError);
+      controller.abort(error);
     }
     this.incomingRequests.clear();
-    void this.receiveReader?.cancel(closeError).catch(() => {});
+    void this.receiveReader?.cancel(error).catch(() => {});
+  }
+
+  private rejectPendingResponses(error: unknown): void {
+    for (const pendingResponse of this.pendingResponses.values()) {
+      pendingResponse.cleanup?.();
+      pendingResponse.reject(error);
+    }
+    this.pendingResponses.clear();
+  }
+
+  private trackIncoming(work: Promise<void>): Promise<void> {
+    const settled = work.then(
+      () => {},
+      () => {},
+    );
+    this.incomingWork.add(settled);
+    void settled.then(() => this.incomingWork.delete(settled));
+    return work;
+  }
+
+  private async drainIncoming(): Promise<void> {
+    while (this.incomingWork.size > 0 && !this.abortController.signal.aborted) {
+      await Promise.race([Promise.all(this.incomingWork), this.closedPromise]);
+    }
+  }
+
+  private async closeFromEof(): Promise<void> {
+    if (this.abortController.signal.aborted || this.drainingClose) {
+      return;
+    }
+
+    const closeError = new Error("ACP connection closed");
+    this.acceptingIncoming = false;
+    this.incomingEof = true;
+    this.resolveIncomingEof();
+    this.closingReason = closeError;
+    this.rejectPendingResponses(closeError);
+
+    await this.drainIncoming();
+    if (this.abortController.signal.aborted || this.drainingClose) {
+      return;
+    }
+
+    try {
+      if (this.drainOnEof) {
+        await Promise.race([this.drainOnEof(), this.closedPromise]);
+      }
+    } catch (error) {
+      this.close(error);
+      return;
+    }
+    if (this.abortController.signal.aborted || this.drainingClose) {
+      return;
+    }
+
+    // Freeze the queue only after accepted handlers have had a chance to
+    // enqueue their responses and notifications. Writes already in the queue
+    // remain valid while later sends are rejected.
+    this.acceptingOutgoing = false;
+    try {
+      await this.writeQueue;
+    } catch {
+      // A write failure closes the connection from sendWireMessage().
+      return;
+    }
+
+    this.finishClose(closeError, true);
   }
 
   private initialize(
@@ -1188,6 +1343,10 @@ export class Connection {
     this.stream = stream;
     this.staticHandlers = handlers;
     this.allowBatches = options?.allowBatches ?? true;
+    this.drainOnEof = options?.drainOnEof;
+    this.incomingEofPromise = new Promise((resolve) => {
+      this.resolveIncomingEof = resolve;
+    });
     this.closedPromise = new Promise((resolve) => {
       this.abortController.signal.addEventListener("abort", () => resolve());
     });
@@ -1218,17 +1377,19 @@ export class Connection {
 
   private async receive(): Promise<void> {
     let closeError: unknown = undefined;
+    let reachedEof = false;
 
     try {
       const reader = this.stream.readable.getReader();
       this.receiveReader = reader;
       try {
-        while (!this.abortController.signal.aborted) {
+        while (!this.abortController.signal.aborted && this.acceptingIncoming) {
           const { value: message, done } = await reader.read();
-          if (this.abortController.signal.aborted) {
+          if (this.abortController.signal.aborted || !this.acceptingIncoming) {
             break;
           }
           if (done) {
+            reachedEof = true;
             break;
           }
 
@@ -1242,7 +1403,15 @@ export class Connection {
       }
     } catch (error) {
       closeError = error;
-    } finally {
+    }
+
+    if (this.abortController.signal.aborted || this.drainingClose) {
+      return;
+    }
+
+    if (reachedEof) {
+      await this.closeFromEof();
+    } else {
       this.close(closeError);
     }
   }
@@ -1329,9 +1498,11 @@ export class Connection {
       }
 
       if (!isRequestMessage(message) && !isNotificationMessage(message)) {
-        void collectResponse(
-          protocolErrorResponse(RequestError.invalidRequest(message)),
-        ).catch(() => {});
+        this.trackIncoming(
+          collectResponse(
+            protocolErrorResponse(RequestError.invalidRequest(message)),
+          ).catch((error) => this.close(error)),
+        );
         continue;
       }
 
@@ -1341,10 +1512,14 @@ export class Connection {
         batch.length,
       );
       if (isNotificationMessage(message)) {
-        void processing.finally(() => {
-          remainingNotifications -= 1;
-          void sendResponsesIfReady().catch((error) => this.close(error));
-        });
+        this.trackIncoming(
+          processing
+            .finally(async () => {
+              remainingNotifications -= 1;
+              await sendResponsesIfReady();
+            })
+            .catch((error) => this.close(error)),
+        );
       }
     }
   }
@@ -1369,9 +1544,11 @@ export class Connection {
       if (!("id" in message)) {
         this.handleProtocolNotification(message);
       }
-      return this.processIncomingMessage(
-        this.toIncomingMessage(message, sendResponse, batchSize),
-      ).catch((error) => this.close(error));
+      return this.trackIncoming(
+        this.processIncomingMessage(
+          this.toIncomingMessage(message, sendResponse, batchSize),
+        ).catch((error) => this.close(error)),
+      );
     } else if ("id" in message) {
       this.handleResponse(message);
     } else {
@@ -1530,12 +1707,14 @@ export class Connection {
 
   private closedReason(): unknown {
     return (
-      this.abortController.signal.reason ?? new Error("ACP connection closed")
+      this.abortController.signal.reason ??
+      this.closingReason ??
+      new Error("ACP connection closed")
     );
   }
 
   private async sendWireMessage(message: AnyWireMessage): Promise<void> {
-    if (this.abortController.signal.aborted) {
+    if (this.abortController.signal.aborted || !this.acceptingOutgoing) {
       return rejectedPromise(this.closedReason());
     }
 

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { agent, client, inMemoryStreamPair } from "./acp.js";
 import { Connection, Handled, RequestError } from "./jsonrpc.js";
-import type { JsonRpcHandler } from "./jsonrpc.js";
+import type { JsonRpcHandler, RequestResponder } from "./jsonrpc.js";
 import { proxy } from "./proxy.js";
 import type { ProxyHandle } from "./proxy.js";
 import type { Stream } from "./stream.js";
@@ -137,6 +137,75 @@ describe("proxy forwarding", () => {
     canceller.abort();
 
     await expect(failure).rejects.toMatchObject({ code: -32800 });
+  });
+
+  it("preserves notification order when an earlier handler is slow", async () => {
+    const { clientStream, agentStream } = setupProxy({
+      fromAgent: [
+        {
+          async handleMessage(message) {
+            if (message.kind === "notification") {
+              const { delay } = message.params as { delay: number };
+              await new Promise((resolve) => setTimeout(resolve, delay));
+            }
+
+            return Handled.no(message);
+          },
+        },
+      ],
+    });
+    const received: string[] = [];
+    const gotBoth = Promise.withResolvers<void>();
+    Connection.builder()
+      .onReceiveNotification(
+        "update",
+        (params) => params as { tag: string },
+        (notification) => {
+          received.push(notification.tag);
+          if (received.length === 2) {
+            gotBoth.resolve();
+          }
+        },
+      )
+      .connect(clientStream);
+    const agentEnd = new Connection(agentStream, []);
+
+    // Without serialized dispatch the second (instant) chain would overtake
+    // the first (delayed) one.
+    await agentEnd.sendNotification("update", { tag: "first", delay: 25 });
+    await agentEnd.sendNotification("update", { tag: "second", delay: 0 });
+    await gotBoth.promise;
+
+    expect(received).toEqual(["first", "second"]);
+  });
+
+  it("does not block later messages behind a pending request round trip", async () => {
+    const { clientStream, agentStream } = setupProxy();
+    const slowArrived = Promise.withResolvers<RequestResponder<unknown>>();
+    Connection.builder()
+      .onReceiveRequest(
+        "slow",
+        (params) => params,
+        (_request, responder) => {
+          // Hold the request open; it is answered after `ping` completes.
+          slowArrived.resolve(responder);
+        },
+      )
+      .onReceiveRequest(
+        "ping",
+        (params) => params,
+        (_request, responder) => responder.respond({ pong: true }),
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    const slow = clientEnd.sendRequest("slow", {});
+    const ping = await clientEnd.sendRequest("ping", {});
+    expect(ping).toEqual({ pong: true });
+
+    const responder = await slowArrived.promise;
+    await responder.respond({ done: true });
+    await expect(slow).resolves.toEqual({ done: true });
   });
 
   it("closes the other side when one side of the proxy closes", async () => {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -217,10 +217,6 @@ describe("proxy forwarding", () => {
     handle.client.close(new Error("client side went away"));
 
     await handle.closed;
-    const agentSide = handle.agent as Connection;
-    await expect(agentSide.sendRequest("anything", {})).rejects.toThrow(
-      "client side went away",
-    );
   });
 
   it("closes both sides through the handle", async () => {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -390,7 +390,7 @@ describe("proxy typed registration", () => {
     expect(wildcardSaw).toEqual(["other"]);
   });
 
-  it("applies handlers registered after connect to subsequent messages", async () => {
+  it("snapshots registrations at connect", async () => {
     const { clientStream, agentStream, builder } = setupProxy();
     Connection.builder()
       .onReceiveRequest(
@@ -401,19 +401,16 @@ describe("proxy typed registration", () => {
       .connect(agentStream);
     const clientEnd = new Connection(clientStream, []);
 
-    // Before registration the request forwards untouched.
-    await expect(clientEnd.sendRequest("echo", { n: 1 })).resolves.toEqual({
-      echoed: { n: 1 },
-    });
-
+    // Registering after connect is allowed but must not affect the
+    // already-connected proxy — same semantics as the fluent app builders.
     builder.client.onRequest(
       "echo",
       (params) => params as Record<string, unknown>,
       async ({ forward }) => forward({ late: true }),
     );
 
-    await expect(clientEnd.sendRequest("echo", { n: 2 })).resolves.toEqual({
-      echoed: { late: true },
+    await expect(clientEnd.sendRequest("echo", { n: 1 })).resolves.toEqual({
+      echoed: { n: 1 },
     });
   });
 

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -213,7 +213,8 @@ describe("proxy forwarding", () => {
     handle.client.close(new Error("client side went away"));
 
     await handle.closed;
-    await expect(handle.agent.sendRequest("anything", {})).rejects.toThrow(
+    const agentSide = handle.agent as Connection;
+    await expect(agentSide.sendRequest("anything", {})).rejects.toThrow(
       "client side went away",
     );
   });
@@ -402,35 +403,28 @@ describe("proxy typed registration", () => {
     ).toThrow("already registered");
   });
 
-  it("intercepts everything through raw withHandler before typed handlers", async () => {
-    const rawSaw: string[] = [];
+  it("routes unclaimed notifications to '*'", async () => {
+    const wildcardSaw: string[] = [];
     const { clientStream, agentStream } = setupProxy((p) => {
-      p.client
-        .withHandler({
-          handleMessage(message) {
-            rawSaw.push(message.method);
-            return Handled.no(message);
-          },
-        })
-        .onRequest(
-          "claimed",
-          (params) => params,
-          () => ({ via: "typed" }),
-        );
+      p.client.onNotification("*", async ({ method, params, forward }) => {
+        wildcardSaw.push(method);
+        await forward(params);
+      });
     });
+    const seen = Promise.withResolvers<void>();
     Connection.builder()
-      .onReceiveRequest(
-        "unclaimed",
+      .onReceiveNotification(
+        "log",
         (params) => params,
-        (_request, responder) => responder.respond({ via: "agent" }),
+        () => seen.resolve(),
       )
       .connect(agentStream);
     const clientEnd = new Connection(clientStream, []);
 
-    await clientEnd.sendRequest("claimed", {});
-    await clientEnd.sendRequest("unclaimed", {});
+    await clientEnd.sendNotification("log", { line: "hi" });
+    await seen.promise;
 
-    expect(rawSaw).toEqual(["claimed", "unclaimed"]);
+    expect(wildcardSaw).toEqual(["log"]);
   });
 });
 

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,6 +1,8 @@
+import { PassThrough, Readable, Writable } from "node:stream";
+
 import { describe, expect, it, vi } from "vitest";
 
-import { agent, client } from "./acp.js";
+import { agent, client, ndJsonStream } from "./acp.js";
 import { Connection, Handled, RequestError } from "./jsonrpc.js";
 import type { RequestResponder } from "./jsonrpc.js";
 import { proxy } from "./proxy.js";
@@ -225,6 +227,31 @@ describe("proxy forwarding", () => {
     const { handle } = setupProxy();
 
     handle.client.close(new Error("client side went away"));
+
+    await handle.closed;
+  });
+
+  it("closes both sides when the client transport reaches EOF", async () => {
+    // Over a real byte transport (stdio, sockets) a disconnect arrives as
+    // EOF on the read loop, not as a close() call. Byte pipes reproduce
+    // that, unlike the in-memory object streams used elsewhere.
+    const clientToProxy = new PassThrough();
+    const proxyToClient = new PassThrough();
+    const [proxyAgentSide, agentStream] = inMemoryStreamPair();
+    const handle = proxy().connect({
+      client: ndJsonStream(
+        Writable.toWeb(proxyToClient),
+        Readable.toWeb(clientToProxy) as ReadableStream<Uint8Array>,
+      ),
+      agent: proxyAgentSide,
+    });
+    const agentEnd = new Connection(agentStream, []);
+    // In-flight traffic when the transport dies; over the in-memory agent
+    // pair this pending request can never settle, so it is not awaited.
+    void agentEnd.sendRequest("confirm", {}).catch(() => {});
+
+    // The client goes away mid-request.
+    clientToProxy.end();
 
     await handle.closed;
   });

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -228,7 +228,7 @@ describe("proxy forwarding", () => {
 
     handle.client.close(new Error("client side went away"));
 
-    await handle.closed;
+    await expect(handle.closed).resolves.toBeUndefined();
   });
 
   it("closes both sides when the client transport reaches EOF", async () => {
@@ -253,7 +253,7 @@ describe("proxy forwarding", () => {
     // The client goes away mid-request.
     clientToProxy.end();
 
-    await handle.closed;
+    await expect(handle.closed).resolves.toBeUndefined();
   });
 
   it("closes both sides through the handle", async () => {
@@ -261,7 +261,7 @@ describe("proxy forwarding", () => {
 
     handle.close();
 
-    await handle.closed;
+    await expect(handle.closed).resolves.toBeUndefined();
   });
 });
 

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -238,6 +238,306 @@ describe("proxy forwarding", () => {
   });
 });
 
+describe("proxy error and cancellation edges", () => {
+  it("propagates cancellation through a registered handler's forward", async () => {
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.onRequestFromClient(
+        "slow",
+        (params) => params,
+        async ({ params, forward }) => forward(params),
+      );
+    });
+    Connection.builder()
+      .onReceiveRequest(
+        "slow",
+        (params) => params,
+        (_request, responder) => {
+          responder.signal.addEventListener("abort", () => {
+            void responder.respondWithError(RequestError.requestCancelled());
+          });
+        },
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    const canceller = new AbortController();
+    const failure = clientEnd.sendRequest("slow", {}, undefined, {
+      cancellationSignal: canceller.signal,
+    });
+    canceller.abort();
+
+    await expect(failure).rejects.toMatchObject({ code: -32800 });
+  });
+
+  it("maps a handler's abort after cancellation to request-cancelled", async () => {
+    const { clientStream } = setupProxy((p) => {
+      p.onRequestFromClient(
+        "watch",
+        (params) => params,
+        ({ signal }) =>
+          new Promise((_resolve, reject) => {
+            signal.addEventListener("abort", () => {
+              const abortError = new Error("The operation was aborted");
+              abortError.name = "AbortError";
+              reject(abortError);
+            });
+          }),
+      );
+    });
+    const clientEnd = new Connection(clientStream, []);
+
+    const canceller = new AbortController();
+    const failure = clientEnd.sendRequest("watch", {}, undefined, {
+      cancellationSignal: canceller.signal,
+    });
+    canceller.abort();
+
+    await expect(failure).rejects.toMatchObject({ code: -32800 });
+  });
+
+  it("answers a generic handler throw as an internal error", async () => {
+    const { clientStream } = setupProxy((p) => {
+      p.onRequestFromClient(
+        "boom",
+        (params) => params,
+        () => {
+          throw new Error("kaput");
+        },
+      );
+    });
+    const clientEnd = new Connection(clientStream, []);
+
+    await expect(clientEnd.sendRequest("boom", {})).rejects.toMatchObject({
+      code: -32603,
+    });
+  });
+
+  it("answers a parser failure as invalid params", async () => {
+    class FakeZodError extends Error {
+      name = "ZodError";
+      issues: unknown[] = [];
+      format(): unknown {
+        return { _errors: ["expected a number"] };
+      }
+    }
+    const { clientStream } = setupProxy((p) => {
+      p.onRequestFromClient(
+        "strict",
+        () => {
+          throw new FakeZodError("invalid");
+        },
+        async ({ params, forward }) => forward(params),
+      );
+    });
+    const clientEnd = new Connection(clientStream, []);
+
+    await expect(
+      clientEnd.sendRequest("strict", { n: "not-a-number" }),
+    ).rejects.toMatchObject({ code: -32602 });
+  });
+
+  it("drops a throwing notification handler's message and keeps dispatching", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.onNotificationFromClient(
+        "log",
+        (params) => params as { fail: boolean },
+        async ({ params, forward }) => {
+          if (params.fail) {
+            throw new Error("handler exploded");
+          }
+          await forward(params);
+        },
+      );
+    });
+    const received = vi.fn();
+    const gotSecond = Promise.withResolvers<void>();
+    Connection.builder()
+      .onReceiveNotification(
+        "log",
+        (params) => params,
+        (notification) => {
+          received(notification);
+          gotSecond.resolve();
+        },
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    await clientEnd.sendNotification("log", { fail: true });
+    await clientEnd.sendNotification("log", { fail: false });
+    await gotSecond.promise;
+
+    expect(received).toHaveBeenCalledTimes(1);
+    expect(received).toHaveBeenCalledWith({ fail: false });
+    consoleError.mockRestore();
+  });
+});
+
+describe("proxy ordering and correlation", () => {
+  it("preserves request send order through an async registered handler", async () => {
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.onRequestFromClient(
+        "echo",
+        (params) => params as { n: number },
+        async ({ params, forward }) => {
+          // Delay before forwarding; serialization must keep send order.
+          await new Promise((resolve) => setTimeout(resolve, 15 - params.n));
+          return forward(params);
+        },
+      );
+    });
+    const arrivals: number[] = [];
+    Connection.builder()
+      .onReceiveRequest(
+        "echo",
+        (params) => params as { n: number },
+        (request, responder) => {
+          arrivals.push(request.n);
+          return responder.respond({ echoed: request.n });
+        },
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    const [first, second] = await Promise.all([
+      clientEnd.sendRequest("echo", { n: 1 }),
+      clientEnd.sendRequest("echo", { n: 2 }),
+    ]);
+
+    expect(arrivals).toEqual([1, 2]);
+    expect(first).toEqual({ echoed: 1 });
+    expect(second).toEqual({ echoed: 2 });
+  });
+
+  it("correlates concurrent round trips answered out of order", async () => {
+    const { clientStream, agentStream } = setupProxy();
+    const held: Array<{ n: number; responder: RequestResponder<unknown> }> = [];
+    const gotBoth = Promise.withResolvers<void>();
+    Connection.builder()
+      .onReceiveRequest(
+        "hold",
+        (params) => params as { n: number },
+        (request, responder) => {
+          held.push({ n: request.n, responder });
+          if (held.length === 2) {
+            gotBoth.resolve();
+          }
+        },
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    const first = clientEnd.sendRequest("hold", { n: 1 });
+    const second = clientEnd.sendRequest("hold", { n: 2 });
+    await gotBoth.promise;
+
+    // Answer in reverse order; each caller must still get its own response.
+    await held[1]!.responder.respond({ answered: 2 });
+    await held[0]!.responder.respond({ answered: 1 });
+
+    await expect(second).resolves.toEqual({ answered: 2 });
+    await expect(first).resolves.toEqual({ answered: 1 });
+  });
+
+  it("keeps pass-through traffic ordered behind a busy registered handler", async () => {
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.onNotificationFromAgent(
+        "update",
+        (params) => params,
+        async ({ params, forward }) => {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          await forward(params);
+        },
+      );
+    });
+    const received: string[] = [];
+    const gotBoth = Promise.withResolvers<void>();
+    Connection.builder()
+      .onReceiveMessage((message) => {
+        received.push(message.method);
+        if (received.length === 2) {
+          gotBoth.resolve();
+        }
+        return Handled.yes();
+      })
+      .connect(clientStream);
+    const agentEnd = new Connection(agentStream, []);
+
+    // "update" is registered (slow); "other" is unregistered pass-through.
+    // The fast path must not let "other" overtake the busy queue.
+    await agentEnd.sendNotification("update", {});
+    await agentEnd.sendNotification("other", {});
+    await gotBoth.promise;
+
+    expect(received).toEqual(["update", "other"]);
+  });
+});
+
+describe("proxy composition", () => {
+  it("chains two proxies, each rewriting in flight", async () => {
+    const [clientStream, firstClientSide] = inMemoryStreamPair();
+    const [firstAgentSide, secondClientSide] = inMemoryStreamPair();
+    const [secondAgentSide, agentStream] = inMemoryStreamPair();
+    proxy()
+      .onRequestFromClient(
+        "echo",
+        (params) => params as Record<string, unknown>,
+        async ({ params, forward }) => forward({ ...params, hop1: true }),
+      )
+      .connect({ client: firstClientSide, agent: firstAgentSide });
+    proxy()
+      .onRequestFromClient(
+        "echo",
+        (params) => params as Record<string, unknown>,
+        async ({ params, forward }) => forward({ ...params, hop2: true }),
+      )
+      .connect({ client: secondClientSide, agent: secondAgentSide });
+    Connection.builder()
+      .onReceiveRequest(
+        "echo",
+        (params) => params,
+        (request, responder) => responder.respond({ echoed: request }),
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    const response = await clientEnd.sendRequest("echo", { original: true });
+
+    expect(response).toEqual({
+      echoed: { original: true, hop1: true, hop2: true },
+    });
+  });
+
+  it("connects one configured builder to multiple stream pairs independently", async () => {
+    const builder = proxy().onRequestFromClient(
+      "echo",
+      (params) => params as Record<string, unknown>,
+      async ({ params, forward }) => forward({ ...params, stamped: true }),
+    );
+
+    for (const label of ["a", "b"]) {
+      const [clientStream, proxyClientSide] = inMemoryStreamPair();
+      const [proxyAgentSide, agentStream] = inMemoryStreamPair();
+      builder.connect({ client: proxyClientSide, agent: proxyAgentSide });
+      Connection.builder()
+        .onReceiveRequest(
+          "echo",
+          (params) => params,
+          (request, responder) => responder.respond({ echoed: request }),
+        )
+        .connect(agentStream);
+      const clientEnd = new Connection(clientStream, []);
+
+      await expect(
+        clientEnd.sendRequest("echo", { via: label }),
+      ).resolves.toEqual({ echoed: { via: label, stamped: true } });
+    }
+  });
+});
+
 describe("proxy typed registration", () => {
   it("rewrites request params before forwarding", async () => {
     const { clientStream, agentStream } = setupProxy((p) => {
@@ -461,6 +761,60 @@ describe("proxy typed registration", () => {
 });
 
 describe("proxy with fluent apps", () => {
+  it("relays a full initialize/new/prompt flow with a typed interceptor", async () => {
+    const promptTexts: string[] = [];
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.onRequestFromClient("session/prompt", async ({ params, forward }) => {
+        // Typed literal: params is PromptRequest, response is PromptResponse.
+        for (const block of params.prompt) {
+          if (block.type === "text") {
+            promptTexts.push(block.text);
+          }
+        }
+        const response = await forward(params);
+        return { ...response, _meta: { ...response._meta, proxied: true } };
+      });
+    });
+
+    agent({ name: "e2e-agent" })
+      .onRequest("initialize", ({ params }) => ({
+        protocolVersion: params.protocolVersion,
+        agentCapabilities: {},
+      }))
+      .onRequest("session/new", () => ({ sessionId: "s-1" }))
+      .onRequest("session/prompt", ({ params }) => ({
+        stopReason: "end_turn" as const,
+        _meta: { sawSession: params.sessionId },
+      }))
+      .connect(agentStream);
+
+    const connection = client({ name: "e2e-client" }).connect(clientStream);
+    try {
+      const init = await connection.agent.request("initialize", {
+        protocolVersion: 1,
+        clientCapabilities: {},
+      });
+      expect(init.protocolVersion).toBe(1);
+
+      const session = await connection.agent.request("session/new", {
+        cwd: "/tmp",
+        mcpServers: [],
+      });
+      expect(session.sessionId).toBe("s-1");
+
+      const result = await connection.agent.request("session/prompt", {
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "hello through the proxy" }],
+      });
+
+      expect(result.stopReason).toBe("end_turn");
+      expect(result._meta).toEqual({ sawSession: "s-1", proxied: true });
+      expect(promptTexts).toEqual(["hello through the proxy"]);
+    } finally {
+      connection.close();
+    }
+  });
+
   it("connects a client app to an agent app through the proxy", async () => {
     const promptsSeen: string[] = [];
     const { clientStream, agentStream } = setupProxy((p) => {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -489,6 +489,215 @@ describe("proxy forwarding", () => {
     }
   });
 
+  it("aborts an intercepted request before draining source EOF", async () => {
+    const [clientStream, proxyClientSide] = inMemoryStreamPair();
+    const [proxyAgentSide] = inMemoryStreamPair();
+    const handlerStarted = Promise.withResolvers<void>();
+    const handlerAborted = Promise.withResolvers<void>();
+    const handle = proxy()
+      .onRequestFromClient(
+        "wait",
+        (params) => params,
+        ({ signal }) =>
+          new Promise((resolve) => {
+            handlerStarted.resolve();
+            const finish = () => {
+              handlerAborted.resolve();
+              resolve({ stopped: true });
+            };
+            if (signal.aborted) {
+              finish();
+            } else {
+              signal.addEventListener("abort", finish, { once: true });
+            }
+          }),
+      )
+      .connect({ client: proxyClientSide, agent: proxyAgentSide });
+    const clientReader = clientStream.readable.getReader();
+    const clientWriter = clientStream.writable.getWriter();
+
+    try {
+      await clientWriter.write({
+        jsonrpc: "2.0",
+        id: 23,
+        method: "wait",
+      });
+      await handlerStarted.promise;
+      const response = clientReader.read();
+      await clientWriter.close();
+
+      await withTimeout(
+        handlerAborted.promise,
+        "source EOF did not abort the interceptor",
+      );
+      expect(handle.client.signal.aborted).toBe(false);
+      await expect(withTimeout(response)).resolves.toEqual({
+        done: false,
+        value: {
+          jsonrpc: "2.0",
+          id: 23,
+          result: { stopped: true },
+        },
+      });
+      await withTimeout(
+        handle.closed,
+        "proxy did not close after handler exit",
+      );
+    } finally {
+      handle.close();
+      await clientReader.cancel().catch(() => {});
+      clientReader.releaseLock();
+      clientWriter.releaseLock();
+    }
+  });
+
+  it("aborts every duplicate-ID request before draining source EOF", async () => {
+    const [clientStream, proxyClientSide] = inMemoryStreamPair();
+    const [proxyAgentSide] = inMemoryStreamPair();
+    const firstStarted = Promise.withResolvers<void>();
+    const bothAborted = Promise.withResolvers<void>();
+    const aborted: number[] = [];
+    const handle = proxy()
+      .onRequestFromClient(
+        "wait",
+        (params) => params as { sequence: number },
+        ({ params, signal }) =>
+          new Promise((resolve) => {
+            if (params.sequence === 1) firstStarted.resolve();
+            const finish = () => {
+              aborted.push(params.sequence);
+              if (aborted.length === 2) bothAborted.resolve();
+              resolve({ stopped: params.sequence });
+            };
+            if (signal.aborted) {
+              finish();
+            } else {
+              signal.addEventListener("abort", finish, { once: true });
+            }
+          }),
+      )
+      .connect({ client: proxyClientSide, agent: proxyAgentSide });
+    const clientReader = clientStream.readable.getReader();
+    const clientWriter = clientStream.writable.getWriter();
+
+    try {
+      await clientWriter.write({
+        jsonrpc: "2.0",
+        id: 23,
+        method: "wait",
+        params: { sequence: 1 },
+      });
+      await firstStarted.promise;
+      await clientWriter.write({
+        jsonrpc: "2.0",
+        id: 23,
+        method: "wait",
+        params: { sequence: 2 },
+      });
+      const responses = Promise.all([clientReader.read(), clientReader.read()]);
+      await clientWriter.close();
+
+      await withTimeout(
+        bothAborted.promise,
+        "source EOF did not abort every duplicate-ID request",
+      );
+      await expect(withTimeout(responses)).resolves.toEqual([
+        {
+          done: false,
+          value: {
+            jsonrpc: "2.0",
+            id: 23,
+            result: { stopped: 1 },
+          },
+        },
+        {
+          done: false,
+          value: {
+            jsonrpc: "2.0",
+            id: 23,
+            result: { stopped: 2 },
+          },
+        },
+      ]);
+      expect(aborted).toEqual([1, 2]);
+      await withTimeout(
+        handle.closed,
+        "proxy did not close after duplicate IDs",
+      );
+    } finally {
+      handle.close();
+      await clientReader.cancel().catch(() => {});
+      clientReader.releaseLock();
+      clientWriter.releaseLock();
+    }
+  });
+
+  it("aborts a source request before draining target EOF", async () => {
+    const [clientStream, proxyClientSide] = inMemoryStreamPair();
+    const [proxyAgentSide, agentStream] = inMemoryStreamPair();
+    const responseReceived = Promise.withResolvers<void>();
+    const handlerAborted = Promise.withResolvers<void>();
+    const waitForAbort = (signal: AbortSignal): Promise<void> =>
+      signal.aborted
+        ? Promise.resolve()
+        : new Promise((resolve) =>
+            signal.addEventListener("abort", () => resolve(), { once: true }),
+          );
+    const handle = proxy()
+      .onRequestFromClient(
+        "echo",
+        (params) => params,
+        async ({ params, forward, signal }) => {
+          const response = (await forward(params)) as Record<string, unknown>;
+          responseReceived.resolve();
+          await waitForAbort(signal);
+          handlerAborted.resolve();
+          return { ...response, intercepted: true };
+        },
+      )
+      .connect({ client: proxyClientSide, agent: proxyAgentSide });
+    const clientEnd = new Connection(clientStream, []);
+    const agentReader = agentStream.readable.getReader();
+    const agentWriter = agentStream.writable.getWriter();
+
+    try {
+      const response = clientEnd.sendRequest("echo", { value: 42 });
+      const { value: forwarded } = await agentReader.read();
+      if (
+        !forwarded ||
+        Array.isArray(forwarded) ||
+        !("id" in forwarded) ||
+        !("method" in forwarded)
+      ) {
+        throw new Error("Expected the forwarded request");
+      }
+
+      await agentWriter.write({
+        jsonrpc: "2.0",
+        id: forwarded.id,
+        result: { echoed: forwarded.params },
+      });
+      await responseReceived.promise;
+      await agentWriter.close();
+
+      await withTimeout(
+        handlerAborted.promise,
+        "target EOF did not abort the source request",
+      );
+      await expect(withTimeout(response)).resolves.toEqual({
+        echoed: { value: 42 },
+        intercepted: true,
+      });
+      await withTimeout(handle.closed, "proxy did not close after target EOF");
+    } finally {
+      handle.close();
+      clientEnd.close();
+      await agentReader.cancel().catch(() => {});
+      agentReader.releaseLock();
+      agentWriter.releaseLock();
+    }
+  });
+
   it("drains a final notification whose interceptor has not forwarded before EOF", async () => {
     const [clientStream, proxyClientSide] = inMemoryStreamPair();
     const [proxyAgentSide, agentStream] = inMemoryStreamPair();

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -512,6 +512,71 @@ describe("proxy ordering and correlation", () => {
   });
 });
 
+describe("proxy agent-side interception", () => {
+  it("intercepts agent-initiated requests with onRequestFromAgent", async () => {
+    const clientSaw = vi.fn();
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.onRequestFromAgent(
+        "confirm",
+        (params) => params as { action: string },
+        // Answer in the proxy; the client must never be consulted.
+        ({ params }) => ({ approved: params.action === "safe" }),
+      );
+    });
+    Connection.builder()
+      .onReceiveMessage((message) => {
+        clientSaw(message.method);
+        return Handled.no(message);
+      })
+      .connect(clientStream);
+    const agentEnd = new Connection(agentStream, []);
+
+    await expect(
+      agentEnd.sendRequest("confirm", { action: "safe" }),
+    ).resolves.toEqual({
+      approved: true,
+    });
+    await expect(
+      agentEnd.sendRequest("confirm", { action: "risky" }),
+    ).resolves.toEqual({ approved: false });
+
+    expect(clientSaw).not.toHaveBeenCalled();
+  });
+
+  it("parses params with an object-form (schema-style) parser", async () => {
+    const parsed: unknown[] = [];
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.onRequestFromClient(
+        "strict",
+        // Object form, like a zod schema: { parse(input) { ... } }.
+        {
+          parse: (input: unknown) => {
+            const record = input as { n: number };
+            return { n: record.n * 10 };
+          },
+        },
+        async ({ params, forward }) => {
+          parsed.push(params);
+          return forward(params);
+        },
+      );
+    });
+    Connection.builder()
+      .onReceiveRequest(
+        "strict",
+        (params) => params,
+        (request, responder) => responder.respond({ echoed: request }),
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    const response = await clientEnd.sendRequest("strict", { n: 4 });
+
+    expect(parsed).toEqual([{ n: 40 }]);
+    expect(response).toEqual({ echoed: { n: 40 } });
+  });
+});
+
 describe("proxy composition", () => {
   it("chains two proxies, each rewriting in flight", async () => {
     const [clientStream, firstClientSide] = inMemoryStreamPair();

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -229,6 +229,11 @@ describe("proxy forwarding", () => {
     handle.client.close(new Error("client side went away"));
 
     await expect(handle.closed).resolves.toBeUndefined();
+    expect(handle.agent.signal.aborted).toBe(true);
+    // The close reason crosses to the other side's pending requests.
+    expect(handle.agent.signal.reason).toMatchObject({
+      message: "client side went away",
+    });
   });
 
   it("closes both sides when the client transport reaches EOF", async () => {
@@ -254,6 +259,8 @@ describe("proxy forwarding", () => {
     clientToProxy.end();
 
     await expect(handle.closed).resolves.toBeUndefined();
+    expect(handle.client.signal.aborted).toBe(true);
+    expect(handle.agent.signal.aborted).toBe(true);
   });
 
   it("closes both sides through the handle", async () => {
@@ -262,6 +269,8 @@ describe("proxy forwarding", () => {
     handle.close();
 
     await expect(handle.closed).resolves.toBeUndefined();
+    expect(handle.client.signal.aborted).toBe(true);
+    expect(handle.agent.signal.aborted).toBe(true);
   });
 });
 

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -140,7 +140,7 @@ describe("proxy forwarding", () => {
 
   it("preserves notification order when an earlier handler is slow", async () => {
     const { clientStream, agentStream } = setupProxy((p) => {
-      p.agent.onNotification(
+      p.onNotificationFromAgent(
         "update",
         (params) => params as { tag: string; delay: number },
         async ({ params, forward }) => {
@@ -178,7 +178,7 @@ describe("proxy forwarding", () => {
     // `slow` goes through a typed handler that awaits forward(...), which
     // must release the dispatch loop at the send, not the response.
     const { clientStream, agentStream } = setupProxy((p) => {
-      p.client.onRequest(
+      p.onRequestFromClient(
         "slow",
         (params) => params,
         async ({ params, forward }) => forward(params),
@@ -231,7 +231,7 @@ describe("proxy forwarding", () => {
 describe("proxy typed registration", () => {
   it("rewrites request params before forwarding", async () => {
     const { clientStream, agentStream } = setupProxy((p) => {
-      p.client.onRequest(
+      p.onRequestFromClient(
         "echo",
         (params) => params as Record<string, unknown>,
         async ({ forward }) => forward({ rewritten: true }),
@@ -253,7 +253,7 @@ describe("proxy typed registration", () => {
 
   it("rewrites responses on the way back", async () => {
     const { clientStream, agentStream } = setupProxy((p) => {
-      p.client.onRequest(
+      p.onRequestFromClient(
         "echo",
         (params) => params,
         async ({ params, forward }) => {
@@ -279,7 +279,7 @@ describe("proxy typed registration", () => {
   it("answers intercepted requests without the agent seeing them", async () => {
     const agentSaw = vi.fn();
     const { clientStream, agentStream } = setupProxy((p) => {
-      p.client.onRequest(
+      p.onRequestFromClient(
         "denied",
         (params) => params,
         () => {
@@ -306,7 +306,7 @@ describe("proxy typed registration", () => {
 
   it("answers without forwarding when the handler returns its own response", async () => {
     const { clientStream } = setupProxy((p) => {
-      p.client.onRequest(
+      p.onRequestFromClient(
         "cached",
         (params) => params,
         () => ({ fromProxy: true }),
@@ -321,7 +321,7 @@ describe("proxy typed registration", () => {
 
   it("drops notifications when the handler skips forward", async () => {
     const { clientStream, agentStream } = setupProxy((p) => {
-      p.agent.onNotification(
+      p.onNotificationFromAgent(
         "update",
         (params) => params as { secret: boolean },
         async ({ params, forward }) => {
@@ -356,16 +356,14 @@ describe("proxy typed registration", () => {
   it("routes unclaimed traffic to '*' with exact registrations winning", async () => {
     const wildcardSaw: string[] = [];
     const { clientStream, agentStream } = setupProxy((p) => {
-      p.client
-        .onRequest(
-          "specific",
-          (params) => params,
-          () => ({ via: "specific" }),
-        )
-        .onRequest("*", ({ method, params, forward }) => {
-          wildcardSaw.push(method);
-          return forward(params);
-        });
+      p.onRequestFromClient(
+        "specific",
+        (params) => params,
+        () => ({ via: "specific" }),
+      ).onRequestFromClient("*", ({ method, params, forward }) => {
+        wildcardSaw.push(method);
+        return forward(params);
+      });
     });
     Connection.builder()
       .onReceiveRequest(
@@ -399,7 +397,7 @@ describe("proxy typed registration", () => {
 
     // Registering after connect is allowed but must not affect the
     // already-connected proxy — same semantics as the fluent app builders.
-    builder.client.onRequest(
+    builder.onRequestFromClient(
       "echo",
       (params) => params as Record<string, unknown>,
       async ({ forward }) => forward({ late: true }),
@@ -412,14 +410,14 @@ describe("proxy typed registration", () => {
 
   it("rejects duplicate registrations for the same method", () => {
     const p = proxy();
-    p.client.onRequest(
+    p.onRequestFromClient(
       "echo",
       (params) => params,
       async ({ params, forward }) => forward(params),
     );
 
     expect(() =>
-      p.client.onRequest(
+      p.onRequestFromClient(
         "echo",
         (params) => params,
         async ({ params, forward }) => forward(params),
@@ -430,7 +428,7 @@ describe("proxy typed registration", () => {
   it("routes unclaimed notifications to '*'", async () => {
     const wildcardSaw: string[] = [];
     const { clientStream, agentStream } = setupProxy((p) => {
-      p.client.onNotification("*", async ({ method, params, forward }) => {
+      p.onNotificationFromClient("*", async ({ method, params, forward }) => {
         wildcardSaw.push(method);
         await forward(params);
       });
@@ -456,7 +454,7 @@ describe("proxy with fluent apps", () => {
   it("connects a client app to an agent app through the proxy", async () => {
     const promptsSeen: string[] = [];
     const { clientStream, agentStream } = setupProxy((p) => {
-      p.client.onRequest(
+      p.onRequestFromClient(
         "_test/echo",
         (params) => params as { value: number },
         async ({ params, forward }) => {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -38,6 +38,23 @@ function setupProxy(configure?: (p: ProxyBuilder) => void): ProxySetup {
   return { clientStream, agentStream, builder, handle };
 }
 
+async function withTimeout<T>(
+  promise: Promise<T>,
+  message = "operation timed out",
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), 500);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 describe("proxy forwarding", () => {
   it("forwards client requests to the agent and responses back", async () => {
     const { clientStream, agentStream } = setupProxy();
@@ -398,6 +415,283 @@ describe("proxy forwarding", () => {
     agentReader.releaseLock();
     agentWriter.releaseLock();
     clientEnd.close();
+  });
+
+  it("drains an already-received response back to a requester that reaches EOF", async () => {
+    const [clientStream, proxyClientSide] = inMemoryStreamPair();
+    const [proxyAgentSide, agentStream] = inMemoryStreamPair();
+    const responseReceived = Promise.withResolvers<void>();
+    const releaseInterceptor = Promise.withResolvers<void>();
+    const handle = proxy()
+      .onRequestFromAgent(
+        "ask",
+        (params) => params,
+        async ({ params, forward }) => {
+          const response = (await forward(params)) as Record<string, unknown>;
+          responseReceived.resolve();
+          await releaseInterceptor.promise;
+          return { ...response, intercepted: true };
+        },
+      )
+      .connect({ client: proxyClientSide, agent: proxyAgentSide });
+    const clientReader = clientStream.readable.getReader();
+    const clientWriter = clientStream.writable.getWriter();
+    const agentReader = agentStream.readable.getReader();
+    const agentWriter = agentStream.writable.getWriter();
+
+    try {
+      await agentWriter.write({
+        jsonrpc: "2.0",
+        id: 91,
+        method: "ask",
+        params: { value: 42 },
+      });
+      const { value: forwarded } = await clientReader.read();
+      if (
+        !forwarded ||
+        Array.isArray(forwarded) ||
+        !("id" in forwarded) ||
+        !("method" in forwarded)
+      ) {
+        throw new Error("Expected the forwarded request");
+      }
+
+      await clientWriter.write({
+        jsonrpc: "2.0",
+        id: forwarded.id,
+        result: { answered: true },
+      });
+      await responseReceived.promise;
+      await agentWriter.close();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(handle.agent.signal.aborted).toBe(false);
+
+      const response = agentReader.read();
+      releaseInterceptor.resolve();
+      await expect(withTimeout(response)).resolves.toEqual({
+        done: false,
+        value: {
+          jsonrpc: "2.0",
+          id: 91,
+          result: { answered: true, intercepted: true },
+        },
+      });
+      await withTimeout(handle.closed, "proxy did not close after response");
+    } finally {
+      releaseInterceptor.resolve();
+      handle.close();
+      await clientReader.cancel().catch(() => {});
+      await agentReader.cancel().catch(() => {});
+      clientReader.releaseLock();
+      clientWriter.releaseLock();
+      agentReader.releaseLock();
+      agentWriter.releaseLock();
+    }
+  });
+
+  it("drains a final notification whose interceptor has not forwarded before EOF", async () => {
+    const [clientStream, proxyClientSide] = inMemoryStreamPair();
+    const [proxyAgentSide, agentStream] = inMemoryStreamPair();
+    const handlerStarted = Promise.withResolvers<void>();
+    const releaseHandler = Promise.withResolvers<void>();
+    const handle = proxy()
+      .onNotificationFromAgent(
+        "note",
+        (params) => params,
+        async ({ params, forward }) => {
+          handlerStarted.resolve();
+          await releaseHandler.promise;
+          await forward(params);
+        },
+      )
+      .connect({ client: proxyClientSide, agent: proxyAgentSide });
+    const clientReader = clientStream.readable.getReader();
+    const agentWriter = agentStream.writable.getWriter();
+
+    try {
+      const notification = {
+        jsonrpc: "2.0" as const,
+        method: "note",
+        params: { final: true },
+      };
+      await agentWriter.write(notification);
+      await handlerStarted.promise;
+      await agentWriter.close();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(handle.agent.signal.aborted).toBe(false);
+      expect(handle.client.signal.aborted).toBe(false);
+
+      const received = clientReader.read();
+      releaseHandler.resolve();
+      await expect(withTimeout(received)).resolves.toEqual({
+        done: false,
+        value: notification,
+      });
+      await withTimeout(handle.closed, "proxy did not close after EOF drain");
+    } finally {
+      releaseHandler.resolve();
+      handle.close();
+      await clientReader.cancel().catch(() => {});
+      clientReader.releaseLock();
+      agentWriter.releaseLock();
+    }
+  });
+
+  it("drains every queued notification write before propagating EOF", async () => {
+    const firstWriteStarted = Promise.withResolvers<void>();
+    const secondWriteStarted = Promise.withResolvers<void>();
+    const releaseFirstWrite = Promise.withResolvers<void>();
+    const releaseSecondWrite = Promise.withResolvers<void>();
+    const written: AnyMessage[] = [];
+    const proxyClientSide: Stream = {
+      readable: new ReadableStream<AnyMessage>(),
+      writable: new WritableStream<AnyMessage>({
+        async write(message) {
+          written.push(message);
+          if (written.length === 1) {
+            firstWriteStarted.resolve();
+            await releaseFirstWrite.promise;
+          } else {
+            secondWriteStarted.resolve();
+            await releaseSecondWrite.promise;
+          }
+        },
+      }),
+    };
+    const [proxyAgentSide, agentStream] = inMemoryStreamPair();
+    const handle = proxy().connect({
+      client: proxyClientSide,
+      agent: proxyAgentSide,
+    });
+    const agentWriter = agentStream.writable.getWriter();
+
+    try {
+      const first = {
+        jsonrpc: "2.0" as const,
+        method: "note",
+        params: { n: 1 },
+      };
+      const second = {
+        jsonrpc: "2.0" as const,
+        method: "note",
+        params: { n: 2 },
+      };
+      await agentWriter.write(first);
+      await agentWriter.write(second);
+      await agentWriter.close();
+      await withTimeout(firstWriteStarted.promise, "first write did not start");
+      await withTimeout(handle.agent.closed, "agent EOF did not settle");
+
+      expect(handle.client.signal.aborted).toBe(false);
+      releaseFirstWrite.resolve();
+      await withTimeout(secondWriteStarted.promise, "second write was dropped");
+      expect(handle.client.signal.aborted).toBe(false);
+
+      releaseSecondWrite.resolve();
+      await withTimeout(handle.closed, "queued writes did not drain");
+      expect(written).toEqual([first, second]);
+    } finally {
+      releaseFirstWrite.resolve();
+      releaseSecondWrite.resolve();
+      handle.close();
+      agentWriter.releaseLock();
+    }
+  });
+
+  it("propagates a protocol-error close without waiting for interceptor cleanup", async () => {
+    const [clientStream, proxyClientSide] = inMemoryStreamPair();
+    const [proxyAgentSide, agentStream] = inMemoryStreamPair();
+    const interceptorPaused = Promise.withResolvers<void>();
+    const releaseInterceptor = Promise.withResolvers<void>();
+    const handle = proxy()
+      .onNotificationFromAgent(
+        "note",
+        (params) => params,
+        async ({ params, forward }) => {
+          await forward(params);
+          interceptorPaused.resolve();
+          await releaseInterceptor.promise;
+        },
+      )
+      .connect({ client: proxyClientSide, agent: proxyAgentSide });
+    const clientReader = clientStream.readable.getReader();
+    const clientWriter = clientStream.writable.getWriter();
+    const agentWriter = agentStream.writable.getWriter();
+
+    try {
+      await agentWriter.write({
+        jsonrpc: "2.0",
+        method: "note",
+        params: { final: true },
+      });
+      await withTimeout(clientReader.read());
+      await interceptorPaused.promise;
+
+      await clientWriter.write([
+        { jsonrpc: "2.0", method: "unsupported-batch" },
+      ] as unknown as AnyMessage);
+      await withTimeout(
+        handle.closed,
+        "protocol error waited for interceptor cleanup",
+      );
+
+      expect(handle.client.signal.reason).toBeInstanceOf(TypeError);
+      expect(handle.agent.signal.reason).toBe(handle.client.signal.reason);
+    } finally {
+      releaseInterceptor.resolve();
+      handle.close();
+      await clientReader.cancel().catch(() => {});
+      clientReader.releaseLock();
+      clientWriter.releaseLock();
+      agentWriter.releaseLock();
+    }
+  });
+
+  it("propagates an explicit side close without waiting for interceptor cleanup", async () => {
+    const [clientStream, proxyClientSide] = inMemoryStreamPair();
+    const [proxyAgentSide, agentStream] = inMemoryStreamPair();
+    const interceptorPaused = Promise.withResolvers<void>();
+    const releaseInterceptor = Promise.withResolvers<void>();
+    const handle = proxy()
+      .onNotificationFromAgent(
+        "note",
+        (params) => params,
+        async ({ params, forward }) => {
+          await forward(params);
+          interceptorPaused.resolve();
+          await releaseInterceptor.promise;
+        },
+      )
+      .connect({ client: proxyClientSide, agent: proxyAgentSide });
+    const clientReader = clientStream.readable.getReader();
+    const agentWriter = agentStream.writable.getWriter();
+
+    try {
+      await agentWriter.write({
+        jsonrpc: "2.0",
+        method: "note",
+        params: { final: true },
+      });
+      await withTimeout(clientReader.read());
+      await interceptorPaused.promise;
+
+      const reason = new Error("client closed explicitly");
+      handle.client.close(reason);
+      await withTimeout(
+        handle.closed,
+        "explicit close waited for interceptor cleanup",
+      );
+
+      expect(handle.client.signal.reason).toBe(reason);
+      expect(handle.agent.signal.reason).toBe(reason);
+    } finally {
+      releaseInterceptor.resolve();
+      handle.close();
+      await clientReader.cancel().catch(() => {});
+      clientReader.releaseLock();
+      agentWriter.releaseLock();
+    }
   });
 
   it("closes both sides through the handle", async () => {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { agent, client, inMemoryStreamPair } from "./acp.js";
+import { Connection, Handled, RequestError } from "./jsonrpc.js";
+import type { JsonRpcHandler } from "./jsonrpc.js";
+import { proxy } from "./proxy.js";
+import type { ProxyHandle } from "./proxy.js";
+import type { Stream } from "./stream.js";
+
+type ProxySetup = {
+  clientStream: Stream;
+  agentStream: Stream;
+  handle: ProxyHandle;
+};
+
+function setupProxy(options?: {
+  clientToAgent?: JsonRpcHandler[];
+  agentToClient?: JsonRpcHandler[];
+}): ProxySetup {
+  const [clientStream, proxyClientSide] = inMemoryStreamPair();
+  const [proxyAgentSide, agentStream] = inMemoryStreamPair();
+  const handle = proxy({
+    client: proxyClientSide,
+    agent: proxyAgentSide,
+    ...options,
+  });
+  return { clientStream, agentStream, handle };
+}
+
+describe("proxy forwarding", () => {
+  it("forwards client requests to the agent and responses back", async () => {
+    const { clientStream, agentStream } = setupProxy();
+    Connection.builder()
+      .onReceiveRequest(
+        "echo",
+        (params) => params,
+        (request, responder) => responder.respond({ echoed: request }),
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    const response = await clientEnd.sendRequest("echo", { value: 42 });
+
+    expect(response).toEqual({ echoed: { value: 42 } });
+  });
+
+  it("forwards agent-initiated requests to the client", async () => {
+    const { clientStream, agentStream } = setupProxy();
+    Connection.builder()
+      .onReceiveRequest(
+        "confirm",
+        (params) => params,
+        (_request, responder) => responder.respond({ approved: true }),
+      )
+      .connect(clientStream);
+    const agentEnd = new Connection(agentStream, []);
+
+    const response = await agentEnd.sendRequest("confirm", { action: "run" });
+
+    expect(response).toEqual({ approved: true });
+  });
+
+  it("forwards notifications", async () => {
+    const { clientStream, agentStream } = setupProxy();
+    const received = vi.fn();
+    const seen = Promise.withResolvers<void>();
+    Connection.builder()
+      .onReceiveNotification(
+        "log",
+        (params) => params,
+        (notification) => {
+          received(notification);
+          seen.resolve();
+        },
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    await clientEnd.sendNotification("log", { line: "hello" });
+    await seen.promise;
+
+    expect(received).toHaveBeenCalledWith({ line: "hello" });
+  });
+
+  it("preserves error responses across the proxy", async () => {
+    const { clientStream, agentStream } = setupProxy();
+    Connection.builder()
+      .onReceiveRequest(
+        "always-fails",
+        (params) => params,
+        () => {
+          throw new RequestError(1234, "nope", { reason: "test" });
+        },
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    const failure = clientEnd.sendRequest("always-fails", {});
+
+    await expect(failure).rejects.toMatchObject({
+      code: 1234,
+      message: "nope",
+      data: { reason: "test" },
+    });
+  });
+
+  it("responds method-not-found from the far side, not the proxy", async () => {
+    const { clientStream, agentStream } = setupProxy();
+    Connection.builder().connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    const failure = clientEnd.sendRequest("no-such-method", {});
+
+    await expect(failure).rejects.toMatchObject({ code: -32601 });
+  });
+
+  it("propagates cancellation to the side handling the request", async () => {
+    const { clientStream, agentStream } = setupProxy();
+    Connection.builder()
+      .onReceiveRequest(
+        "slow",
+        (params) => params,
+        (_request, responder) => {
+          // Never respond on our own; settle only when the caller cancels.
+          responder.signal.addEventListener("abort", () => {
+            void responder.respondWithError(RequestError.requestCancelled());
+          });
+        },
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    const canceller = new AbortController();
+    const failure = clientEnd.sendRequest("slow", {}, undefined, {
+      cancellationSignal: canceller.signal,
+    });
+    canceller.abort();
+
+    await expect(failure).rejects.toMatchObject({ code: -32800 });
+  });
+
+  it("closes the other side when one side of the proxy closes", async () => {
+    const { handle } = setupProxy();
+
+    handle.client.close(new Error("client side went away"));
+
+    await handle.closed;
+    await expect(handle.agent.sendRequest("anything", {})).rejects.toThrow(
+      "client side went away",
+    );
+  });
+
+  it("closes both sides through the handle", async () => {
+    const { handle } = setupProxy();
+
+    handle.close();
+
+    await handle.closed;
+  });
+});
+
+describe("proxy interception", () => {
+  it("rewrites request params before forwarding", async () => {
+    const { clientStream, agentStream } = setupProxy({
+      clientToAgent: [
+        {
+          handleMessage(message) {
+            if (message.kind !== "request" || message.method !== "echo") {
+              return Handled.no(message);
+            }
+
+            return Handled.no({
+              ...message,
+              params: { rewritten: true },
+            });
+          },
+        },
+      ],
+    });
+    Connection.builder()
+      .onReceiveRequest(
+        "echo",
+        (params) => params,
+        (request, responder) => responder.respond({ echoed: request }),
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    const response = await clientEnd.sendRequest("echo", { original: true });
+
+    expect(response).toEqual({ echoed: { rewritten: true } });
+  });
+
+  it("answers intercepted requests without the agent seeing them", async () => {
+    const agentSaw = vi.fn();
+    const { clientStream, agentStream } = setupProxy({
+      clientToAgent: [
+        {
+          async handleMessage(message) {
+            if (message.kind !== "request" || message.method !== "denied") {
+              return Handled.no(message);
+            }
+
+            await message.responder.respondWithError(
+              new RequestError(-32001, "not allowed"),
+            );
+            return Handled.yes();
+          },
+        },
+      ],
+    });
+    Connection.builder()
+      .onReceiveMessage((message) => {
+        agentSaw(message.method);
+        return Handled.no(message);
+      })
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    const denied = clientEnd.sendRequest("denied", {});
+    await expect(denied).rejects.toMatchObject({ code: -32001 });
+
+    // A permitted request afterwards proves the denied one never crossed.
+    await clientEnd.sendRequest("allowed", {}).catch(() => {});
+    expect(agentSaw).toHaveBeenCalledWith("allowed");
+    expect(agentSaw).not.toHaveBeenCalledWith("denied");
+  });
+
+  it("intercepts agent-to-client traffic with agentToClient handlers", async () => {
+    const { clientStream, agentStream } = setupProxy({
+      agentToClient: [
+        {
+          handleMessage(message) {
+            if (
+              message.kind !== "notification" ||
+              message.method !== "update"
+            ) {
+              return Handled.no(message);
+            }
+
+            return Handled.no({
+              ...message,
+              params: { filtered: true },
+            });
+          },
+        },
+      ],
+    });
+    const received = Promise.withResolvers<unknown>();
+    Connection.builder()
+      .onReceiveNotification(
+        "update",
+        (params) => params,
+        (notification) => received.resolve(notification),
+      )
+      .connect(clientStream);
+    const agentEnd = new Connection(agentStream, []);
+
+    await agentEnd.sendNotification("update", { secret: "value" });
+
+    await expect(received.promise).resolves.toEqual({ filtered: true });
+  });
+});
+
+describe("proxy with fluent apps", () => {
+  it("connects a client app to an agent app through the proxy", async () => {
+    const { clientStream, agentStream } = setupProxy();
+    agent({ name: "test-agent" })
+      .onRequest(
+        "_test/echo",
+        (params) => params as { value: number },
+        ({ params }) => ({ doubled: params.value * 2 }),
+      )
+      .connect(agentStream);
+
+    const connection = client({ name: "test-client" }).connect(clientStream);
+    try {
+      const response = await connection.agent.request<{ doubled: number }>(
+        "_test/echo",
+        { value: 21 },
+      );
+
+      expect(response).toEqual({ doubled: 42 });
+    } finally {
+      connection.close();
+    }
+  });
+});

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -950,3 +950,22 @@ describe("proxy with fluent apps", () => {
     }
   });
 });
+
+describe("proxy batch rejection", () => {
+  it("closes both sides when a batch wire message arrives", async () => {
+    const { clientStream, handle } = setupProxy();
+    const writer = clientStream.writable.getWriter();
+
+    await writer.write([
+      { jsonrpc: "2.0", id: 1, method: "example/one" },
+      { jsonrpc: "2.0", method: "example/notify" },
+    ] as unknown as AnyMessage);
+
+    await handle.closed;
+    expect(handle.client.signal.reason).toBeInstanceOf(TypeError);
+    expect(String(handle.client.signal.reason)).toContain(
+      "batches are not supported",
+    );
+    expect(handle.agent.signal.reason).toBe(handle.client.signal.reason);
+  });
+});

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import { agent, client, inMemoryStreamPair } from "./acp.js";
 import { Connection, Handled, RequestError } from "./jsonrpc.js";
-import type { JsonRpcHandler, RequestResponder } from "./jsonrpc.js";
+import type { RequestResponder } from "./jsonrpc.js";
 import { proxy } from "./proxy.js";
-import type { ProxyHandle } from "./proxy.js";
+import type { ProxyBuilder, ProxyHandle } from "./proxy.js";
 import type { Stream } from "./stream.js";
 
 type ProxySetup = {
@@ -13,17 +13,12 @@ type ProxySetup = {
   handle: ProxyHandle;
 };
 
-function setupProxy(options?: {
-  fromClient?: JsonRpcHandler[];
-  fromAgent?: JsonRpcHandler[];
-}): ProxySetup {
+function setupProxy(configure?: (p: ProxyBuilder) => void): ProxySetup {
   const [clientStream, proxyClientSide] = inMemoryStreamPair();
   const [proxyAgentSide, agentStream] = inMemoryStreamPair();
-  const handle = proxy({
-    client: proxyClientSide,
-    agent: proxyAgentSide,
-    ...options,
-  });
+  const p = proxy();
+  configure?.(p);
+  const handle = p.connect({ client: proxyClientSide, agent: proxyAgentSide });
   return { clientStream, agentStream, handle };
 }
 
@@ -140,19 +135,15 @@ describe("proxy forwarding", () => {
   });
 
   it("preserves notification order when an earlier handler is slow", async () => {
-    const { clientStream, agentStream } = setupProxy({
-      fromAgent: [
-        {
-          async handleMessage(message) {
-            if (message.kind === "notification") {
-              const { delay } = message.params as { delay: number };
-              await new Promise((resolve) => setTimeout(resolve, delay));
-            }
-
-            return Handled.no(message);
-          },
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.agent.onNotification(
+        "update",
+        (params) => params as { tag: string; delay: number },
+        async ({ params, forward }) => {
+          await new Promise((resolve) => setTimeout(resolve, params.delay));
+          await forward(params);
         },
-      ],
+      );
     });
     const received: string[] = [];
     const gotBoth = Promise.withResolvers<void>();
@@ -180,7 +171,15 @@ describe("proxy forwarding", () => {
   });
 
   it("does not block later messages behind a pending request round trip", async () => {
-    const { clientStream, agentStream } = setupProxy();
+    // `slow` goes through a typed handler that awaits forward(...), which
+    // must release the dispatch loop at the send, not the response.
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.client.onRequest(
+        "slow",
+        (params) => params,
+        async ({ params, forward }) => forward(params),
+      );
+    });
     const slowArrived = Promise.withResolvers<RequestResponder<unknown>>();
     Connection.builder()
       .onReceiveRequest(
@@ -228,23 +227,14 @@ describe("proxy forwarding", () => {
   });
 });
 
-describe("proxy interception", () => {
+describe("proxy typed registration", () => {
   it("rewrites request params before forwarding", async () => {
-    const { clientStream, agentStream } = setupProxy({
-      fromClient: [
-        {
-          handleMessage(message) {
-            if (message.kind !== "request" || message.method !== "echo") {
-              return Handled.no(message);
-            }
-
-            return Handled.no({
-              ...message,
-              params: { rewritten: true },
-            });
-          },
-        },
-      ],
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.client.onRequest(
+        "echo",
+        (params) => params as Record<string, unknown>,
+        async ({ forward }) => forward({ rewritten: true }),
+      );
     });
     Connection.builder()
       .onReceiveRequest(
@@ -260,23 +250,41 @@ describe("proxy interception", () => {
     expect(response).toEqual({ echoed: { rewritten: true } });
   });
 
+  it("rewrites responses on the way back", async () => {
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.client.onRequest(
+        "echo",
+        (params) => params,
+        async ({ params, forward }) => {
+          const response = (await forward(params)) as Record<string, unknown>;
+          return { ...response, stamped: true };
+        },
+      );
+    });
+    Connection.builder()
+      .onReceiveRequest(
+        "echo",
+        (params) => params,
+        (request, responder) => responder.respond({ echoed: request }),
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    const response = await clientEnd.sendRequest("echo", { value: 1 });
+
+    expect(response).toEqual({ echoed: { value: 1 }, stamped: true });
+  });
+
   it("answers intercepted requests without the agent seeing them", async () => {
     const agentSaw = vi.fn();
-    const { clientStream, agentStream } = setupProxy({
-      fromClient: [
-        {
-          async handleMessage(message) {
-            if (message.kind !== "request" || message.method !== "denied") {
-              return Handled.no(message);
-            }
-
-            await message.responder.respondWithError(
-              new RequestError(-32001, "not allowed"),
-            );
-            return Handled.yes();
-          },
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.client.onRequest(
+        "denied",
+        (params) => params,
+        () => {
+          throw new RequestError(-32001, "not allowed");
         },
-      ],
+      );
     });
     Connection.builder()
       .onReceiveMessage((message) => {
@@ -295,45 +303,150 @@ describe("proxy interception", () => {
     expect(agentSaw).not.toHaveBeenCalledWith("denied");
   });
 
-  it("intercepts agent-to-client traffic with fromAgent handlers", async () => {
-    const { clientStream, agentStream } = setupProxy({
-      fromAgent: [
-        {
-          handleMessage(message) {
-            if (
-              message.kind !== "notification" ||
-              message.method !== "update"
-            ) {
-              return Handled.no(message);
-            }
-
-            return Handled.no({
-              ...message,
-              params: { filtered: true },
-            });
-          },
-        },
-      ],
+  it("answers without forwarding when the handler returns its own response", async () => {
+    const { clientStream } = setupProxy((p) => {
+      p.client.onRequest(
+        "cached",
+        (params) => params,
+        () => ({ fromProxy: true }),
+      );
     });
-    const received = Promise.withResolvers<unknown>();
+    const clientEnd = new Connection(clientStream, []);
+
+    const response = await clientEnd.sendRequest("cached", {});
+
+    expect(response).toEqual({ fromProxy: true });
+  });
+
+  it("drops notifications when the handler skips forward", async () => {
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.agent.onNotification(
+        "update",
+        (params) => params as { secret: boolean },
+        async ({ params, forward }) => {
+          if (!params.secret) {
+            await forward(params);
+          }
+        },
+      );
+    });
+    const received = vi.fn();
+    const gotPublic = Promise.withResolvers<void>();
     Connection.builder()
       .onReceiveNotification(
         "update",
         (params) => params,
-        (notification) => received.resolve(notification),
+        (notification) => {
+          received(notification);
+          gotPublic.resolve();
+        },
       )
       .connect(clientStream);
     const agentEnd = new Connection(agentStream, []);
 
-    await agentEnd.sendNotification("update", { secret: "value" });
+    await agentEnd.sendNotification("update", { secret: true });
+    await agentEnd.sendNotification("update", { secret: false });
+    await gotPublic.promise;
 
-    await expect(received.promise).resolves.toEqual({ filtered: true });
+    expect(received).toHaveBeenCalledTimes(1);
+    expect(received).toHaveBeenCalledWith({ secret: false });
+  });
+
+  it("routes unclaimed traffic to '*' with exact registrations winning", async () => {
+    const wildcardSaw: string[] = [];
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.client
+        .onRequest(
+          "specific",
+          (params) => params,
+          () => ({ via: "specific" }),
+        )
+        .onRequest("*", ({ method, params, forward }) => {
+          wildcardSaw.push(method);
+          return forward(params);
+        });
+    });
+    Connection.builder()
+      .onReceiveRequest(
+        "other",
+        (params) => params,
+        (_request, responder) => responder.respond({ via: "agent" }),
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    await expect(clientEnd.sendRequest("specific", {})).resolves.toEqual({
+      via: "specific",
+    });
+    await expect(clientEnd.sendRequest("other", {})).resolves.toEqual({
+      via: "agent",
+    });
+
+    expect(wildcardSaw).toEqual(["other"]);
+  });
+
+  it("rejects duplicate registrations for the same method", () => {
+    const p = proxy();
+    p.client.onRequest(
+      "echo",
+      (params) => params,
+      async ({ params, forward }) => forward(params),
+    );
+
+    expect(() =>
+      p.client.onRequest(
+        "echo",
+        (params) => params,
+        async ({ params, forward }) => forward(params),
+      ),
+    ).toThrow("already registered");
+  });
+
+  it("intercepts everything through raw withHandler before typed handlers", async () => {
+    const rawSaw: string[] = [];
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.client
+        .withHandler({
+          handleMessage(message) {
+            rawSaw.push(message.method);
+            return Handled.no(message);
+          },
+        })
+        .onRequest(
+          "claimed",
+          (params) => params,
+          () => ({ via: "typed" }),
+        );
+    });
+    Connection.builder()
+      .onReceiveRequest(
+        "unclaimed",
+        (params) => params,
+        (_request, responder) => responder.respond({ via: "agent" }),
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    await clientEnd.sendRequest("claimed", {});
+    await clientEnd.sendRequest("unclaimed", {});
+
+    expect(rawSaw).toEqual(["claimed", "unclaimed"]);
   });
 });
 
 describe("proxy with fluent apps", () => {
   it("connects a client app to an agent app through the proxy", async () => {
-    const { clientStream, agentStream } = setupProxy();
+    const promptsSeen: string[] = [];
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.client.onRequest(
+        "_test/echo",
+        (params) => params as { value: number },
+        async ({ params, forward }) => {
+          promptsSeen.push(`echo:${params.value}`);
+          return forward(params);
+        },
+      );
+    });
     agent({ name: "test-agent" })
       .onRequest(
         "_test/echo",
@@ -350,6 +463,7 @@ describe("proxy with fluent apps", () => {
       );
 
       expect(response).toEqual({ doubled: 42 });
+      expect(promptsSeen).toEqual(["echo:21"]);
     } finally {
       connection.close();
     }

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -10,16 +10,20 @@ import type { Stream } from "./stream.js";
 type ProxySetup = {
   clientStream: Stream;
   agentStream: Stream;
+  builder: ProxyBuilder;
   handle: ProxyHandle;
 };
 
 function setupProxy(configure?: (p: ProxyBuilder) => void): ProxySetup {
   const [clientStream, proxyClientSide] = inMemoryStreamPair();
   const [proxyAgentSide, agentStream] = inMemoryStreamPair();
-  const p = proxy();
-  configure?.(p);
-  const handle = p.connect({ client: proxyClientSide, agent: proxyAgentSide });
-  return { clientStream, agentStream, handle };
+  const builder = proxy();
+  configure?.(builder);
+  const handle = builder.connect({
+    client: proxyClientSide,
+    agent: proxyAgentSide,
+  });
+  return { clientStream, agentStream, builder, handle };
 }
 
 describe("proxy forwarding", () => {
@@ -384,6 +388,33 @@ describe("proxy typed registration", () => {
     });
 
     expect(wildcardSaw).toEqual(["other"]);
+  });
+
+  it("applies handlers registered after connect to subsequent messages", async () => {
+    const { clientStream, agentStream, builder } = setupProxy();
+    Connection.builder()
+      .onReceiveRequest(
+        "echo",
+        (params) => params,
+        (request, responder) => responder.respond({ echoed: request }),
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    // Before registration the request forwards untouched.
+    await expect(clientEnd.sendRequest("echo", { n: 1 })).resolves.toEqual({
+      echoed: { n: 1 },
+    });
+
+    builder.client.onRequest(
+      "echo",
+      (params) => params as Record<string, unknown>,
+      async ({ forward }) => forward({ late: true }),
+    );
+
+    await expect(clientEnd.sendRequest("echo", { n: 2 })).resolves.toEqual({
+      echoed: { late: true },
+    });
   });
 
   it("rejects duplicate registrations for the same method", () => {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { agent, client, ndJsonStream } from "./acp.js";
 import { Connection, Handled, RequestError } from "./jsonrpc.js";
-import type { RequestResponder } from "./jsonrpc.js";
+import type { JsonRpcId, RequestResponder } from "./jsonrpc.js";
 import { proxy } from "./proxy.js";
 import type { ProxyBuilder, ProxyHandle } from "./proxy.js";
 import type { AnyMessage } from "./jsonrpc.js";
@@ -150,6 +150,89 @@ describe("proxy forwarding", () => {
     await expect(failure).rejects.toMatchObject({ code: -32800 });
   });
 
+  it("reissues cancellation with the target ID without forwarding the source ID", async () => {
+    const { clientStream, agentStream } = setupProxy((p) => {
+      p.onRequestFromClient(
+        "local",
+        (params) => params,
+        () => ({ answered: "locally" }),
+      );
+    });
+    const arrived = Promise.withResolvers<void>();
+    const responders = new Map<
+      string,
+      { responder: RequestResponder<unknown>; aborted: boolean }
+    >();
+    const cancellations: JsonRpcId[] = [];
+    Connection.builder()
+      .onReceiveRequest(
+        "park",
+        (params) => params as { name: string },
+        (request, responder) => {
+          const state = { responder, aborted: false };
+          responders.set(request.name, state);
+          responder.signal.addEventListener("abort", () => {
+            state.aborted = true;
+            if (request.name === "cancelled") {
+              void responder.respondWithError(RequestError.requestCancelled());
+            }
+          });
+          if (responders.size === 2) {
+            arrived.resolve();
+          }
+        },
+      )
+      .onReceiveRequest(
+        "barrier",
+        (params) => params,
+        (_request, responder) => responder.respond({ passed: true }),
+      )
+      .onReceiveNotification(
+        "$/cancel_request",
+        (params) => params as { requestId: JsonRpcId },
+        (notification) => {
+          cancellations.push(notification.requestId);
+        },
+      )
+      .connect(agentStream);
+    const clientEnd = new Connection(clientStream, []);
+
+    await expect(clientEnd.sendRequest("local", {})).resolves.toEqual({
+      answered: "locally",
+    });
+
+    const canceller = new AbortController();
+    const cancelled = clientEnd.sendRequest(
+      "park",
+      { name: "cancelled" },
+      undefined,
+      { cancellationSignal: canceller.signal },
+    );
+    const unrelated = clientEnd.sendRequest("park", { name: "unrelated" });
+    await arrived.promise;
+
+    const cancelledAtAgent = responders.get("cancelled")!;
+    const unrelatedAtAgent = responders.get("unrelated")!;
+    // The locally answered source request consumed source ID 0 without
+    // consuming a target ID, so the two connections now allocate different
+    // IDs for the same forwarded request.
+    expect(cancelledAtAgent.responder.id).toBe(0);
+    expect(unrelatedAtAgent.responder.id).toBe(1);
+
+    canceller.abort();
+    await expect(clientEnd.sendRequest("barrier", {})).resolves.toEqual({
+      passed: true,
+    });
+    await expect(cancelled).rejects.toMatchObject({ code: -32800 });
+
+    expect(cancellations).toEqual([cancelledAtAgent.responder.id]);
+    expect(cancelledAtAgent.aborted).toBe(true);
+    expect(unrelatedAtAgent.aborted).toBe(false);
+
+    await unrelatedAtAgent.responder.respond({ done: true });
+    await expect(unrelated).resolves.toEqual({ done: true });
+  });
+
   it("preserves notification order when an earlier handler is slow", async () => {
     const { clientStream, agentStream } = setupProxy((p) => {
       p.onNotificationFromAgent(
@@ -261,6 +344,60 @@ describe("proxy forwarding", () => {
     await expect(handle.closed).resolves.toBeUndefined();
     expect(handle.client.signal.aborted).toBe(true);
     expect(handle.agent.signal.aborted).toBe(true);
+  });
+
+  it("drains a final response through an async interceptor before propagating EOF", async () => {
+    const [clientStream, proxyClientSide] = inMemoryStreamPair();
+    const [proxyAgentSide, agentStream] = inMemoryStreamPair();
+    const releaseInterceptor = Promise.withResolvers<void>();
+    const responseReceived = Promise.withResolvers<void>();
+    const handle = proxy()
+      .onRequestFromClient(
+        "echo",
+        (params) => params,
+        async ({ params, forward }) => {
+          const response = (await forward(params)) as Record<string, unknown>;
+          responseReceived.resolve();
+          await releaseInterceptor.promise;
+          return { ...response, intercepted: true };
+        },
+      )
+      .connect({ client: proxyClientSide, agent: proxyAgentSide });
+    const clientEnd = new Connection(clientStream, []);
+    const agentReader = agentStream.readable.getReader();
+    const agentWriter = agentStream.writable.getWriter();
+
+    const response = clientEnd.sendRequest("echo", { value: 42 });
+    const { value: forwarded } = await agentReader.read();
+    if (
+      !forwarded ||
+      Array.isArray(forwarded) ||
+      !("id" in forwarded) ||
+      !("method" in forwarded)
+    ) {
+      throw new Error("Expected the forwarded request");
+    }
+
+    await agentWriter.write({
+      jsonrpc: "2.0",
+      id: forwarded.id,
+      result: { echoed: forwarded.params },
+    });
+    await responseReceived.promise;
+    await agentWriter.close();
+    await handle.agent.closed;
+
+    expect(handle.client.signal.aborted).toBe(false);
+    releaseInterceptor.resolve();
+    await expect(response).resolves.toEqual({
+      echoed: { value: 42 },
+      intercepted: true,
+    });
+    await handle.closed;
+
+    agentReader.releaseLock();
+    agentWriter.releaseLock();
+    clientEnd.close();
   });
 
   it("closes both sides through the handle", async () => {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -14,8 +14,8 @@ type ProxySetup = {
 };
 
 function setupProxy(options?: {
-  clientToAgent?: JsonRpcHandler[];
-  agentToClient?: JsonRpcHandler[];
+  fromClient?: JsonRpcHandler[];
+  fromAgent?: JsonRpcHandler[];
 }): ProxySetup {
   const [clientStream, proxyClientSide] = inMemoryStreamPair();
   const [proxyAgentSide, agentStream] = inMemoryStreamPair();
@@ -162,7 +162,7 @@ describe("proxy forwarding", () => {
 describe("proxy interception", () => {
   it("rewrites request params before forwarding", async () => {
     const { clientStream, agentStream } = setupProxy({
-      clientToAgent: [
+      fromClient: [
         {
           handleMessage(message) {
             if (message.kind !== "request" || message.method !== "echo") {
@@ -194,7 +194,7 @@ describe("proxy interception", () => {
   it("answers intercepted requests without the agent seeing them", async () => {
     const agentSaw = vi.fn();
     const { clientStream, agentStream } = setupProxy({
-      clientToAgent: [
+      fromClient: [
         {
           async handleMessage(message) {
             if (message.kind !== "request" || message.method !== "denied") {
@@ -226,9 +226,9 @@ describe("proxy interception", () => {
     expect(agentSaw).not.toHaveBeenCalledWith("denied");
   });
 
-  it("intercepts agent-to-client traffic with agentToClient handlers", async () => {
+  it("intercepts agent-to-client traffic with fromAgent handlers", async () => {
     const { clientStream, agentStream } = setupProxy({
-      agentToClient: [
+      fromAgent: [
         {
           handleMessage(message) {
             if (

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { agent, client, inMemoryStreamPair } from "./acp.js";
+import { agent, client } from "./acp.js";
 import { Connection, Handled, RequestError } from "./jsonrpc.js";
 import type { RequestResponder } from "./jsonrpc.js";
 import { proxy } from "./proxy.js";
 import type { ProxyBuilder, ProxyHandle } from "./proxy.js";
+import type { AnyMessage } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
+
+function inMemoryStreamPair(): [Stream, Stream] {
+  const leftToRight = new TransformStream<AnyMessage>();
+  const rightToLeft = new TransformStream<AnyMessage>();
+  return [
+    { readable: rightToLeft.readable, writable: leftToRight.writable },
+    { readable: leftToRight.readable, writable: rightToLeft.writable },
+  ];
+}
 
 type ProxySetup = {
   clientStream: Stream;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -127,9 +127,15 @@ export type ProxyStreams = {
 };
 
 /**
- * One side of a running proxy.
+ * One side of a running proxy. Matches the shape of the fluent
+ * `AcpConnection` interface.
  */
 export type ProxySideConnection = {
+  /**
+   * Aborts when this side's connection closes; `signal.reason` carries the
+   * close reason.
+   */
+  readonly signal: AbortSignal;
   /**
    * Promise that resolves when this side's connection closes.
    */

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,137 @@
+import { Connection, Handled } from "./jsonrpc.js";
+import type { JsonRpcHandler } from "./jsonrpc.js";
+import type { Stream } from "./stream.js";
+
+/**
+ * Options for {@link proxy}.
+ */
+export type ProxyOptions = {
+  /**
+   * Stream connected to the client side. The proxy presents as an agent on
+   * this stream.
+   */
+  client: Stream;
+  /**
+   * Stream connected to the agent side. The proxy presents as a client on
+   * this stream.
+   */
+  agent: Stream;
+  /**
+   * Handlers run on messages arriving from the client, in order, before the
+   * proxy forwards them to the agent.
+   *
+   * Return `Handled.no(message)` with a replacement message to rewrite a
+   * request or notification in flight. Return `Handled.yes()` after
+   * responding through `message.responder` to intercept a request without
+   * the agent ever seeing it (for example to deny it). Handlers that return
+   * `Handled.no()` without a replacement pass the message through untouched.
+   */
+  clientToAgent?: JsonRpcHandler[];
+  /**
+   * Handlers run on messages arriving from the agent, in order, before the
+   * proxy forwards them to the client. Same contract as `clientToAgent`.
+   */
+  agentToClient?: JsonRpcHandler[];
+};
+
+/**
+ * Handle to a running proxy returned by {@link proxy}.
+ */
+export type ProxyHandle = {
+  /**
+   * Connection facing the client stream. Requests sent here go to the client.
+   */
+  readonly client: Connection;
+  /**
+   * Connection facing the agent stream. Requests sent here go to the agent.
+   */
+  readonly agent: Connection;
+  /**
+   * Promise that resolves once both sides of the proxy have closed.
+   */
+  readonly closed: Promise<void>;
+  /**
+   * Closes both sides of the proxy and rejects pending requests.
+   */
+  close(error?: unknown): void;
+};
+
+/**
+ * Runs an ACP proxy between a client stream and an agent stream.
+ *
+ * The proxy terminates the protocol on both sides: each side is a full
+ * JSON-RPC connection, so forwarded requests are re-issued with the proxy's
+ * own request ids and their responses are correlated back to the original
+ * caller automatically. This works in both directions — client-initiated
+ * requests such as `session/prompt` flow toward the agent, and
+ * agent-initiated requests such as `session/request_permission` flow toward
+ * the client.
+ *
+ * Forwarding preserves the observable protocol behavior of a direct
+ * connection:
+ *
+ * - Error responses pass through with their original code, message, and data.
+ * - `$/cancel_request` from the original caller is propagated to the side
+ *   handling the request, and the eventual response (which may be a normal
+ *   result) still settles the original request.
+ * - When either side closes, the other side is closed and its pending
+ *   requests are rejected.
+ *
+ * Messages can be observed, rewritten, answered, or dropped before they are
+ * forwarded by passing `clientToAgent` / `agentToClient` handlers; see
+ * {@link ProxyOptions}.
+ *
+ * This mirrors the Rust SDK's `Proxy` role: unhandled messages forward by
+ * default, and handlers intercept traffic from an explicit peer. The
+ * `_proxy/successor` envelope protocol used by the Rust conductor to chain
+ * proxy processes over a single pipe is not needed here — this proxy owns a
+ * real stream per side, so proxies chain by connecting one proxy's agent
+ * stream to the next proxy's client stream.
+ */
+export function proxy(options: ProxyOptions): ProxyHandle {
+  // Each side's handler chain ends in a forwarder that re-issues the message
+  // on the opposite connection. The connections reference each other, so the
+  // forwarders resolve their target lazily.
+  const forwardTo = (target: () => Connection): JsonRpcHandler => ({
+    handleMessage: async (message) => {
+      if (message.kind === "request") {
+        const result = await target().sendRequest(
+          message.method,
+          message.params,
+          undefined,
+          { cancellationSignal: message.signal },
+        );
+        await message.responder.respond(result);
+      } else {
+        await target().sendNotification(message.method, message.params);
+      }
+
+      return Handled.yes();
+    },
+    describe: () => "proxy:forward",
+  });
+
+  const client: Connection = new Connection(options.client, [
+    ...(options.clientToAgent ?? []),
+    forwardTo(() => agent),
+  ]);
+  const agent: Connection = new Connection(options.agent, [
+    ...(options.agentToClient ?? []),
+    forwardTo(() => client),
+  ]);
+
+  // When either side closes, close the other with the same reason so its
+  // pending requests reject with the true cause.
+  void client.closed.then(() => agent.close(client.signal.reason));
+  void agent.closed.then(() => client.close(agent.signal.reason));
+
+  return {
+    client,
+    agent,
+    closed: Promise.all([client.closed, agent.closed]).then(() => {}),
+    close(error?: unknown): void {
+      client.close(error);
+      agent.close(error);
+    },
+  };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,10 +10,14 @@ import type {
 } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
 import type {
+  AgentNotificationMethod,
   AgentNotificationParamsByMethod,
+  AgentRequestMethod,
   AgentRequestParamsByMethod,
   AgentRequestResponsesByMethod,
+  ClientNotificationMethod,
   ClientNotificationParamsByMethod,
+  ClientRequestMethod,
   ClientRequestParamsByMethod,
   ClientRequestResponsesByMethod,
 } from "./acp.js";
@@ -107,141 +111,6 @@ type Registration = {
 };
 
 /**
- * Registration surface for one side of a proxy.
- *
- * `proxy().client` registers handlers for traffic arriving from the client
- * (agent-bound methods such as `session/prompt`); `proxy().agent` registers
- * handlers for traffic arriving from the agent (client-bound methods such as
- * `session/request_permission`). The type parameters select the matching
- * ByMethod maps so built-in method literals infer their params and response
- * types, mirroring `agent(...)`/`client(...)` registration.
- *
- * Handlers claim their method: at most one typed handler runs per message.
- * Register `"*"` to catch traffic no exact registration claims
- * (most-specific wins); anything still unclaimed is forwarded untouched.
- *
- * Each `connect(...)` snapshots the registrations, exactly like the
- * `agent(...)`/`client(...)` builders: registering afterwards is allowed but
- * applies only to subsequent connects, never to already-connected proxies.
- * For behavior that changes mid-session, keep the changing state in your
- * handler's closure instead of changing the registrations.
- */
-export class ProxySideBuilder<
-  RequestParams extends Record<string, unknown>,
-  RequestResponses extends Record<string, unknown>,
-  NotificationParams extends Record<string, unknown>,
-> {
-  private readonly requests = new Map<string, Registration>();
-  private readonly notifications = new Map<string, Registration>();
-
-  /**
-   * Registers a typed handler for requests arriving from this side's peer.
-   *
-   * Built-in method literals infer their params and response types from
-   * `method`. Pass a parser as the second argument for custom extension
-   * methods or to opt into runtime validation. Register `"*"` to catch any
-   * request no exact registration claims.
-   */
-  onRequest<Method extends keyof RequestParams & string>(
-    method: Method,
-    handler: ProxyRequestHandler<
-      RequestParams[Method],
-      Method extends keyof RequestResponses ? RequestResponses[Method] : never
-    >,
-  ): this;
-  onRequest(method: "*", handler: ProxyRequestHandler<unknown, unknown>): this;
-  onRequest<Params, Response>(
-    method: string,
-    params: ParamsParser<Params>,
-    handler: ProxyRequestHandler<Params, Response>,
-  ): this;
-  onRequest(
-    method: string,
-    handlerOrParams: ErasedHandler | ParamsParser<unknown>,
-    handler?: ErasedHandler,
-  ): this {
-    this.register(this.requests, "request", method, handlerOrParams, handler);
-    return this;
-  }
-
-  /**
-   * Registers a typed handler for notifications arriving from this side's
-   * peer. Same registration forms as `onRequest`.
-   */
-  onNotification<Method extends keyof NotificationParams & string>(
-    method: Method,
-    handler: ProxyNotificationHandler<NotificationParams[Method]>,
-  ): this;
-  onNotification(method: "*", handler: ProxyNotificationHandler<unknown>): this;
-  onNotification<Params>(
-    method: string,
-    params: ParamsParser<Params>,
-    handler: ProxyNotificationHandler<Params>,
-  ): this;
-  onNotification(
-    method: string,
-    handlerOrParams: ErasedHandler | ParamsParser<unknown>,
-    handler?: ErasedHandler,
-  ): this {
-    this.register(
-      this.notifications,
-      "notification",
-      method,
-      handlerOrParams,
-      handler,
-    );
-    return this;
-  }
-
-  private register(
-    table: Map<string, Registration>,
-    kind: "request" | "notification",
-    method: string,
-    handlerOrParams: ErasedHandler | ParamsParser<unknown>,
-    handler?: ErasedHandler,
-  ): void {
-    if (table.has(method)) {
-      throw new Error(`Proxy ${kind} handler already registered: ${method}`);
-    }
-
-    if (handler) {
-      table.set(method, {
-        params: handlerOrParams as ParamsParser<unknown>,
-        handler,
-      });
-      return;
-    }
-
-    table.set(method, { handler: handlerOrParams as ErasedHandler });
-  }
-
-  /** @internal */
-  buildHandler(target: () => Connection): JsonRpcHandler {
-    // Snapshot so registrations made after connect(...) apply only to
-    // subsequent connects — the same semantics as the fluent app builders.
-    return serialize(
-      dispatcher(new Map(this.requests), new Map(this.notifications), target),
-    );
-  }
-}
-
-/**
- * The wildcard-only view of a proxy side — what a side-agnostic tap
- * (logger, metrics, authorization gate) needs. Both `proxy().client` and
- * `proxy().agent` are assignable to it.
- */
-export type ProxyTap = {
-  onRequest(
-    method: "*",
-    handler: ProxyRequestHandler<unknown, unknown>,
-  ): ProxyTap;
-  onNotification(
-    method: "*",
-    handler: ProxyNotificationHandler<unknown>,
-  ): ProxyTap;
-};
-
-/**
  * Streams accepted by `ProxyBuilder.connect(...)`.
  */
 export type ProxyStreams = {
@@ -298,39 +167,166 @@ export type ProxyHandle = {
 /**
  * Builder for an ACP proxy between a client stream and an agent stream.
  *
- * Register handlers on `client` (traffic from the client) and `agent`
- * (traffic from the agent), then call `connect(...)`.
+ * The four registration methods name the traffic they intercept: requests
+ * and notifications arriving **from the client** (agent-bound methods such
+ * as `session/prompt`) or **from the agent** (client-bound methods such as
+ * `session/request_permission`). Built-in method literals infer their
+ * params and response types from the same ByMethod maps the
+ * `agent(...)`/`client(...)` builders use.
+ *
+ * Handlers claim their method: at most one runs per message. Register `"*"`
+ * to catch traffic no exact registration claims (most-specific wins);
+ * anything still unclaimed is forwarded untouched.
+ *
+ * Each `connect(...)` snapshots the registrations, exactly like the
+ * `agent(...)`/`client(...)` builders: registering afterwards is allowed but
+ * applies only to subsequent connects, never to already-connected proxies.
+ * For behavior that changes mid-session, keep the changing state in your
+ * handler's closure instead of changing the registrations.
  */
 export class ProxyBuilder {
-  /**
-   * Registration surface for traffic arriving from the client — agent-bound
-   * methods, typed by the agent request/notification maps.
-   */
-  readonly client = new ProxySideBuilder<
-    AgentRequestParamsByMethod,
-    AgentRequestResponsesByMethod,
-    AgentNotificationParamsByMethod
-  >();
+  private readonly clientRequests = new Map<string, Registration>();
+  private readonly clientNotifications = new Map<string, Registration>();
+  private readonly agentRequests = new Map<string, Registration>();
+  private readonly agentNotifications = new Map<string, Registration>();
 
   /**
-   * Registration surface for traffic arriving from the agent — client-bound
-   * methods, typed by the client request/notification maps.
+   * Registers a typed handler for requests arriving from the client.
+   *
+   * Built-in method literals infer their params and response types from
+   * `method`. Pass a parser as the second argument for custom extension
+   * methods or to opt into runtime validation. Register `"*"` to catch any
+   * request no exact registration claims.
    */
-  readonly agent = new ProxySideBuilder<
-    ClientRequestParamsByMethod,
-    ClientRequestResponsesByMethod,
-    ClientNotificationParamsByMethod
-  >();
+  onRequestFromClient<Method extends AgentRequestMethod>(
+    method: Method,
+    handler: ProxyRequestHandler<
+      AgentRequestParamsByMethod[Method],
+      AgentRequestResponsesByMethod[Method]
+    >,
+  ): this;
+  onRequestFromClient(
+    method: "*",
+    handler: ProxyRequestHandler<unknown, unknown>,
+  ): this;
+  onRequestFromClient<Params, Response>(
+    method: string,
+    params: ParamsParser<Params>,
+    handler: ProxyRequestHandler<Params, Response>,
+  ): this;
+  onRequestFromClient(
+    method: string,
+    handlerOrParams: ErasedHandler | ParamsParser<unknown>,
+    handler?: ErasedHandler,
+  ): this {
+    register(this.clientRequests, method, handlerOrParams, handler);
+    return this;
+  }
+
+  /**
+   * Registers a typed handler for notifications arriving from the client.
+   * Same registration forms as `onRequestFromClient`.
+   */
+  onNotificationFromClient<Method extends AgentNotificationMethod>(
+    method: Method,
+    handler: ProxyNotificationHandler<AgentNotificationParamsByMethod[Method]>,
+  ): this;
+  onNotificationFromClient(
+    method: "*",
+    handler: ProxyNotificationHandler<unknown>,
+  ): this;
+  onNotificationFromClient<Params>(
+    method: string,
+    params: ParamsParser<Params>,
+    handler: ProxyNotificationHandler<Params>,
+  ): this;
+  onNotificationFromClient(
+    method: string,
+    handlerOrParams: ErasedHandler | ParamsParser<unknown>,
+    handler?: ErasedHandler,
+  ): this {
+    register(this.clientNotifications, method, handlerOrParams, handler);
+    return this;
+  }
+
+  /**
+   * Registers a typed handler for requests arriving from the agent.
+   * Same registration forms as `onRequestFromClient`.
+   */
+  onRequestFromAgent<Method extends ClientRequestMethod>(
+    method: Method,
+    handler: ProxyRequestHandler<
+      ClientRequestParamsByMethod[Method],
+      ClientRequestResponsesByMethod[Method]
+    >,
+  ): this;
+  onRequestFromAgent(
+    method: "*",
+    handler: ProxyRequestHandler<unknown, unknown>,
+  ): this;
+  onRequestFromAgent<Params, Response>(
+    method: string,
+    params: ParamsParser<Params>,
+    handler: ProxyRequestHandler<Params, Response>,
+  ): this;
+  onRequestFromAgent(
+    method: string,
+    handlerOrParams: ErasedHandler | ParamsParser<unknown>,
+    handler?: ErasedHandler,
+  ): this {
+    register(this.agentRequests, method, handlerOrParams, handler);
+    return this;
+  }
+
+  /**
+   * Registers a typed handler for notifications arriving from the agent.
+   * Same registration forms as `onRequestFromClient`.
+   */
+  onNotificationFromAgent<Method extends ClientNotificationMethod>(
+    method: Method,
+    handler: ProxyNotificationHandler<ClientNotificationParamsByMethod[Method]>,
+  ): this;
+  onNotificationFromAgent(
+    method: "*",
+    handler: ProxyNotificationHandler<unknown>,
+  ): this;
+  onNotificationFromAgent<Params>(
+    method: string,
+    params: ParamsParser<Params>,
+    handler: ProxyNotificationHandler<Params>,
+  ): this;
+  onNotificationFromAgent(
+    method: string,
+    handlerOrParams: ErasedHandler | ParamsParser<unknown>,
+    handler?: ErasedHandler,
+  ): this {
+    register(this.agentNotifications, method, handlerOrParams, handler);
+    return this;
+  }
 
   /**
    * Connects the proxy between the two streams and starts relaying.
    */
   connect(streams: ProxyStreams): ProxyHandle {
+    // Snapshot so registrations made after connect(...) apply only to
+    // subsequent connects — the same semantics as the fluent app builders.
     const client: Connection = new Connection(streams.client, [
-      this.client.buildHandler(() => agent),
+      serialize(
+        dispatcher(
+          new Map(this.clientRequests),
+          new Map(this.clientNotifications),
+          () => agent,
+        ),
+      ),
     ]);
     const agent: Connection = new Connection(streams.agent, [
-      this.agent.buildHandler(() => client),
+      serialize(
+        dispatcher(
+          new Map(this.agentRequests),
+          new Map(this.agentNotifications),
+          () => client,
+        ),
+      ),
     ]);
     linkClosed(client, agent);
 
@@ -344,6 +340,27 @@ export class ProxyBuilder {
       },
     };
   }
+}
+
+function register(
+  table: Map<string, Registration>,
+  method: string,
+  handlerOrParams: ErasedHandler | ParamsParser<unknown>,
+  handler?: ErasedHandler,
+): void {
+  if (table.has(method)) {
+    throw new Error(`Proxy handler already registered: ${method}`);
+  }
+
+  if (handler) {
+    table.set(method, {
+      params: handlerOrParams as ParamsParser<unknown>,
+      handler,
+    });
+    return;
+  }
+
+  table.set(method, { handler: handlerOrParams as ErasedHandler });
 }
 
 /**
@@ -379,15 +396,15 @@ export class ProxyBuilder {
  *
  * @example
  * ```ts
- * const p = proxy();
- * p.client.onRequest("session/prompt", async ({ params, forward }) => {
- *   audit(params);
- *   return forward(params);
- * });
- * p.agent.onNotification("session/update", async ({ params, forward }) => {
- *   if (!redacted(params)) await forward(params);
- * });
- * const handle = p.connect({ client: clientStream, agent: agentStream });
+ * const handle = proxy()
+ *   .onRequestFromClient("session/prompt", async ({ params, forward }) => {
+ *     audit(params);
+ *     return forward(params);
+ *   })
+ *   .onNotificationFromAgent("session/update", async ({ params, forward }) => {
+ *     if (!redacted(params)) await forward(params);
+ *   })
+ *   .connect({ client: clientStream, agent: agentStream });
  * ```
  */
 export function proxy(): ProxyBuilder {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -378,6 +378,10 @@ export class ProxyBuilder {
         agent.close(client.signal.reason);
         return;
       }
+      // A request originating on agent may still be completing an interceptor
+      // after its forwarded request to client settled. Release request-scoped
+      // cleanup before waiting for that interceptor's relay continuation.
+      agent.abortIncomingRequests(client.signal.reason);
       await agentDrain.drain();
       await agent.closeAfterDraining(client.signal.reason);
     });
@@ -386,6 +390,7 @@ export class ProxyBuilder {
         client.close(agent.signal.reason);
         return;
       }
+      client.abortIncomingRequests(agent.signal.reason);
       await clientDrain.drain();
       await client.closeAfterDraining(agent.signal.reason);
     });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,10 +1,12 @@
-import { Connection, Handled, errorToResult, linkClosed } from "./jsonrpc.js";
+import { Connection, Handled, linkClosed, parseParams } from "./jsonrpc.js";
 import type {
   HandleResult,
+  IncomingMessage,
   IncomingNotification,
   IncomingRequest,
   JsonRpcHandler,
   MaybePromise,
+  ParamsParser,
 } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
 import type {
@@ -14,7 +16,6 @@ import type {
   ClientNotificationParamsByMethod,
   ClientRequestParamsByMethod,
   ClientRequestResponsesByMethod,
-  ParamsParser,
 } from "./acp.js";
 
 /**
@@ -94,9 +95,15 @@ export type ProxyNotificationHandler<Params> = (
   context: ProxyNotificationContext<Params>,
 ) => MaybePromise<void>;
 
+/**
+ * Handler with its context type erased for storage; dispatch restores the
+ * matching context shape per registration kind.
+ */
+type ErasedHandler = (context: never) => MaybePromise<unknown>;
+
 type Registration = {
-  parse?: (params: unknown) => unknown;
-  handler: (context: never) => MaybePromise<unknown>;
+  params?: ParamsParser<unknown>;
+  handler: ErasedHandler;
 };
 
 /**
@@ -127,9 +134,6 @@ export class ProxySideBuilder<
   private readonly requests = new Map<string, Registration>();
   private readonly notifications = new Map<string, Registration>();
 
-  /** @internal */
-  constructor() {}
-
   /**
    * Registers a typed handler for requests arriving from this side's peer.
    *
@@ -153,9 +157,8 @@ export class ProxySideBuilder<
   ): this;
   onRequest(
     method: string,
-    handlerOrParams:
-      ((context: never) => MaybePromise<unknown>) | ParamsParser<unknown>,
-    handler?: (context: never) => MaybePromise<unknown>,
+    handlerOrParams: ErasedHandler | ParamsParser<unknown>,
+    handler?: ErasedHandler,
   ): this {
     this.register(this.requests, "request", method, handlerOrParams, handler);
     return this;
@@ -177,9 +180,8 @@ export class ProxySideBuilder<
   ): this;
   onNotification(
     method: string,
-    handlerOrParams:
-      ((context: never) => MaybePromise<unknown>) | ParamsParser<unknown>,
-    handler?: (context: never) => MaybePromise<unknown>,
+    handlerOrParams: ErasedHandler | ParamsParser<unknown>,
+    handler?: ErasedHandler,
   ): this {
     this.register(
       this.notifications,
@@ -195,40 +197,49 @@ export class ProxySideBuilder<
     table: Map<string, Registration>,
     kind: "request" | "notification",
     method: string,
-    handlerOrParams: object | ((context: never) => MaybePromise<unknown>),
-    handler?: (context: never) => MaybePromise<unknown>,
+    handlerOrParams: ErasedHandler | ParamsParser<unknown>,
+    handler?: ErasedHandler,
   ): void {
     if (table.has(method)) {
       throw new Error(`Proxy ${kind} handler already registered: ${method}`);
     }
 
     if (handler) {
-      const parser = handlerOrParams as ParamsParser<unknown>;
-      const parse =
-        typeof parser === "function" ? parser : parser.parse.bind(parser);
-      table.set(method, { parse, handler });
+      table.set(method, {
+        params: handlerOrParams as ParamsParser<unknown>,
+        handler,
+      });
       return;
     }
 
-    table.set(method, {
-      handler: handlerOrParams as (context: never) => MaybePromise<unknown>,
-    });
+    table.set(method, { handler: handlerOrParams as ErasedHandler });
   }
 
   /** @internal */
-  buildChain(target: () => Connection): JsonRpcHandler[] {
+  buildHandler(target: () => Connection): JsonRpcHandler {
     // Snapshot so registrations made after connect(...) apply only to
     // subsequent connects — the same semantics as the fluent app builders.
-    return [
-      typedDispatch(
-        new Map(this.requests),
-        new Map(this.notifications),
-        target,
-      ),
-      forwardTo(target),
-    ];
+    return serialize(
+      dispatcher(new Map(this.requests), new Map(this.notifications), target),
+    );
   }
 }
+
+/**
+ * The wildcard-only view of a proxy side — what a side-agnostic tap
+ * (logger, metrics, authorization gate) needs. Both `proxy().client` and
+ * `proxy().agent` are assignable to it.
+ */
+export type ProxyTap = {
+  onRequest(
+    method: "*",
+    handler: ProxyRequestHandler<unknown, unknown>,
+  ): ProxyTap;
+  onNotification(
+    method: "*",
+    handler: ProxyNotificationHandler<unknown>,
+  ): ProxyTap;
+};
 
 /**
  * Streams accepted by `ProxyBuilder.connect(...)`.
@@ -316,10 +327,10 @@ export class ProxyBuilder {
    */
   connect(streams: ProxyStreams): ProxyHandle {
     const client: Connection = new Connection(streams.client, [
-      serialDispatch(this.client.buildChain(() => agent)),
+      this.client.buildHandler(() => agent),
     ]);
     const agent: Connection = new Connection(streams.agent, [
-      serialDispatch(this.agent.buildChain(() => client)),
+      this.agent.buildHandler(() => client),
     ]);
     linkClosed(client, agent);
 
@@ -387,33 +398,44 @@ export function proxy(): ProxyBuilder {
 }
 
 /**
- * Chain handler dispatching typed registrations and the fallback.
+ * Builds the dispatch function for one proxy side.
  *
- * Unregistered traffic returns `Handled.no` so the terminal forwarder
- * relays it untouched. Request handlers run detached from the dispatch
- * queue once they forward: the returned promise resolves when the request
- * has been forwarded or answered — not when the handler finishes waiting on
- * the round trip — so the loop keeps its ordering guarantee without a
- * pending request blocking later messages.
+ * Each message runs the most specific registration — exact method, then
+ * `"*"` — or, unclaimed, is forwarded untouched on a fully synchronous fast
+ * path (the send is enqueued in arrival order and the loop is never held).
+ *
+ * Request registrations run detached from the dispatch loop once they
+ * forward or settle: the loop resumes when the request has been sent (or
+ * answered), not when the handler finishes waiting on the round trip, so a
+ * pending request never blocks later messages. Notification registrations
+ * hold the loop until the handler settles, which is what preserves
+ * delivery ordering across async handlers.
  */
-function typedDispatch(
+function dispatcher(
   requests: Map<string, Registration>,
   notifications: Map<string, Registration>,
   target: () => Connection,
-): JsonRpcHandler {
+): (message: IncomingMessage) => MaybePromise<HandleResult> {
   const runRequest = (
     message: IncomingRequest,
-    run: (
+    registration: Registration,
+  ): MaybePromise<HandleResult> => {
+    const { responder } = message;
+    let released = false;
+    let resolveReleased: (() => void) | undefined;
+    const release = () => {
+      released = true;
+      resolveReleased?.();
+    };
+    const run = registration.handler as (
       context: ProxyRequestContext<unknown, unknown>,
-    ) => MaybePromise<unknown>,
-    parse?: (params: unknown) => unknown,
-  ): Promise<HandleResult> => {
-    const released = Promise.withResolvers<void>();
+    ) => MaybePromise<unknown>;
+
     void (async () => {
       try {
         const response = await run({
           method: message.method,
-          params: parse ? parse(message.params) : message.params,
+          params: parseParams(registration.params, message.params),
           signal: message.signal,
           forward: (params: unknown) => {
             const sent = target().sendRequest(
@@ -422,125 +444,120 @@ function typedDispatch(
               undefined,
               { cancellationSignal: message.signal },
             );
-            released.resolve();
+            release();
             return sent;
           },
         });
-        await message.responder.respond(response ?? null);
+        await responder.respond(response ?? null);
       } catch (error) {
-        await message.responder
-          .respondWithResult(errorToResult(error))
-          .catch(() => {});
+        await responder.respondWithThrown(error).catch(() => {});
       } finally {
-        released.resolve();
+        release();
       }
     })();
-    return released.promise.then(() => Handled.yes());
+
+    // A handler that forwards before its first await has already released;
+    // skip the promise entirely so the loop continues on the same tick.
+    if (released) {
+      return Handled.yes();
+    }
+
+    return new Promise((resolve) => {
+      resolveReleased = () => resolve(Handled.yes());
+    });
   };
 
   const runNotification = async (
     message: IncomingNotification,
-    run: (context: ProxyNotificationContext<unknown>) => MaybePromise<unknown>,
-    parse?: (params: unknown) => unknown,
+    registration: Registration,
   ): Promise<HandleResult> => {
+    const run = registration.handler as (
+      context: ProxyNotificationContext<unknown>,
+    ) => MaybePromise<unknown>;
     await run({
       method: message.method,
-      params: parse ? parse(message.params) : message.params,
+      params: parseParams(registration.params, message.params),
       forward: (params: unknown) =>
         target().sendNotification(message.method, params),
     });
     return Handled.yes();
   };
 
-  return {
-    handleMessage(message) {
-      const table = message.kind === "request" ? requests : notifications;
-      // Most-specific wins: an exact method registration beats "*", and "*"
-      // catches only otherwise-unclaimed traffic.
-      const registration = table.get(message.method) ?? table.get("*");
-      if (!registration) {
-        return Handled.no(message);
-      }
+  return (message) => {
+    const table = message.kind === "request" ? requests : notifications;
+    // Most-specific wins: an exact method registration beats "*", and "*"
+    // catches only otherwise-unclaimed traffic.
+    const registration = table.get(message.method) ?? table.get("*");
 
-      const run = registration.handler as (
-        context: unknown,
-      ) => MaybePromise<unknown>;
-      return message.kind === "request"
-        ? runRequest(message, run, registration.parse)
-        : runNotification(message, run, registration.parse);
-    },
-    describe: () => "proxy:typed-dispatch",
-  };
-}
-
-/**
- * Runs one side's handler chain one message at a time, in arrival order.
- *
- * The underlying `Connection` dispatches each incoming message as its own
- * async task, which would let chains with slow handlers overtake each other.
- * The Rust SDK guarantees sequential dispatch, so the proxy provides the
- * same: the next message is not dispatched until the previous chain settles.
- * A handler that throws fails only its own message (the connection converts
- * the error to a response or log line); the queue continues.
- */
-function serialDispatch(handlers: JsonRpcHandler[]): JsonRpcHandler {
-  let queue: Promise<unknown> = Promise.resolve();
-  return {
-    handleMessage(message, cx) {
-      const result = queue.then(async (): Promise<HandleResult> => {
-        let current = message;
-        for (const handler of handlers) {
-          const outcome =
-            (await handler.handleMessage(current, cx)) ?? Handled.yes();
-          if (outcome.handled) {
-            return Handled.yes();
-          }
-          current = outcome.message ?? current;
-        }
-
-        // Unreachable: the forwarder at the end of the chain always handles.
-        return Handled.yes();
-      });
-      queue = result.catch(() => {});
-      return result;
-    },
-    describe: () => "proxy:serial-dispatch",
-  };
-}
-
-/**
- * Terminal handler for one proxy side: re-issues the incoming message on the
- * opposite connection and relays the response back. The two connections
- * reference each other, so the target is resolved lazily.
- *
- * Requests are forwarded split-phase: the outgoing request is sent
- * synchronously (preserving send order), the response continuation is
- * registered, and the dispatch queue is released immediately so the round
- * trip never blocks later messages.
- */
-function forwardTo(target: () => Connection): JsonRpcHandler {
-  return {
-    handleMessage(message) {
-      if (message.kind !== "request") {
-        return target()
+    if (!registration) {
+      // Pass-through: the send is enqueued synchronously (so send order is
+      // arrival order) and the loop is never held.
+      if (message.kind === "request") {
+        const { responder } = message;
+        target()
+          .sendRequest(message.method, message.params, undefined, {
+            cancellationSignal: message.signal,
+          })
+          .then(
+            (result) => responder.respond(result),
+            (error) => responder.respondWithThrown(error),
+          )
+          // The response cannot be delivered when the caller's side is
+          // already closed; there is nowhere left to report it.
+          .catch(() => {});
+      } else {
+        // Write failures close the connection via the write queue; there is
+        // no per-notification error to report.
+        void target()
           .sendNotification(message.method, message.params)
-          .then(() => Handled.yes());
+          .catch(() => {});
       }
 
-      const { responder } = message;
-      target()
-        .sendRequest(message.method, message.params, undefined, {
-          cancellationSignal: message.signal,
-        })
-        .then(
-          (result) => responder.respond(result),
-          (error) => responder.respondWithResult(errorToResult(error)),
-        )
-        // The response cannot be delivered when the caller's side is already
-        // closed; there is nowhere left to report it.
-        .catch(() => {});
       return Handled.yes();
+    }
+
+    return message.kind === "request"
+      ? runRequest(message, registration)
+      : runNotification(message, registration);
+  };
+}
+
+/**
+ * Serializes one side's dispatch: messages run one at a time, in arrival
+ * order, matching the Rust SDK's dispatch loop. The underlying `Connection`
+ * dispatches each message as its own async task, which would let slow
+ * handlers be overtaken. Synchronous dispatches (pass-through traffic,
+ * handlers that forward immediately) bypass the queue entirely; a rejected
+ * dispatch fails only its own message.
+ */
+function serialize(
+  dispatch: (message: IncomingMessage) => MaybePromise<HandleResult>,
+): JsonRpcHandler {
+  let pending = 0;
+  let tail: Promise<unknown> = Promise.resolve();
+
+  const track = (result: Promise<HandleResult>): Promise<HandleResult> => {
+    pending++;
+    tail = result.then(
+      () => {
+        pending--;
+      },
+      () => {
+        pending--;
+      },
+    );
+    return result;
+  };
+
+  return {
+    handleMessage(message) {
+      if (pending === 0) {
+        const result = dispatch(message);
+        return result instanceof Promise ? track(result) : result;
+      }
+
+      return track(tail.then(() => dispatch(message)));
     },
-    describe: () => "proxy:forward",
+    describe: () => "proxy:dispatch",
   };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -112,6 +112,12 @@ type Registration = {
  * Handlers claim their method: at most one typed handler runs per message.
  * Register `"*"` to catch traffic no exact registration claims
  * (most-specific wins); anything still unclaimed is forwarded untouched.
+ *
+ * Registration is live and append-only: handlers may be added after
+ * `connect(...)` and apply to messages dispatched from then on (useful for
+ * interceptors that depend on values learned mid-session), registering a
+ * method twice throws, and a builder connected to multiple stream pairs
+ * shares its registrations across all of them.
  */
 export class ProxySideBuilder<
   RequestParams extends Record<string, unknown>,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -113,11 +113,11 @@ type Registration = {
  * Register `"*"` to catch traffic no exact registration claims
  * (most-specific wins); anything still unclaimed is forwarded untouched.
  *
- * Registration is live and append-only: handlers may be added after
- * `connect(...)` and apply to messages dispatched from then on (useful for
- * interceptors that depend on values learned mid-session), registering a
- * method twice throws, and a builder connected to multiple stream pairs
- * shares its registrations across all of them.
+ * Each `connect(...)` snapshots the registrations, exactly like the
+ * `agent(...)`/`client(...)` builders: registering afterwards is allowed but
+ * applies only to subsequent connects, never to already-connected proxies.
+ * For behavior that changes mid-session, keep the changing state in your
+ * handler's closure instead of changing the registrations.
  */
 export class ProxySideBuilder<
   RequestParams extends Record<string, unknown>,
@@ -217,8 +217,14 @@ export class ProxySideBuilder<
 
   /** @internal */
   buildChain(target: () => Connection): JsonRpcHandler[] {
+    // Snapshot so registrations made after connect(...) apply only to
+    // subsequent connects — the same semantics as the fluent app builders.
     return [
-      typedDispatch(this.requests, this.notifications, target),
+      typedDispatch(
+        new Map(this.requests),
+        new Map(this.notifications),
+        target,
+      ),
       forwardTo(target),
     ];
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -110,6 +110,17 @@ type Registration = {
   handler: ErasedHandler;
 };
 
+const CANCEL_REQUEST_METHOD = "$/cancel_request";
+
+/**
+ * Work that crossed one proxy hop and must finish before that hop's target
+ * connection is allowed to tear down the source connection.
+ */
+type RelayDrain = {
+  track(work: Promise<unknown>): void;
+  drain(): Promise<void>;
+};
+
 /**
  * Streams accepted by `ProxyBuilder.connect(...)`.
  */
@@ -319,6 +330,8 @@ export class ProxyBuilder {
     // Batches are rejected on both sides (as on every stable v1 connection):
     // relaying batch entries individually would silently drop batch framing,
     // and batch relay is not part of this proxy's contract.
+    const clientDrain = relayDrain();
+    const agentDrain = relayDrain();
     const client: Connection = new Connection(
       streams.client,
       [
@@ -327,6 +340,7 @@ export class ProxyBuilder {
             new Map(this.clientRequests),
             new Map(this.clientNotifications),
             () => agent,
+            clientDrain,
           ),
         ),
       ],
@@ -340,15 +354,26 @@ export class ProxyBuilder {
             new Map(this.agentRequests),
             new Map(this.agentNotifications),
             () => client,
+            agentDrain,
           ),
         ),
       ],
       { allowBatches: false },
     );
-    // When either side closes, close the other with the same reason so its
-    // pending requests reject with the true cause.
-    void client.closed.then(() => agent.close(client.signal.reason));
-    void agent.closed.then(() => client.close(agent.signal.reason));
+    // When either side closes, let work forwarded to that side finish relaying
+    // its already-received result before closing the other connection. This is
+    // especially important on normal EOF: a response may have resolved the
+    // downstream request while an interceptor is still transforming it for the
+    // original caller. Explicitly closing the handle still closes both sides
+    // immediately below.
+    void client.closed.then(async () => {
+      await agentDrain.drain();
+      agent.close(client.signal.reason);
+    });
+    void agent.closed.then(async () => {
+      await clientDrain.drain();
+      client.close(agent.signal.reason);
+    });
 
     return {
       client,
@@ -405,11 +430,11 @@ function register(
  * observable protocol behavior of a direct connection:
  *
  * - Error responses pass through with their original code, message, and data.
- * - `$/cancel_request` from the original caller is propagated to the side
- *   handling the request, and the eventual response (which may be a normal
- *   result) still settles the original request.
- * - When either side closes, the other side is closed and its pending
- *   requests are rejected.
+ * - `$/cancel_request` from the original caller is reissued with the request
+ *   ID allocated on the target hop, and the eventual response (which may be a
+ *   normal result) still settles the original request.
+ * - When either side closes, already-forwarded work targeting that side is
+ *   drained before the other side closes and rejects its remaining requests.
  *
  * Each side processes messages one at a time in arrival order: the next
  * message is not dispatched until the previous handler completes. Request
@@ -455,6 +480,7 @@ function dispatcher(
   requests: Map<string, Registration>,
   notifications: Map<string, Registration>,
   target: () => Connection,
+  drain: RelayDrain,
 ): (message: IncomingMessage) => MaybePromise<HandleResult> {
   const runRequest = (
     message: IncomingRequest,
@@ -463,6 +489,8 @@ function dispatcher(
     const { responder } = message;
     let released = false;
     let resolveReleased: (() => void) | undefined;
+    const completed = Promise.withResolvers<void>();
+    let completionTracked = false;
     const release = () => {
       released = true;
       resolveReleased?.();
@@ -486,6 +514,11 @@ function dispatcher(
               undefined,
               { cancellationSignal: message.signal },
             );
+            drain.track(sent);
+            if (!completionTracked) {
+              completionTracked = true;
+              drain.track(completed.promise);
+            }
             release();
             return sent;
           },
@@ -496,6 +529,7 @@ function dispatcher(
           .respondWithResult(errorToRequestResult(error, message.signal))
           .catch(() => {});
       } finally {
+        completed.resolve();
         release();
       }
     })();
@@ -518,18 +552,43 @@ function dispatcher(
     const run = registration.handler as (
       context: ProxyNotificationContext<unknown>,
     ) => MaybePromise<unknown>;
-    await run({
-      method: message.method,
-      params: registration.parse
-        ? registration.parse(message.params)
-        : message.params,
-      forward: (params: unknown) =>
-        target().sendNotification(message.method, params),
-    });
-    return Handled.yes();
+    const completed = Promise.withResolvers<void>();
+    let completionTracked = false;
+    try {
+      await run({
+        method: message.method,
+        params: registration.parse
+          ? registration.parse(message.params)
+          : message.params,
+        forward: (params: unknown) => {
+          const sent = target().sendNotification(message.method, params);
+          drain.track(sent);
+          if (!completionTracked) {
+            completionTracked = true;
+            drain.track(completed.promise);
+          }
+          return sent;
+        },
+      });
+      return Handled.yes();
+    } finally {
+      completed.resolve();
+    }
   };
 
   return (message) => {
+    // The source connection has already applied this hop's cancellation to the
+    // incoming request signal. `sendRequest` observes that signal and reissues
+    // cancellation using the target connection's request ID, so tunnelling the
+    // raw notification would duplicate it under a hop-local (and potentially
+    // unrelated) source ID.
+    if (
+      message.kind === "notification" &&
+      message.method === CANCEL_REQUEST_METHOD
+    ) {
+      return Handled.yes();
+    }
+
     const table = message.kind === "request" ? requests : notifications;
     // Most-specific wins: an exact method registration beats "*", and "*"
     // catches only otherwise-unclaimed traffic.
@@ -540,7 +599,7 @@ function dispatcher(
       // arrival order) and the loop is never held.
       if (message.kind === "request") {
         const { responder } = message;
-        target()
+        const relayed = target()
           .sendRequest(message.method, message.params, undefined, {
             cancellationSignal: message.signal,
           })
@@ -554,12 +613,14 @@ function dispatcher(
           // The response cannot be delivered when the caller's side is
           // already closed; there is nowhere left to report it.
           .catch(() => {});
+        drain.track(relayed);
       } else {
         // Write failures close the connection via the write queue; there is
         // no per-notification error to report.
-        void target()
+        const relayed = target()
           .sendNotification(message.method, message.params)
           .catch(() => {});
+        drain.track(relayed);
       }
 
       return Handled.yes();
@@ -568,6 +629,26 @@ function dispatcher(
     return message.kind === "request"
       ? runRequest(message, registration)
       : runNotification(message, registration);
+  };
+}
+
+function relayDrain(): RelayDrain {
+  const pending = new Set<Promise<void>>();
+
+  return {
+    track(work) {
+      const settled = work.then(
+        () => {},
+        () => {},
+      );
+      pending.add(settled);
+      void settled.then(() => pending.delete(settled));
+    },
+    async drain() {
+      while (pending.size > 0) {
+        await Promise.all(pending);
+      }
+    },
   };
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,5 @@
-import { Connection, Handled, linkClosed } from "./jsonrpc.js";
-import type { JsonRpcHandler } from "./jsonrpc.js";
+import { Connection, Handled, errorToResult, linkClosed } from "./jsonrpc.js";
+import type { HandleResult, JsonRpcHandler } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
 
 /**
@@ -77,6 +77,13 @@ export type ProxyHandle = {
  * - When either side closes, the other side is closed and its pending
  *   requests are rejected.
  *
+ * Each side processes messages one at a time in arrival order, matching the
+ * Rust SDK's dispatch loop: the next message is not dispatched until the
+ * previous handler chain completes. A forwarded request releases the loop
+ * once it has been sent rather than holding it across the round trip (the
+ * Rust `forward_response_to` pattern), so a pending request never blocks
+ * later messages such as `session/cancel`.
+ *
  * Messages can be observed, rewritten, answered, or dropped before they are
  * forwarded by passing `fromClient` / `fromAgent` handlers; see
  * {@link ProxyOptions}.
@@ -93,12 +100,10 @@ export type ProxyHandle = {
  */
 export function proxy(options: ProxyOptions): ProxyHandle {
   const client: Connection = new Connection(options.client, [
-    ...(options.fromClient ?? []),
-    forwardTo(() => agent),
+    serialDispatch([...(options.fromClient ?? []), forwardTo(() => agent)]),
   ]);
   const agent: Connection = new Connection(options.agent, [
-    ...(options.fromAgent ?? []),
-    forwardTo(() => client),
+    serialDispatch([...(options.fromAgent ?? []), forwardTo(() => client)]),
   ]);
   linkClosed(client, agent);
 
@@ -114,25 +119,71 @@ export function proxy(options: ProxyOptions): ProxyHandle {
 }
 
 /**
+ * Runs one side's handler chain one message at a time, in arrival order.
+ *
+ * The underlying `Connection` dispatches each incoming message as its own
+ * async task, which would let chains with slow handlers overtake each other.
+ * The Rust SDK guarantees sequential dispatch, so the proxy provides the
+ * same: the next message is not dispatched until the previous chain settles.
+ * A handler that throws fails only its own message (the connection converts
+ * the error to a response or log line); the queue continues.
+ */
+function serialDispatch(handlers: JsonRpcHandler[]): JsonRpcHandler {
+  let queue: Promise<unknown> = Promise.resolve();
+  return {
+    handleMessage(message, cx) {
+      const result = queue.then(async (): Promise<HandleResult> => {
+        let current = message;
+        for (const handler of handlers) {
+          const outcome =
+            (await handler.handleMessage(current, cx)) ?? Handled.yes();
+          if (outcome.handled) {
+            return Handled.yes();
+          }
+          current = outcome.message ?? current;
+        }
+
+        // Unreachable: the forwarder at the end of the chain always handles.
+        return Handled.yes();
+      });
+      queue = result.catch(() => {});
+      return result;
+    },
+    describe: () => "proxy:serial-dispatch",
+  };
+}
+
+/**
  * Terminal handler for one proxy side: re-issues the incoming message on the
  * opposite connection and relays the response back. The two connections
  * reference each other, so the target is resolved lazily.
+ *
+ * Requests are forwarded split-phase: the outgoing request is sent
+ * synchronously (preserving send order), the response continuation is
+ * registered, and the dispatch queue is released immediately so the round
+ * trip never blocks later messages.
  */
 function forwardTo(target: () => Connection): JsonRpcHandler {
   return {
-    handleMessage: async (message) => {
-      if (message.kind === "request") {
-        const result = await target().sendRequest(
-          message.method,
-          message.params,
-          undefined,
-          { cancellationSignal: message.signal },
-        );
-        await message.responder.respond(result);
-      } else {
-        await target().sendNotification(message.method, message.params);
+    handleMessage(message) {
+      if (message.kind !== "request") {
+        return target()
+          .sendNotification(message.method, message.params)
+          .then(() => Handled.yes());
       }
 
+      const { responder } = message;
+      target()
+        .sendRequest(message.method, message.params, undefined, {
+          cancellationSignal: message.signal,
+        })
+        .then(
+          (result) => responder.respond(result),
+          (error) => responder.respondWithResult(errorToResult(error)),
+        )
+        // The response cannot be delivered when the caller's side is already
+        // closed; there is nowhere left to report it.
+        .catch(() => {});
       return Handled.yes();
     },
     describe: () => "proxy:forward",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -118,7 +118,9 @@ const CANCEL_REQUEST_METHOD = "$/cancel_request";
  */
 type RelayDrain = {
   track(work: Promise<unknown>): void;
+  trackRequest(response: Promise<unknown>, completion: Promise<unknown>): void;
   drain(): Promise<void>;
+  drainSettledRequests(): Promise<void>;
 };
 
 /**
@@ -344,7 +346,10 @@ export class ProxyBuilder {
           ),
         ),
       ],
-      { allowBatches: false },
+      {
+        allowBatches: false,
+        drainOnEof: () => clientDrain.drainSettledRequests(),
+      },
     );
     const agent: Connection = new Connection(
       streams.agent,
@@ -358,21 +363,31 @@ export class ProxyBuilder {
           ),
         ),
       ],
-      { allowBatches: false },
+      {
+        allowBatches: false,
+        drainOnEof: () => agentDrain.drainSettledRequests(),
+      },
     );
-    // When either side closes, let work forwarded to that side finish relaying
-    // its already-received result before closing the other connection. This is
-    // especially important on normal EOF: a response may have resolved the
-    // downstream request while an interceptor is still transforming it for the
-    // original caller. Explicitly closing the handle still closes both sides
-    // immediately below.
+    // Clean EOF is graceful: each Connection first drains the messages it
+    // accepted and its own writes. Then let work forwarded to that side finish
+    // relaying already-received results before draining and closing the other
+    // connection. Explicit, protocol, and transport-error closes propagate
+    // immediately instead of waiting on arbitrary interceptor work.
     void client.closed.then(async () => {
+      if (!client.closedByEof) {
+        agent.close(client.signal.reason);
+        return;
+      }
       await agentDrain.drain();
-      agent.close(client.signal.reason);
+      await agent.closeAfterDraining(client.signal.reason);
     });
     void agent.closed.then(async () => {
+      if (!agent.closedByEof) {
+        client.close(agent.signal.reason);
+        return;
+      }
       await clientDrain.drain();
-      client.close(agent.signal.reason);
+      await client.closeAfterDraining(agent.signal.reason);
     });
 
     return {
@@ -433,8 +448,9 @@ function register(
  * - `$/cancel_request` from the original caller is reissued with the request
  *   ID allocated on the target hop, and the eventual response (which may be a
  *   normal result) still settles the original request.
- * - When either side closes, already-forwarded work targeting that side is
- *   drained before the other side closes and rejects its remaining requests.
+ * - When either side reaches clean EOF, accepted messages and queued writes
+ *   are drained before the other side closes. Explicit, protocol, and
+ *   transport-error closes still propagate immediately.
  *
  * Each side processes messages one at a time in arrival order: the next
  * message is not dispatched until the previous handler completes. Request
@@ -489,8 +505,7 @@ function dispatcher(
     const { responder } = message;
     let released = false;
     let resolveReleased: (() => void) | undefined;
-    const completed = Promise.withResolvers<void>();
-    let completionTracked = false;
+    const completed = completion();
     const release = () => {
       released = true;
       resolveReleased?.();
@@ -514,11 +529,7 @@ function dispatcher(
               undefined,
               { cancellationSignal: message.signal },
             );
-            drain.track(sent);
-            if (!completionTracked) {
-              completionTracked = true;
-              drain.track(completed.promise);
-            }
+            drain.trackRequest(sent, completed.promise);
             release();
             return sent;
           },
@@ -552,7 +563,7 @@ function dispatcher(
     const run = registration.handler as (
       context: ProxyNotificationContext<unknown>,
     ) => MaybePromise<unknown>;
-    const completed = Promise.withResolvers<void>();
+    const completed = completion();
     let completionTracked = false;
     try {
       await run({
@@ -599,10 +610,13 @@ function dispatcher(
       // arrival order) and the loop is never held.
       if (message.kind === "request") {
         const { responder } = message;
-        const relayed = target()
-          .sendRequest(message.method, message.params, undefined, {
-            cancellationSignal: message.signal,
-          })
+        const sent = target().sendRequest(
+          message.method,
+          message.params,
+          undefined,
+          { cancellationSignal: message.signal },
+        );
+        const relayed = sent
           .then(
             (result) => responder.respond(result),
             (error) =>
@@ -613,7 +627,7 @@ function dispatcher(
           // The response cannot be delivered when the caller's side is
           // already closed; there is nowhere left to report it.
           .catch(() => {});
-        drain.track(relayed);
+        drain.trackRequest(sent, relayed);
       } else {
         // Write failures close the connection via the write queue; there is
         // no per-notification error to report.
@@ -634,22 +648,70 @@ function dispatcher(
 
 function relayDrain(): RelayDrain {
   const pending = new Set<Promise<void>>();
+  const requests = new Set<{
+    responseSettled: boolean;
+    completion: Promise<void>;
+  }>();
+
+  const track = (work: Promise<unknown>): Promise<void> => {
+    const settled = work.then(
+      () => {},
+      () => {},
+    );
+    pending.add(settled);
+    void settled.then(() => pending.delete(settled));
+    return settled;
+  };
 
   return {
     track(work) {
-      const settled = work.then(
-        () => {},
-        () => {},
+      track(work);
+    },
+    trackRequest(response, completion) {
+      const request = {
+        responseSettled: false,
+        completion: track(completion),
+      };
+      requests.add(request);
+      track(response);
+      void response.then(
+        () => {
+          request.responseSettled = true;
+        },
+        () => {
+          request.responseSettled = true;
+        },
       );
-      pending.add(settled);
-      void settled.then(() => pending.delete(settled));
+      void request.completion.then(() => requests.delete(request));
     },
     async drain() {
       while (pending.size > 0) {
         await Promise.all(pending);
       }
     },
+    async drainSettledRequests() {
+      // Let already-settled response reactions mark their request before the
+      // EOF cutoff is observed.
+      await Promise.resolve();
+      while (true) {
+        const completions = [...requests]
+          .filter((request) => request.responseSettled)
+          .map((request) => request.completion);
+        if (completions.length === 0) {
+          return;
+        }
+        await Promise.all(completions);
+      }
+    },
   };
+}
+
+function completion(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
 }
 
 /**

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,11 +1,232 @@
 import { Connection, Handled, errorToResult, linkClosed } from "./jsonrpc.js";
-import type { HandleResult, JsonRpcHandler } from "./jsonrpc.js";
+import type {
+  HandleResult,
+  IncomingNotification,
+  IncomingRequest,
+  JsonRpcHandler,
+  MaybePromise,
+} from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
+import type {
+  AgentNotificationParamsByMethod,
+  AgentRequestParamsByMethod,
+  AgentRequestResponsesByMethod,
+  ClientNotificationParamsByMethod,
+  ClientRequestParamsByMethod,
+  ClientRequestResponsesByMethod,
+  ParamsParser,
+} from "./acp.js";
 
 /**
- * Options for {@link proxy}.
+ * Context passed to a typed proxy request handler.
  */
-export type ProxyOptions = {
+export type ProxyRequestContext<Params, Response> = {
+  /**
+   * Method name of the intercepted request.
+   */
+  method: string;
+  /**
+   * Request params as received on the wire.
+   *
+   * Built-in method literals type the params for convenience, but the proxy
+   * does not validate or normalize them — schema validation happens at the
+   * destination app, and a proxy that re-parsed params would strip unknown
+   * extension fields from traffic it relays. Register with a parser when you
+   * want runtime validation.
+   */
+  params: Params;
+  /**
+   * Aborts when the caller cancels this request or the connection closes.
+   */
+  signal: AbortSignal;
+  /**
+   * Forwards the request to the other side and resolves with its response.
+   *
+   * Pass the received params to forward unchanged, or a modified copy to
+   * rewrite the request in flight. Cancellation by the original caller is
+   * propagated automatically.
+   */
+  forward(params: Params): Promise<Response>;
+};
+
+/**
+ * Typed proxy request handler: return the response for the intercepted
+ * request — usually `forward(params)`'s result, possibly modified, or your
+ * own response without calling `forward` at all. Throw a `RequestError` to
+ * answer with a specific JSON-RPC error.
+ */
+export type ProxyRequestHandler<Params, Response> = (
+  context: ProxyRequestContext<Params, Response>,
+) => MaybePromise<Response>;
+
+/**
+ * Context passed to a typed proxy notification handler.
+ */
+export type ProxyNotificationContext<Params> = {
+  /**
+   * Method name of the intercepted notification.
+   */
+  method: string;
+  /**
+   * Notification params as received on the wire (see
+   * {@link ProxyRequestContext.params} on validation).
+   */
+  params: Params;
+  /**
+   * Forwards the notification to the other side.
+   */
+  forward(params: Params): Promise<void>;
+};
+
+/**
+ * Typed proxy notification handler: call `forward(params)` to deliver the
+ * notification (possibly rewritten); returning without forwarding drops it.
+ */
+export type ProxyNotificationHandler<Params> = (
+  context: ProxyNotificationContext<Params>,
+) => MaybePromise<void>;
+
+type Registration = {
+  parse?: (params: unknown) => unknown;
+  handler: (context: never) => MaybePromise<unknown>;
+};
+
+/**
+ * Registration surface for one side of a proxy.
+ *
+ * `proxy().client` registers handlers for traffic arriving from the client
+ * (agent-bound methods such as `session/prompt`); `proxy().agent` registers
+ * handlers for traffic arriving from the agent (client-bound methods such as
+ * `session/request_permission`). The type parameters select the matching
+ * ByMethod maps so built-in method literals infer their params and response
+ * types, mirroring `agent(...)`/`client(...)` registration.
+ *
+ * Handlers claim their method: at most one typed handler runs per message.
+ * Register `"*"` to catch traffic no exact registration claims
+ * (most-specific wins); anything still unclaimed is forwarded untouched.
+ */
+export class ProxySideBuilder<
+  RequestParams extends Record<string, unknown>,
+  RequestResponses extends Record<string, unknown>,
+  NotificationParams extends Record<string, unknown>,
+> {
+  private readonly rawHandlers: JsonRpcHandler[] = [];
+  private readonly requests = new Map<string, Registration>();
+  private readonly notifications = new Map<string, Registration>();
+
+  /** @internal */
+  constructor() {}
+
+  /**
+   * Registers a typed handler for requests arriving from this side's peer.
+   *
+   * Built-in method literals infer their params and response types from
+   * `method`. Pass a parser as the second argument for custom extension
+   * methods or to opt into runtime validation. Register `"*"` to catch any
+   * request no exact registration claims.
+   */
+  onRequest<Method extends keyof RequestParams & string>(
+    method: Method,
+    handler: ProxyRequestHandler<
+      RequestParams[Method],
+      Method extends keyof RequestResponses ? RequestResponses[Method] : never
+    >,
+  ): this;
+  onRequest(method: "*", handler: ProxyRequestHandler<unknown, unknown>): this;
+  onRequest<Params, Response>(
+    method: string,
+    params: ParamsParser<Params>,
+    handler: ProxyRequestHandler<Params, Response>,
+  ): this;
+  onRequest(
+    method: string,
+    handlerOrParams:
+      ((context: never) => MaybePromise<unknown>) | ParamsParser<unknown>,
+    handler?: (context: never) => MaybePromise<unknown>,
+  ): this {
+    this.register(this.requests, "request", method, handlerOrParams, handler);
+    return this;
+  }
+
+  /**
+   * Registers a typed handler for notifications arriving from this side's
+   * peer. Same registration forms as `onRequest`.
+   */
+  onNotification<Method extends keyof NotificationParams & string>(
+    method: Method,
+    handler: ProxyNotificationHandler<NotificationParams[Method]>,
+  ): this;
+  onNotification(method: "*", handler: ProxyNotificationHandler<unknown>): this;
+  onNotification<Params>(
+    method: string,
+    params: ParamsParser<Params>,
+    handler: ProxyNotificationHandler<Params>,
+  ): this;
+  onNotification(
+    method: string,
+    handlerOrParams:
+      ((context: never) => MaybePromise<unknown>) | ParamsParser<unknown>,
+    handler?: (context: never) => MaybePromise<unknown>,
+  ): this {
+    this.register(
+      this.notifications,
+      "notification",
+      method,
+      handlerOrParams,
+      handler,
+    );
+    return this;
+  }
+
+  /**
+   * Adds a raw JSON-RPC handler that sees every message from this side's
+   * peer before typed handlers run. Raw handlers use `Handled` semantics:
+   * pass messages through (possibly replaced) with `Handled.no(message)` or
+   * consume them with `Handled.yes()`.
+   */
+  withHandler(handler: JsonRpcHandler): this {
+    this.rawHandlers.push(handler);
+    return this;
+  }
+
+  private register(
+    table: Map<string, Registration>,
+    kind: "request" | "notification",
+    method: string,
+    handlerOrParams: object | ((context: never) => MaybePromise<unknown>),
+    handler?: (context: never) => MaybePromise<unknown>,
+  ): void {
+    if (table.has(method)) {
+      throw new Error(`Proxy ${kind} handler already registered: ${method}`);
+    }
+
+    if (handler) {
+      const parser = handlerOrParams as ParamsParser<unknown>;
+      const parse =
+        typeof parser === "function" ? parser : parser.parse.bind(parser);
+      table.set(method, { parse, handler });
+      return;
+    }
+
+    table.set(method, {
+      handler: handlerOrParams as (context: never) => MaybePromise<unknown>,
+    });
+  }
+
+  /** @internal */
+  buildChain(target: () => Connection): JsonRpcHandler[] {
+    return [
+      ...this.rawHandlers,
+      typedDispatch(this.requests, this.notifications, target),
+      forwardTo(target),
+    ];
+  }
+}
+
+/**
+ * Streams accepted by `ProxyBuilder.connect(...)`.
+ */
+export type ProxyStreams = {
   /**
    * Stream connected to the client side. The proxy presents as an agent on
    * this stream.
@@ -16,26 +237,10 @@ export type ProxyOptions = {
    * this stream.
    */
   agent: Stream;
-  /**
-   * Handlers run on messages arriving from the client, in order, before the
-   * proxy forwards them to the agent.
-   *
-   * Return `Handled.no(message)` with a replacement message to rewrite a
-   * request or notification in flight. Return `Handled.yes()` after
-   * responding through `message.responder` to intercept a request without
-   * the agent ever seeing it (for example to deny it). Handlers that return
-   * `Handled.no()` without a replacement pass the message through untouched.
-   */
-  fromClient?: JsonRpcHandler[];
-  /**
-   * Handlers run on messages arriving from the agent, in order, before the
-   * proxy forwards them to the client. Same contract as `fromClient`.
-   */
-  fromAgent?: JsonRpcHandler[];
 };
 
 /**
- * Handle to a running proxy returned by {@link proxy}.
+ * Handle to a running proxy returned by `ProxyBuilder.connect(...)`.
  */
 export type ProxyHandle = {
   /**
@@ -57,18 +262,70 @@ export type ProxyHandle = {
 };
 
 /**
- * Runs an ACP proxy between a client stream and an agent stream.
+ * Builder for an ACP proxy between a client stream and an agent stream.
  *
- * The proxy terminates the protocol on both sides: each side is a full
- * JSON-RPC connection, so forwarded requests are re-issued with the proxy's
- * own request ids and their responses are correlated back to the original
- * caller automatically. This works in both directions — client-initiated
- * requests such as `session/prompt` flow toward the agent, and
- * agent-initiated requests such as `session/request_permission` flow toward
- * the client.
+ * Register handlers on `client` (traffic from the client) and `agent`
+ * (traffic from the agent), then call `connect(...)`.
+ */
+export class ProxyBuilder {
+  /**
+   * Registration surface for traffic arriving from the client — agent-bound
+   * methods, typed by the agent request/notification maps.
+   */
+  readonly client = new ProxySideBuilder<
+    AgentRequestParamsByMethod,
+    AgentRequestResponsesByMethod,
+    AgentNotificationParamsByMethod
+  >();
+
+  /**
+   * Registration surface for traffic arriving from the agent — client-bound
+   * methods, typed by the client request/notification maps.
+   */
+  readonly agent = new ProxySideBuilder<
+    ClientRequestParamsByMethod,
+    ClientRequestResponsesByMethod,
+    ClientNotificationParamsByMethod
+  >();
+
+  /**
+   * Connects the proxy between the two streams and starts relaying.
+   */
+  connect(streams: ProxyStreams): ProxyHandle {
+    const client: Connection = new Connection(streams.client, [
+      serialDispatch(this.client.buildChain(() => agent)),
+    ]);
+    const agent: Connection = new Connection(streams.agent, [
+      serialDispatch(this.agent.buildChain(() => client)),
+    ]);
+    linkClosed(client, agent);
+
+    return {
+      client,
+      agent,
+      closed: Promise.all([client.closed, agent.closed]).then(() => {}),
+      close(error?: unknown): void {
+        client.close(error);
+        agent.close(error);
+      },
+    };
+  }
+}
+
+/**
+ * Creates an ACP proxy builder.
  *
- * Forwarding preserves the observable protocol behavior of a direct
- * connection:
+ * A proxy sits between a client and an agent, intercepting messages in both
+ * directions — this mirrors the Rust SDK's `Proxy` role. The proxy
+ * terminates the protocol on both sides: each side is a full JSON-RPC
+ * connection, so forwarded requests are re-issued with the proxy's own
+ * request ids and their responses are correlated back to the original
+ * caller automatically. Client-initiated requests such as `session/prompt`
+ * flow toward the agent, and agent-initiated requests such as
+ * `session/request_permission` flow toward the client.
+ *
+ * Messages that no handler claims are forwarded untouched, preserving the
+ * observable protocol behavior of a direct connection:
  *
  * - Error responses pass through with their original code, message, and data.
  * - `$/cancel_request` from the original caller is propagated to the side
@@ -79,42 +336,117 @@ export type ProxyHandle = {
  *
  * Each side processes messages one at a time in arrival order, matching the
  * Rust SDK's dispatch loop: the next message is not dispatched until the
- * previous handler chain completes. A forwarded request releases the loop
- * once it has been sent rather than holding it across the round trip (the
- * Rust `forward_response_to` pattern), so a pending request never blocks
- * later messages such as `session/cancel`.
+ * previous handler completes. Request handlers release the loop as soon as
+ * they forward (or settle without forwarding) rather than holding it across
+ * the round trip — the Rust `forward_response_to` pattern — so a pending
+ * request never blocks later messages such as `session/cancel`.
  *
- * Messages can be observed, rewritten, answered, or dropped before they are
- * forwarded by passing `fromClient` / `fromAgent` handlers; see
- * {@link ProxyOptions}.
+ * The `_proxy/successor` envelope protocol used by the Rust conductor to
+ * chain proxy processes over a single pipe is not needed here — this proxy
+ * owns a real stream per side, so proxies chain by connecting one proxy's
+ * agent stream to the next proxy's client stream.
  *
- * This mirrors the Rust SDK's `Proxy` role: a proxy sits between a client
- * and an agent, intercepting messages in both directions; messages it does
- * not handle are forwarded by default, and handlers intercept traffic from
- * an explicit peer (`fromClient` / `fromAgent`, like the Rust builder's
- * `on_receive_request_from(Client | Agent, ...)`). The
- * `_proxy/successor` envelope protocol used by the Rust conductor to chain
- * proxy processes over a single pipe is not needed here — this proxy owns a
- * real stream per side, so proxies chain by connecting one proxy's agent
- * stream to the next proxy's client stream.
+ * @example
+ * ```ts
+ * const p = proxy();
+ * p.client.onRequest("session/prompt", async ({ params, forward }) => {
+ *   audit(params);
+ *   return forward(params);
+ * });
+ * p.agent.onNotification("session/update", async ({ params, forward }) => {
+ *   if (!redacted(params)) await forward(params);
+ * });
+ * const handle = p.connect({ client: clientStream, agent: agentStream });
+ * ```
  */
-export function proxy(options: ProxyOptions): ProxyHandle {
-  const client: Connection = new Connection(options.client, [
-    serialDispatch([...(options.fromClient ?? []), forwardTo(() => agent)]),
-  ]);
-  const agent: Connection = new Connection(options.agent, [
-    serialDispatch([...(options.fromAgent ?? []), forwardTo(() => client)]),
-  ]);
-  linkClosed(client, agent);
+export function proxy(): ProxyBuilder {
+  return new ProxyBuilder();
+}
+
+/**
+ * Chain handler dispatching typed registrations and the fallback.
+ *
+ * Unregistered traffic returns `Handled.no` so the terminal forwarder
+ * relays it untouched. Request handlers run detached from the dispatch
+ * queue once they forward: the returned promise resolves when the request
+ * has been forwarded or answered — not when the handler finishes waiting on
+ * the round trip — so the loop keeps its ordering guarantee without a
+ * pending request blocking later messages.
+ */
+function typedDispatch(
+  requests: Map<string, Registration>,
+  notifications: Map<string, Registration>,
+  target: () => Connection,
+): JsonRpcHandler {
+  const runRequest = (
+    message: IncomingRequest,
+    run: (
+      context: ProxyRequestContext<unknown, unknown>,
+    ) => MaybePromise<unknown>,
+    parse?: (params: unknown) => unknown,
+  ): Promise<HandleResult> => {
+    const released = Promise.withResolvers<void>();
+    void (async () => {
+      try {
+        const response = await run({
+          method: message.method,
+          params: parse ? parse(message.params) : message.params,
+          signal: message.signal,
+          forward: (params: unknown) => {
+            const sent = target().sendRequest(
+              message.method,
+              params,
+              undefined,
+              { cancellationSignal: message.signal },
+            );
+            released.resolve();
+            return sent;
+          },
+        });
+        await message.responder.respond(response ?? null);
+      } catch (error) {
+        await message.responder
+          .respondWithResult(errorToResult(error))
+          .catch(() => {});
+      } finally {
+        released.resolve();
+      }
+    })();
+    return released.promise.then(() => Handled.yes());
+  };
+
+  const runNotification = async (
+    message: IncomingNotification,
+    run: (context: ProxyNotificationContext<unknown>) => MaybePromise<unknown>,
+    parse?: (params: unknown) => unknown,
+  ): Promise<HandleResult> => {
+    await run({
+      method: message.method,
+      params: parse ? parse(message.params) : message.params,
+      forward: (params: unknown) =>
+        target().sendNotification(message.method, params),
+    });
+    return Handled.yes();
+  };
 
   return {
-    client,
-    agent,
-    closed: Promise.all([client.closed, agent.closed]).then(() => {}),
-    close(error?: unknown): void {
-      client.close(error);
-      agent.close(error);
+    handleMessage(message) {
+      const table = message.kind === "request" ? requests : notifications;
+      // Most-specific wins: an exact method registration beats "*", and "*"
+      // catches only otherwise-unclaimed traffic.
+      const registration = table.get(message.method) ?? table.get("*");
+      if (!registration) {
+        return Handled.no(message);
+      }
+
+      const run = registration.handler as (
+        context: unknown,
+      ) => MaybePromise<unknown>;
+      return message.kind === "request"
+        ? runRequest(message, run, registration.parse)
+        : runNotification(message, run, registration.parse);
     },
+    describe: () => "proxy:typed-dispatch",
   };
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -316,24 +316,35 @@ export class ProxyBuilder {
   connect(streams: ProxyStreams): ProxyHandle {
     // Snapshot so registrations made after connect(...) apply only to
     // subsequent connects — the same semantics as the fluent app builders.
-    const client: Connection = new Connection(streams.client, [
-      serialize(
-        dispatcher(
-          new Map(this.clientRequests),
-          new Map(this.clientNotifications),
-          () => agent,
+    // Batches are rejected on both sides (as on every stable v1 connection):
+    // relaying batch entries individually would silently drop batch framing,
+    // and batch relay is not part of this proxy's contract.
+    const client: Connection = new Connection(
+      streams.client,
+      [
+        serialize(
+          dispatcher(
+            new Map(this.clientRequests),
+            new Map(this.clientNotifications),
+            () => agent,
+          ),
         ),
-      ),
-    ]);
-    const agent: Connection = new Connection(streams.agent, [
-      serialize(
-        dispatcher(
-          new Map(this.agentRequests),
-          new Map(this.agentNotifications),
-          () => client,
+      ],
+      { allowBatches: false },
+    );
+    const agent: Connection = new Connection(
+      streams.agent,
+      [
+        serialize(
+          dispatcher(
+            new Map(this.agentRequests),
+            new Map(this.agentNotifications),
+            () => client,
+          ),
         ),
-      ),
-    ]);
+      ],
+      { allowBatches: false },
+    );
     // When either side closes, close the other with the same reason so its
     // pending requests reject with the true cause.
     void client.closed.then(() => agent.close(client.signal.reason));
@@ -384,6 +395,11 @@ function register(
  * `session/prompt` flow toward the agent, and agent-initiated requests such
  * as `session/request_permission` flow toward the client. The design
  * matches the `Proxy` role in ACP's other SDKs.
+ *
+ * The proxy is scoped to stable ACP v1 connections: like every v1
+ * connection, its sides reject JSON-RPC batch wire messages by closing with
+ * an error. Proxying the experimental batch-capable v2 transport is not
+ * supported.
  *
  * Messages that no handler claims are forwarded untouched, preserving the
  * observable protocol behavior of a direct connection:

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -110,7 +110,6 @@ export class ProxySideBuilder<
   RequestResponses extends Record<string, unknown>,
   NotificationParams extends Record<string, unknown>,
 > {
-  private readonly rawHandlers: JsonRpcHandler[] = [];
   private readonly requests = new Map<string, Registration>();
   private readonly notifications = new Map<string, Registration>();
 
@@ -178,17 +177,6 @@ export class ProxySideBuilder<
     return this;
   }
 
-  /**
-   * Adds a raw JSON-RPC handler that sees every message from this side's
-   * peer before typed handlers run. Raw handlers use `Handled` semantics:
-   * pass messages through (possibly replaced) with `Handled.no(message)` or
-   * consume them with `Handled.yes()`.
-   */
-  withHandler(handler: JsonRpcHandler): this {
-    this.rawHandlers.push(handler);
-    return this;
-  }
-
   private register(
     table: Map<string, Registration>,
     kind: "request" | "notification",
@@ -216,7 +204,6 @@ export class ProxySideBuilder<
   /** @internal */
   buildChain(target: () => Connection): JsonRpcHandler[] {
     return [
-      ...this.rawHandlers,
       typedDispatch(this.requests, this.notifications, target),
       forwardTo(target),
     ];
@@ -240,19 +227,35 @@ export type ProxyStreams = {
 };
 
 /**
+ * One side of a running proxy.
+ */
+export type ProxySideConnection = {
+  /**
+   * Promise that resolves when this side's connection closes.
+   */
+  readonly closed: Promise<void>;
+  /**
+   * Closes this side. The other side is closed with the same reason.
+   */
+  close(error?: unknown): void;
+};
+
+/**
  * Handle to a running proxy returned by `ProxyBuilder.connect(...)`.
  */
 export type ProxyHandle = {
   /**
-   * Connection facing the client stream. Requests sent here go to the client.
+   * The side facing the client stream.
    */
-  readonly client: Connection;
+  readonly client: ProxySideConnection;
   /**
-   * Connection facing the agent stream. Requests sent here go to the agent.
+   * The side facing the agent stream.
    */
-  readonly agent: Connection;
+  readonly agent: ProxySideConnection;
   /**
-   * Promise that resolves once both sides of the proxy have closed.
+   * Promise that resolves once both sides of the proxy have closed. Either
+   * side closing (for example the client stream ending) closes the other,
+   * propagating the close reason to its pending requests.
    */
   readonly closed: Promise<void>;
   /**

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,4 @@
-import { Connection, Handled, linkClosed, parseParams } from "./jsonrpc.js";
+import { Connection, Handled, errorToRequestResult } from "./jsonrpc.js";
 import type {
   HandleResult,
   IncomingMessage,
@@ -6,7 +6,6 @@ import type {
   IncomingRequest,
   JsonRpcHandler,
   MaybePromise,
-  ParamsParser,
 } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
 import type {
@@ -20,6 +19,7 @@ import type {
   ClientRequestMethod,
   ClientRequestParamsByMethod,
   ClientRequestResponsesByMethod,
+  ParamsParser,
 } from "./acp.js";
 
 /**
@@ -106,7 +106,7 @@ export type ProxyNotificationHandler<Params> = (
 type ErasedHandler = (context: never) => MaybePromise<unknown>;
 
 type Registration = {
-  params?: ParamsParser<unknown>;
+  parse?: (params: unknown) => unknown;
   handler: ErasedHandler;
 };
 
@@ -328,7 +328,10 @@ export class ProxyBuilder {
         ),
       ),
     ]);
-    linkClosed(client, agent);
+    // When either side closes, close the other with the same reason so its
+    // pending requests reject with the true cause.
+    void client.closed.then(() => agent.close(client.signal.reason));
+    void agent.closed.then(() => client.close(agent.signal.reason));
 
     return {
       client,
@@ -353,8 +356,9 @@ function register(
   }
 
   if (handler) {
+    const parser = handlerOrParams as ParamsParser<unknown>;
     table.set(method, {
-      params: handlerOrParams as ParamsParser<unknown>,
+      parse: typeof parser === "function" ? parser : (p) => parser.parse(p),
       handler,
     });
     return;
@@ -449,7 +453,9 @@ function dispatcher(
       try {
         const response = await run({
           method: message.method,
-          params: parseParams(registration.params, message.params),
+          params: registration.parse
+            ? registration.parse(message.params)
+            : message.params,
           signal: message.signal,
           forward: (params: unknown) => {
             const sent = target().sendRequest(
@@ -464,7 +470,9 @@ function dispatcher(
         });
         await responder.respond(response ?? null);
       } catch (error) {
-        await responder.respondWithThrown(error).catch(() => {});
+        await responder
+          .respondWithResult(errorToRequestResult(error, message.signal))
+          .catch(() => {});
       } finally {
         release();
       }
@@ -490,7 +498,9 @@ function dispatcher(
     ) => MaybePromise<unknown>;
     await run({
       method: message.method,
-      params: parseParams(registration.params, message.params),
+      params: registration.parse
+        ? registration.parse(message.params)
+        : message.params,
       forward: (params: unknown) =>
         target().sendNotification(message.method, params),
     });
@@ -514,7 +524,10 @@ function dispatcher(
           })
           .then(
             (result) => responder.respond(result),
-            (error) => responder.respondWithThrown(error),
+            (error) =>
+              responder.respondWithResult(
+                errorToRequestResult(error, message.signal),
+              ),
           )
           // The response cannot be delivered when the caller's side is
           // already closed; there is nowhere left to report it.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -50,10 +50,13 @@ export type ProxyRequestContext<Params, Response> = {
 };
 
 /**
- * Typed proxy request handler: return the response for the intercepted
- * request — usually `forward(params)`'s result, possibly modified, or your
- * own response without calling `forward` at all. Throw a `RequestError` to
- * answer with a specific JSON-RPC error.
+ * Typed proxy request handler.
+ *
+ * The caller is waiting on a response, so the handler must produce one:
+ * return `forward(params)`'s result (unchanged or modified) to relay the
+ * request, return your own response without calling `forward` to answer in
+ * the proxy, or throw a `RequestError` to reject with a specific JSON-RPC
+ * error. Unlike notifications, a request can never be silently dropped.
  */
 export type ProxyRequestHandler<Params, Response> = (
   context: ProxyRequestContext<Params, Response>,
@@ -79,8 +82,13 @@ export type ProxyNotificationContext<Params> = {
 };
 
 /**
- * Typed proxy notification handler: call `forward(params)` to deliver the
- * notification (possibly rewritten); returning without forwarding drops it.
+ * Typed proxy notification handler.
+ *
+ * Call `forward(params)` to deliver the notification to the other side,
+ * unchanged or rewritten. Returning without calling `forward` drops the
+ * notification: it is never delivered, and — as with any JSON-RPC
+ * notification — neither side is told, which makes skipping `forward` the
+ * intentional way to filter traffic.
  */
 export type ProxyNotificationHandler<Params> = (
   context: ProxyNotificationContext<Params>,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -26,12 +26,12 @@ export type ProxyOptions = {
    * the agent ever seeing it (for example to deny it). Handlers that return
    * `Handled.no()` without a replacement pass the message through untouched.
    */
-  clientToAgent?: JsonRpcHandler[];
+  fromClient?: JsonRpcHandler[];
   /**
    * Handlers run on messages arriving from the agent, in order, before the
-   * proxy forwards them to the client. Same contract as `clientToAgent`.
+   * proxy forwards them to the client. Same contract as `fromClient`.
    */
-  agentToClient?: JsonRpcHandler[];
+  fromAgent?: JsonRpcHandler[];
 };
 
 /**
@@ -78,11 +78,14 @@ export type ProxyHandle = {
  *   requests are rejected.
  *
  * Messages can be observed, rewritten, answered, or dropped before they are
- * forwarded by passing `clientToAgent` / `agentToClient` handlers; see
+ * forwarded by passing `fromClient` / `fromAgent` handlers; see
  * {@link ProxyOptions}.
  *
- * This mirrors the Rust SDK's `Proxy` role: unhandled messages forward by
- * default, and handlers intercept traffic from an explicit peer. The
+ * This mirrors the Rust SDK's `Proxy` role: a proxy sits between a client
+ * and an agent, intercepting messages in both directions; messages it does
+ * not handle are forwarded by default, and handlers intercept traffic from
+ * an explicit peer (`fromClient` / `fromAgent`, like the Rust builder's
+ * `on_receive_request_from(Client | Agent, ...)`). The
  * `_proxy/successor` envelope protocol used by the Rust conductor to chain
  * proxy processes over a single pipe is not needed here — this proxy owns a
  * real stream per side, so proxies chain by connecting one proxy's agent
@@ -90,11 +93,11 @@ export type ProxyHandle = {
  */
 export function proxy(options: ProxyOptions): ProxyHandle {
   const client: Connection = new Connection(options.client, [
-    ...(options.clientToAgent ?? []),
+    ...(options.fromClient ?? []),
     forwardTo(() => agent),
   ]);
   const agent: Connection = new Connection(options.agent, [
-    ...(options.agentToClient ?? []),
+    ...(options.fromAgent ?? []),
     forwardTo(() => client),
   ]);
   linkClosed(client, agent);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -350,13 +350,13 @@ export class ProxyBuilder {
  * Creates an ACP proxy builder.
  *
  * A proxy sits between a client and an agent, intercepting messages in both
- * directions — this mirrors the Rust SDK's `Proxy` role. The proxy
- * terminates the protocol on both sides: each side is a full JSON-RPC
- * connection, so forwarded requests are re-issued with the proxy's own
- * request ids and their responses are correlated back to the original
- * caller automatically. Client-initiated requests such as `session/prompt`
- * flow toward the agent, and agent-initiated requests such as
- * `session/request_permission` flow toward the client.
+ * directions. The proxy terminates the protocol on both sides: each side is
+ * a full JSON-RPC connection, so forwarded requests are re-issued with the
+ * proxy's own request ids and their responses are correlated back to the
+ * original caller automatically. Client-initiated requests such as
+ * `session/prompt` flow toward the agent, and agent-initiated requests such
+ * as `session/request_permission` flow toward the client. The design
+ * matches the `Proxy` role in ACP's other SDKs.
  *
  * Messages that no handler claims are forwarded untouched, preserving the
  * observable protocol behavior of a direct connection:
@@ -368,17 +368,14 @@ export class ProxyBuilder {
  * - When either side closes, the other side is closed and its pending
  *   requests are rejected.
  *
- * Each side processes messages one at a time in arrival order, matching the
- * Rust SDK's dispatch loop: the next message is not dispatched until the
- * previous handler completes. Request handlers release the loop as soon as
- * they forward (or settle without forwarding) rather than holding it across
- * the round trip — the Rust `forward_response_to` pattern — so a pending
+ * Each side processes messages one at a time in arrival order: the next
+ * message is not dispatched until the previous handler completes. Request
+ * handlers release the loop as soon as they forward (or settle without
+ * forwarding) rather than holding it across the round trip, so a pending
  * request never blocks later messages such as `session/cancel`.
  *
- * The `_proxy/successor` envelope protocol used by the Rust conductor to
- * chain proxy processes over a single pipe is not needed here — this proxy
- * owns a real stream per side, so proxies chain by connecting one proxy's
- * agent stream to the next proxy's client stream.
+ * Proxies chain by connecting one proxy's agent stream to the next proxy's
+ * client stream.
  *
  * @example
  * ```ts
@@ -524,11 +521,11 @@ function dispatcher(
 
 /**
  * Serializes one side's dispatch: messages run one at a time, in arrival
- * order, matching the Rust SDK's dispatch loop. The underlying `Connection`
- * dispatches each message as its own async task, which would let slow
- * handlers be overtaken. Synchronous dispatches (pass-through traffic,
- * handlers that forward immediately) bypass the queue entirely; a rejected
- * dispatch fails only its own message.
+ * order. The underlying `Connection` dispatches each message as its own
+ * async task, which would let slow handlers be overtaken. Synchronous
+ * dispatches (pass-through traffic, handlers that forward immediately)
+ * bypass the queue entirely; a rejected dispatch fails only its own
+ * message.
  */
 function serialize(
   dispatch: (message: IncomingMessage) => MaybePromise<HandleResult>,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,4 @@
-import { Connection, Handled } from "./jsonrpc.js";
+import { Connection, Handled, linkClosed } from "./jsonrpc.js";
 import type { JsonRpcHandler } from "./jsonrpc.js";
 import type { Stream } from "./stream.js";
 
@@ -89,10 +89,34 @@ export type ProxyHandle = {
  * stream to the next proxy's client stream.
  */
 export function proxy(options: ProxyOptions): ProxyHandle {
-  // Each side's handler chain ends in a forwarder that re-issues the message
-  // on the opposite connection. The connections reference each other, so the
-  // forwarders resolve their target lazily.
-  const forwardTo = (target: () => Connection): JsonRpcHandler => ({
+  const client: Connection = new Connection(options.client, [
+    ...(options.clientToAgent ?? []),
+    forwardTo(() => agent),
+  ]);
+  const agent: Connection = new Connection(options.agent, [
+    ...(options.agentToClient ?? []),
+    forwardTo(() => client),
+  ]);
+  linkClosed(client, agent);
+
+  return {
+    client,
+    agent,
+    closed: Promise.all([client.closed, agent.closed]).then(() => {}),
+    close(error?: unknown): void {
+      client.close(error);
+      agent.close(error);
+    },
+  };
+}
+
+/**
+ * Terminal handler for one proxy side: re-issues the incoming message on the
+ * opposite connection and relays the response back. The two connections
+ * reference each other, so the target is resolved lazily.
+ */
+function forwardTo(target: () => Connection): JsonRpcHandler {
+  return {
     handleMessage: async (message) => {
       if (message.kind === "request") {
         const result = await target().sendRequest(
@@ -109,29 +133,5 @@ export function proxy(options: ProxyOptions): ProxyHandle {
       return Handled.yes();
     },
     describe: () => "proxy:forward",
-  });
-
-  const client: Connection = new Connection(options.client, [
-    ...(options.clientToAgent ?? []),
-    forwardTo(() => agent),
-  ]);
-  const agent: Connection = new Connection(options.agent, [
-    ...(options.agentToClient ?? []),
-    forwardTo(() => client),
-  ]);
-
-  // When either side closes, close the other with the same reason so its
-  // pending requests reject with the true cause.
-  void client.closed.then(() => agent.close(client.signal.reason));
-  void agent.closed.then(() => client.close(agent.signal.reason));
-
-  return {
-    client,
-    agent,
-    closed: Promise.all([client.closed, agent.closed]).then(() => {}),
-    close(error?: unknown): void {
-      client.close(error);
-      agent.close(error);
-    },
   };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,7 +7,7 @@ import type {
   JsonRpcHandler,
   MaybePromise,
 } from "./jsonrpc.js";
-import type { Stream } from "./stream.js";
+import type { Stream } from "./acp.js";
 import type {
   AgentNotificationMethod,
   AgentNotificationParamsByMethod,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -334,40 +334,38 @@ export class ProxyBuilder {
     // and batch relay is not part of this proxy's contract.
     const clientDrain = relayDrain();
     const agentDrain = relayDrain();
+    const clientDispatcher = serialize(
+      dispatcher(
+        new Map(this.clientRequests),
+        new Map(this.clientNotifications),
+        () => agent,
+        clientDrain,
+        () => agentDispatcher.notificationsDispatched(),
+      ),
+      clientDrain,
+    );
+    const agentDispatcher = serialize(
+      dispatcher(
+        new Map(this.agentRequests),
+        new Map(this.agentNotifications),
+        () => client,
+        agentDrain,
+        () => clientDispatcher.notificationsDispatched(),
+      ),
+      agentDrain,
+    );
     const client: Connection = new Connection(
       streams.client,
-      [
-        serialize(
-          dispatcher(
-            new Map(this.clientRequests),
-            new Map(this.clientNotifications),
-            () => agent,
-            clientDrain,
-          ),
-        ),
-      ],
+      [clientDispatcher],
       {
         allowBatches: false,
         drainOnEof: () => clientDrain.drainSettledRequests(),
       },
     );
-    const agent: Connection = new Connection(
-      streams.agent,
-      [
-        serialize(
-          dispatcher(
-            new Map(this.agentRequests),
-            new Map(this.agentNotifications),
-            () => client,
-            agentDrain,
-          ),
-        ),
-      ],
-      {
-        allowBatches: false,
-        drainOnEof: () => agentDrain.drainSettledRequests(),
-      },
-    );
+    const agent: Connection = new Connection(streams.agent, [agentDispatcher], {
+      allowBatches: false,
+      drainOnEof: () => agentDrain.drainSettledRequests(),
+    });
     // Clean EOF is graceful: each Connection first drains the messages it
     // accepted and its own writes. Then let work forwarded to that side finish
     // relaying already-received results before draining and closing the other
@@ -502,6 +500,7 @@ function dispatcher(
   notifications: Map<string, Registration>,
   target: () => Connection,
   drain: RelayDrain,
+  notificationsDispatched: () => Promise<unknown>,
 ): (message: IncomingMessage) => MaybePromise<HandleResult> {
   const runRequest = (
     message: IncomingRequest,
@@ -510,7 +509,9 @@ function dispatcher(
     const { responder } = message;
     let released = false;
     let resolveReleased: (() => void) | undefined;
+    let precedingNotifications: Promise<unknown> | undefined;
     const completed = completion();
+    drain.track(completed.promise);
     const release = () => {
       released = true;
       resolveReleased?.();
@@ -534,13 +535,19 @@ function dispatcher(
               undefined,
               { cancellationSignal: message.signal },
             );
+            const captureNotifications = () => {
+              precedingNotifications = notificationsDispatched();
+            };
+            void sent.then(captureNotifications, captureNotifications);
             drain.trackRequest(sent, completed.promise);
             release();
             return sent;
           },
         });
+        await precedingNotifications;
         await responder.respond(response ?? null);
       } catch (error) {
+        await precedingNotifications;
         await responder
           .respondWithResult(errorToRequestResult(error, message.signal))
           .catch(() => {});
@@ -623,11 +630,16 @@ function dispatcher(
         );
         const relayed = sent
           .then(
-            (result) => responder.respond(result),
-            (error) =>
-              responder.respondWithResult(
+            async (result) => {
+              await notificationsDispatched();
+              await responder.respond(result);
+            },
+            async (error) => {
+              await notificationsDispatched();
+              await responder.respondWithResult(
                 errorToRequestResult(error, message.signal),
-              ),
+              );
+            },
           )
           // The response cannot be delivered when the caller's side is
           // already closed; there is nowhere left to report it.
@@ -729,9 +741,11 @@ function completion(): { promise: Promise<void>; resolve(): void } {
  */
 function serialize(
   dispatch: (message: IncomingMessage) => MaybePromise<HandleResult>,
-): JsonRpcHandler {
+  drain: RelayDrain,
+): JsonRpcHandler & { notificationsDispatched(): Promise<unknown> } {
   let pending = 0;
   let tail: Promise<unknown> = Promise.resolve();
+  let notificationTail: Promise<unknown> = tail;
 
   const track = (result: Promise<HandleResult>): Promise<HandleResult> => {
     pending++;
@@ -748,13 +762,27 @@ function serialize(
 
   return {
     handleMessage(message) {
+      let result: MaybePromise<HandleResult>;
       if (pending === 0) {
-        const result = dispatch(message);
-        return result instanceof Promise ? track(result) : result;
+        result = dispatch(message);
+        if (result instanceof Promise) {
+          track(result);
+        }
+      } else {
+        result = track(tail.then(() => dispatch(message)));
       }
 
-      return track(tail.then(() => dispatch(message)));
+      if (message.kind === "request") {
+        if (result instanceof Promise) {
+          drain.track(result);
+        }
+      } else if (message.method !== CANCEL_REQUEST_METHOD) {
+        notificationTail = tail;
+      }
+
+      return result;
     },
+    notificationsDispatched: () => notificationTail,
     describe: () => "proxy:dispatch",
   };
 }


### PR DESCRIPTION
## What this adds

**`proxy()`** — a builder for ACP intermediaries that sit between a client and an agent: authorization gates, audit logs, message filters/transformers, and session routers. It is the TypeScript counterpart of the Rust SDK's `Proxy` role.

A proxy connects two streams. Unclaimed messages are semantically relayed without runtime validation or normalization; handlers can inspect, rewrite, answer, or drop selected traffic:

```ts
const handle = proxy()
  // Traffic arriving FROM THE CLIENT (agent-bound methods):
  .onRequestFromClient("session/prompt", async ({ params, forward }) => {
    // `params` is typed as PromptRequest, inferred from the method literal.
    audit(params);

    // A request handler must produce the response. Three choices:
    return forward(params);                  // 1. forward as-is (or forward a modified copy)
    // return { stopReason: "refusal" };     // 2. answer yourself; the agent never sees the request
    // throw RequestError.authRequired();    // 3. reject; the client gets this JSON-RPC error
  })
  // Traffic arriving FROM THE AGENT (client-bound methods):
  .onNotificationFromAgent("session/update", async ({ params, forward }) => {
    // A notification has no response, so the choice is simpler:
    // call forward(params) to deliver it, or return without calling forward
    // to drop it — the client never receives it, and (as with any JSON-RPC
    // notification) no one is notified that it was dropped.
    if (isVisibleToThisViewer(params)) {
      await forward(params);
    }
  })
  .connect({ client: clientStream, agent: agentStream });
```

Three registration forms, matching the `agent(...)`/`client(...)` builders:

| Form | Example | Params type |
|---|---|---|
| Built-in method literal | `onRequestFromClient("session/prompt", h)` | Inferred (for example, `PromptRequest`) |
| Parser (extension methods) | `onRequestFromClient("_my/ext", zMyParams, h)` | From the parser |
| Wildcard fallback | `onRequestFromClient("*", h)` | `unknown` |

`"*"` catches only methods with no exact registration (most-specific wins). Anything not claimed by a handler is relayed without schema parsing, including protocol methods added after the proxy was written.

Also included: `src/examples/proxy.ts`, a runnable snoop proxy that wraps any agent command and logs traffic in both directions.

## Why

Anyone building an ACP intermediary today has to work with raw streams and reimplement request/response correlation, cancellation propagation, error passthrough, and coordinated teardown. `proxy()` terminates the protocol on both sides — each side is a full JSON-RPC connection internally — so those mechanics live in the SDK.

Requests receive a new hop-local ID when reissued to the target. A source `$/cancel_request` is therefore consumed and reissued from the forwarded request's abort signal using that target ID; the source notification is never copied across with a potentially unrelated ID.

The Rust SDK already ships this concept. This PR matches the same model:

| Behavior | Meaning | Rust equivalent |
|---|---|---|
| Typed interception | Handlers get typed params per method | Type-driven `on_receive_request_from(Client, ...)` |
| Wildcard | `"*"` catches unclaimed traffic | `UntypedMessage` (matches any method) |
| Default relay | Unregistered messages cross without schema normalization | Same |
| Sequential dispatch | Each side handles messages in arrival order | Documented dispatch-loop guarantee |
| Non-blocking round trips | A forwarded request releases the loop, so a pending `session/prompt` cannot block a later cancellation | `forward_response_to` |
| Pre-validation interception | Handlers see wire params; validation happens at the destination | Same |
| Graceful EOF | Accepted proxy dispatch, already-settled response continuations, and queued writes finish before EOF propagates | Incoming dispatch completes before EOF observation; outgoing sink drains |

Explicit closes and protocol/transport failures still tear down promptly rather than waiting for arbitrary interceptor work. Clean EOF aborts request-scoped signals before waiting for accepted proxy dispatch, so an interceptor using its documented signal cannot deadlock shutdown. It also does not wait for a remote round trip that never produced a response.

The proxy is deliberately scoped to stable ACP v1. Both sides reject JSON-RPC batch wire messages; relaying experimental v2 batches entry-by-entry would lose their framing, so v2 batch proxying remains unsupported rather than becoming accidental API behavior.

One deliberate choice to highlight: **the relay path never runtime-parses**. Typed literals type params at compile time only. Runtime Zod parsing strips unknown keys, so reparsing relayed messages could silently delete `_meta` and experimental fields. Authors who want runtime validation use the parser form.

## Deliberately small public surface

New root exports are `proxy` and its related types (`ProxyBuilder` is exported type-only; `proxy()` is the sole factory). The lower-level JSON-RPC `Connection`, its EOF/drain state, and relay bookkeeping remain internal and are stripped from published declarations.

Naming note: registration methods carry their direction (`onRequestFromClient` means requests arriving *from* the client, i.e. agent-bound methods). `connect(...)` snapshots registrations, matching the `agent(...)`/`client(...)` builders: later registrations apply only to subsequent connections. Mid-session behavior changes belong in handler closure state.

Decisions especially worth review:

1. `"*"` as a fallback method key (most-specific wins) versus a separate `onFallback(...)` method.
2. Registering the same method twice throws because the second claim could never run.
3. `forward(params)` requires its argument, so rewrites are explicit.
4. `ProxyHandle` sides expose `signal`/`closed`/`close`, matching the fluent `AcpConnection` shape; `signal.reason` carries the propagated close reason.
5. Registration snapshots match the other fluent builders rather than creating a live mutable handler set.

## Verification

- 45 proxy tests cover both directions, errors, hop-local cancellation translation, parser failures, ordering, out-of-order response correlation, chaining, multi-connect, stable-v1 batch rejection, source/target EOF teardown, and duplicate request IDs.
- A lower-level `Connection` regression verifies that ordinary EOF promptly aborts request and connection-context signals.
- Stress runs cover backpressured writes, settled and unresolved forwarded requests, delayed interceptors, prompt abrupt-close preemption, request handlers waiting on their abort signal, and duplicate-ID teardown.
- `npm run check` passes: generation, lint, formatting, spellcheck, build, 978 tests, and TypeDoc verification.

Proxy-owned connections opt into an internal two-phase EOF path: abort request-scoped work, drain accepted proxy dispatch and queued writes, then close. Ordinary SDK connections preserve immediate EOF cancellation, and explicit, protocol, transport, and write errors remain immediate and authoritative.
