### PR TITLE
fix(v2): enforce absolute protocol paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check generated sources
+        run: npm run generate:check
+
       - name: Check formatting
         run: npm run format:check
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ export default [
       "*.config.js",
       ".github/",
       "src/schema.ts",
+      "src/docs/",
       "src/.schema-*/",
     ],
   },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "test": "vitest run",
     "generate": "node scripts/generate.js",
+    "generate:check": "node scripts/generate.js --skip-download --check",
     "build": "tsc",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -73,7 +74,7 @@
     "lint:fix": "eslint --fix",
     "spellcheck": "./scripts/spellcheck.sh",
     "spellcheck:fix": "./scripts/spellcheck.sh --write-changes",
-    "check": "npm run lint && npm run format:check && npm run spellcheck && npm run build && npm run test && npm run docs:ts:verify",
+    "check": "npm run generate:check && npm run lint && npm run format:check && npm run spellcheck && npm run build && npm run test && npm run docs:ts:verify",
     "docs:ts:build": "cd src && typedoc --options typedoc.json && typedoc --options typedoc.v2.json && echo 'TypeScript documentation generated in ./src/docs'",
     "docs:ts:verify": "cd src && typedoc --options typedoc.json --emit none && typedoc --options typedoc.v2.json --emit none && echo 'TypeDoc verification passed'"
   },

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -12,6 +12,7 @@ import * as prettier from "prettier";
 
 const CURRENT_V1_SCHEMA_RELEASE = "schema-v1.20.0";
 const CURRENT_V2_SCHEMA_RELEASE = "schema-v2.0.0-alpha.2";
+const CHECK_GENERATED = process.argv.includes("--check");
 
 // ── Extensible-union pipeline ────────────────────────────────────────────────
 // Several schemas model forward compatibility as an "extensible union": known
@@ -109,16 +110,22 @@ async function main() {
   }
 
   for (const config of SCHEMA_CONFIGS) {
-    await generateSchema(config);
+    await generateSchema(config, CHECK_GENERATED);
   }
 }
 
-async function generateSchema(config) {
+async function generateSchema(config, checkGenerated) {
   const metadata = JSON.parse(await fs.readFile(config.metadataPath, "utf8"));
 
   const schemaSrc = await fs.readFile(config.schemaPath, "utf8");
   const jsonSchema = JSON.parse(
     schemaSrc.replaceAll("#/$defs/", "#/components/schemas/"),
+  );
+  assertMetadataMatchesSchema(
+    metadata,
+    jsonSchema.$defs,
+    config.name,
+    Number.parseInt(config.openApiVersion, 10),
   );
   addExperimentalTags(jsonSchema);
   stripAnyOfDiscriminators(jsonSchema);
@@ -241,6 +248,19 @@ export const PROTOCOL_VERSION = ${metadata.version};
     await formatStable(`${indexSrc.replace(/\s*ClientOptions,/, "")}\n${meta}`),
   );
 
+  if (checkGenerated) {
+    const drift = await compareGeneratedDirectories(schemaDir, stagingDir);
+    await fs.rm(stagingDir, { recursive: true, force: true });
+    if (drift.length > 0) {
+      throw new Error(
+        `[${config.name}] Generated sources are stale:\n` +
+          `${drift.map((change) => `  ${change}`).join("\n")}\n` +
+          "Run `npm run generate -- --skip-download` and commit the result.",
+      );
+    }
+    return;
+  }
+
   // Rename-aside swap: a valid src/schema exists at every instant, so an
   // interruption strands at worst an ignored dot-directory, never a missing
   // schema. (ENOENT: a fresh checkout may have no schema dir to set aside.)
@@ -250,6 +270,136 @@ export const PROTOCOL_VERSION = ${metadata.version};
   });
   await fs.rename(stagingDir, schemaDir);
   await fs.rm(previousDir, { recursive: true, force: true });
+}
+
+function assertMetadataMatchesSchema(
+  metadata,
+  schemaDefs,
+  lane,
+  expectedVersion,
+) {
+  if (metadata.version !== expectedVersion) {
+    throw new Error(
+      `[${lane}] Expected metadata protocol version ${expectedVersion}, ` +
+        `found ${JSON.stringify(metadata.version)}`,
+    );
+  }
+
+  const schemaMethods = {
+    agent: new Set(),
+    client: new Set(),
+    protocol: new Set(),
+  };
+  for (const [name, schema] of Object.entries(schemaDefs)) {
+    const method = schema["x-method"];
+    const side = schema["x-side"];
+    if (method === undefined) continue;
+    if (typeof method !== "string") {
+      throw new Error(
+        `[${lane}] ${name} has a non-string x-method: ${JSON.stringify(method)}`,
+      );
+    }
+
+    if (side === "both") {
+      schemaMethods.agent.add(method);
+      schemaMethods.client.add(method);
+    } else if (side in schemaMethods) {
+      schemaMethods[side].add(method);
+    } else {
+      throw new Error(
+        `[${lane}] ${name} has x-method ${JSON.stringify(method)} but an ` +
+          `unsupported x-side: ${JSON.stringify(side)}`,
+      );
+    }
+  }
+
+  const metadataMethods = {
+    agent: metadataMethodSet(metadata.agentMethods, lane, "agentMethods"),
+    client: metadataMethodSet(metadata.clientMethods, lane, "clientMethods"),
+    protocol: metadataMethodSet(
+      metadata.protocolMethods,
+      lane,
+      "protocolMethods",
+    ),
+  };
+
+  for (const side of Object.keys(schemaMethods)) {
+    const missing = [...schemaMethods[side]]
+      .filter((method) => !metadataMethods[side].has(method))
+      .sort();
+    const extra = [...metadataMethods[side]]
+      .filter((method) => !schemaMethods[side].has(method))
+      .sort();
+    if (missing.length > 0 || extra.length > 0) {
+      throw new Error(
+        `[${lane}] ${side} method metadata does not match schema x-methods.` +
+          `${missing.length > 0 ? `\n  missing: ${missing.join(", ")}` : ""}` +
+          `${extra.length > 0 ? `\n  extra: ${extra.join(", ")}` : ""}`,
+      );
+    }
+  }
+}
+
+function metadataMethodSet(value, lane, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`[${lane}] Metadata ${field} must be an object`);
+  }
+  const methods = Object.values(value);
+  if (!methods.every((method) => typeof method === "string")) {
+    throw new Error(`[${lane}] Metadata ${field} values must all be strings`);
+  }
+  if (new Set(methods).size !== methods.length) {
+    throw new Error(`[${lane}] Metadata ${field} contains duplicate methods`);
+  }
+  return new Set(methods);
+}
+
+async function compareGeneratedDirectories(expectedDir, generatedDir) {
+  const expected = await readDirectoryFiles(expectedDir);
+  const generated = await readDirectoryFiles(generatedDir);
+  const paths = [...new Set([...expected.keys(), ...generated.keys()])].sort();
+  const drift = [];
+
+  for (const path of paths) {
+    if (!expected.has(path)) {
+      drift.push(`added: ${path}`);
+    } else if (!generated.has(path)) {
+      drift.push(`removed: ${path}`);
+    } else if (!expected.get(path).equals(generated.get(path))) {
+      drift.push(`changed: ${path}`);
+    }
+  }
+
+  return drift;
+}
+
+async function readDirectoryFiles(root, relative = "") {
+  const files = new Map();
+  const entries = await fs.readdir(`${root}/${relative}`, {
+    withFileTypes: true,
+  });
+
+  for (const entry of entries.sort((left, right) =>
+    left.name.localeCompare(right.name),
+  )) {
+    const path = relative ? `${relative}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      for (const [childPath, contents] of await readDirectoryFiles(
+        root,
+        path,
+      )) {
+        files.set(childPath, contents);
+      }
+    } else if (entry.isFile()) {
+      files.set(path, await fs.readFile(`${root}/${path}`));
+    } else {
+      throw new Error(
+        `Unsupported generated filesystem entry: ${root}/${path}`,
+      );
+    }
+  }
+
+  return files;
 }
 
 // Formats until prettier reaches a fixed point. Prettier's member-chain

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -88,6 +88,7 @@ const SCHEMA_CONFIGS = [
     stagingDir: "./src/.schema-v2-staging",
     previousDir: "./src/.schema-v2-previous",
     schemaDeserializeImport: "../../schema-deserialize.js",
+    absolutePathImport: "../absolute-path.js",
     expectedExtensibleUnions: V2_EXTENSIBLE_UNIONS,
     openApiVersion: "2.0.0",
     releaseTag: CURRENT_V2_SCHEMA_RELEASE,
@@ -183,6 +184,13 @@ async function generateSchema(config, checkGenerated) {
   // behavior that isn't in the schema descriptions: custom variants bypass
   // the lenient-field salvage known variants get.
   let zodDocs = updateDocs(zodSrc, schemaDefs);
+  if (config.absolutePathImport) {
+    zodDocs = addAbsolutePathValidation(
+      zodDocs,
+      config.absolutePathImport,
+      config.name,
+    );
+  }
   for (const [name, exclusion] of defExclusions) {
     zodDocs = appendDocNote(
       zodDocs,
@@ -212,15 +220,17 @@ async function generateSchema(config, checkGenerated) {
 
   const tsPath = `${stagingDir}/types.gen.ts`;
   const tsSrc = await fs.readFile(tsPath, "utf8");
-  const ts = await formatStable(
-    updateDocs(
-      tsSrc.replace(
-        `export type ClientOptions`,
-        `// eslint-disable-next-line @typescript-eslint/no-unused-vars\ntype ClientOptions`,
-      ),
-      schemaDefs,
+  let tsDocs = updateDocs(
+    tsSrc.replace(
+      `export type ClientOptions`,
+      `// eslint-disable-next-line @typescript-eslint/no-unused-vars\ntype ClientOptions`,
     ),
+    schemaDefs,
   );
+  if (config.absolutePathImport) {
+    tsDocs = addAbsolutePathBrand(tsDocs, config.name);
+  }
+  const ts = await formatStable(tsDocs);
   await fs.writeFile(tsPath, ts);
 
   // Always write the file: the staging swap replaces the whole directory, so
@@ -416,6 +426,46 @@ async function formatStable(source) {
   throw new Error(
     "prettier did not reach a formatting fixed point after 3 passes; " +
       "the generated output would fail format:check",
+  );
+}
+
+function addAbsolutePathValidation(source, importPath, lane) {
+  const zodImport = source.match(/import \* as z from ["']zod\/v4["'];/)?.[0];
+  const absolutePathSchema = "export const zAbsolutePath = z.string();";
+  if (!zodImport || !source.includes(absolutePathSchema)) {
+    throw new Error(
+      `[${lane}] Could not attach absolute-path validation to generated Zod schemas`,
+    );
+  }
+
+  return source
+    .replace(
+      zodImport,
+      `import { isAbsolutePath } from ${JSON.stringify(importPath)};\n` +
+        `import type { AbsolutePath } from "./types.gen.js";\n` +
+        `${zodImport}`,
+    )
+    .replace(
+      absolutePathSchema,
+      `export const zAbsolutePath = z.string().refine(isAbsolutePath, {\n` +
+        `  message: "Expected an absolute filesystem path",\n` +
+        `}).transform((value) => value as AbsolutePath);`,
+    );
+}
+
+function addAbsolutePathBrand(source, lane) {
+  const absolutePathType = "export type AbsolutePath = string;";
+  if (!source.includes(absolutePathType)) {
+    throw new Error(
+      `[${lane}] Could not brand the generated AbsolutePath type`,
+    );
+  }
+
+  return source.replace(
+    absolutePathType,
+    `export type AbsolutePath = string & {\n` +
+      `  readonly __brand: "AbsolutePath";\n` +
+      `};`,
   );
 }
 

--- a/src/examples/dual-version-agent.ts
+++ b/src/examples/dual-version-agent.ts
@@ -44,7 +44,7 @@ type V2Turn = {
 };
 
 type V2Session = {
-  cwd: string;
+  cwd: v2.AbsolutePath;
   active: boolean;
   history: v2.SessionUpdate[];
   turn?: V2Turn;

--- a/src/v2/absolute-path.test.ts
+++ b/src/v2/absolute-path.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { absolutePath, isAbsolutePath } from "./absolute-path.js";
+import { zAbsolutePath } from "./schema/zod.gen.js";
+import type { AbsolutePath } from "./schema/types.gen.js";
+
+const typedAbsolutePath: AbsolutePath = absolutePath("/workspace");
+const parsedAbsolutePath: AbsolutePath = zAbsolutePath.parse("/workspace");
+// @ts-expect-error Raw strings must be validated before use as protocol paths.
+const unvalidatedAbsolutePath: AbsolutePath = "/workspace";
+void typedAbsolutePath;
+void parsedAbsolutePath;
+void unvalidatedAbsolutePath;
+
+describe("absolute protocol paths", () => {
+  it.each([
+    "/",
+    "/tmp/project",
+    "C:\\",
+    "C:\\Users\\agent\\project",
+    "D:/projects/acp",
+    "\\\\server\\share",
+    "\\\\server/share/directory",
+    "//server/share/directory",
+    "\\\\?\\C:\\long\\path",
+  ])("accepts %s", (value) => {
+    expect(isAbsolutePath(value)).toBe(true);
+    expect(absolutePath(value)).toBe(value);
+    expect(zAbsolutePath.parse(value)).toBe(value);
+  });
+
+  it.each([
+    "",
+    ".",
+    "./project",
+    "../project",
+    "tmp/project",
+    "C:relative",
+    "\\rooted-without-drive",
+    "~/project",
+    "/tmp/\0project",
+  ])("rejects %s", (value) => {
+    expect(isAbsolutePath(value)).toBe(false);
+    expect(() => absolutePath(value)).toThrow(TypeError);
+    expect(zAbsolutePath.safeParse(value).success).toBe(false);
+  });
+});

--- a/src/v2/absolute-path.ts
+++ b/src/v2/absolute-path.ts
@@ -1,0 +1,35 @@
+import type { AbsolutePath } from "./schema/types.gen.js";
+
+const WINDOWS_DRIVE_ABSOLUTE_PATH = /^[A-Za-z]:[\\/]/;
+const WINDOWS_UNC_ABSOLUTE_PATH = /^\\\\[^\\/]+[\\/][^\\/]+(?:[\\/].*)?$/;
+
+/**
+ * Returns whether a string is an absolute POSIX, Windows drive, or Windows UNC
+ * filesystem path. The check is host-independent so ACP messages can be
+ * validated while crossing operating-system boundaries.
+ *
+ * @experimental
+ */
+export function isAbsolutePath(value: string): value is AbsolutePath {
+  if (value.includes("\0")) return false;
+  return (
+    value.startsWith("/") ||
+    WINDOWS_DRIVE_ABSOLUTE_PATH.test(value) ||
+    WINDOWS_UNC_ABSOLUTE_PATH.test(value)
+  );
+}
+
+/**
+ * Validates and returns an absolute protocol path.
+ *
+ * @throws {TypeError} If `value` is not an absolute filesystem path.
+ * @experimental
+ */
+export function absolutePath(value: string): AbsolutePath {
+  if (!isAbsolutePath(value)) {
+    throw new TypeError(
+      `Expected an absolute filesystem path, received ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}

--- a/src/v2/acp.test.ts
+++ b/src/v2/acp.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   PROTOCOL_VERSION,
   agent,
+  absolutePath,
   batchNotification,
   batchRequest,
   client,
@@ -129,7 +130,7 @@ describe("experimental v2 app API", () => {
     const stdioServer = {
       type: "stdio",
       name: "stdio-server",
-      command: "/usr/bin/example-mcp",
+      command: absolutePath("/usr/bin/example-mcp"),
       args,
       env,
       _meta: stdioMeta,
@@ -150,9 +151,9 @@ describe("experimental v2 app API", () => {
       settings: customSettings,
     } satisfies McpServer;
 
-    const additionalDirectories = ["/workspace/other"];
+    const additionalDirectories = [absolutePath("/workspace/other")];
     const request = {
-      cwd: "/workspace",
+      cwd: absolutePath("/workspace"),
       additionalDirectories,
       mcpServers: [httpServer, stdioServer, acpServer, customServer],
       _meta: requestMeta,
@@ -162,7 +163,7 @@ describe("experimental v2 app API", () => {
     await client().connectWith(agent(), (agentClient) => {
       const builder = agentClient.buildSession(request);
 
-      additionalDirectories[0] = "/mutated-input";
+      additionalDirectories[0] = absolutePath("/mutated-input");
       requestMeta.nested.value = "mutated-input";
       httpServer.name = "mutated-input";
       headers[0].value = "mutated-input";
@@ -179,7 +180,7 @@ describe("experimental v2 app API", () => {
       expect(builder.toRequest()).toEqual(expected);
 
       const returned = builder.toRequest();
-      returned.additionalDirectories![0] = "/mutated-output";
+      returned.additionalDirectories![0] = absolutePath("/mutated-output");
       (returned._meta as NestedMeta).nested.value = "mutated-output";
 
       const returnedHttp = returned.mcpServers![0] as typeof httpServer;
@@ -217,7 +218,7 @@ describe("experimental v2 app API", () => {
     const mcpServer = {
       type: "stdio",
       name: "stdio-server",
-      command: "/usr/bin/example-mcp",
+      command: absolutePath("/usr/bin/example-mcp"),
       args,
       env,
       _meta: serverMeta,
@@ -226,7 +227,7 @@ describe("experimental v2 app API", () => {
 
     await client().connectWith(agent(), (agentClient) => {
       const builder = agentClient
-        .buildSession("/workspace")
+        .buildSession(absolutePath("/workspace"))
         .withMcpServer(mcpServer);
 
       args[0] = "mutated-input";
@@ -285,7 +286,9 @@ describe("experimental v2 app API", () => {
         }),
       ).resolves.toMatchObject({ protocolVersion: PROTOCOL_VERSION });
 
-      const session = await agentClient.buildSession("/workspace").start();
+      const session = await agentClient
+        .buildSession(absolutePath("/workspace"))
+        .start();
       try {
         await updateClient!.notify(methods.client.session.update, {
           sessionId: session.sessionId,
@@ -363,7 +366,9 @@ describe("experimental v2 app API", () => {
         protocolVersion: PROTOCOL_VERSION,
         info: clientInfo,
       });
-      const session = await agentClient.buildSession("/workspace").start();
+      const session = await agentClient
+        .buildSession(absolutePath("/workspace"))
+        .start();
       try {
         const first = session.prompt("First");
         const firstText = session.readText();
@@ -420,7 +425,9 @@ describe("experimental v2 app API", () => {
         protocolVersion: PROTOCOL_VERSION,
         info: clientInfo,
       });
-      const session = await agentClient.buildSession("/workspace").start();
+      const session = await agentClient
+        .buildSession(absolutePath("/workspace"))
+        .start();
       try {
         await session.prompt("Hello");
         const text = session.readText();
@@ -489,7 +496,9 @@ describe("experimental v2 app API", () => {
         protocolVersion: PROTOCOL_VERSION,
         info: clientInfo,
       });
-      const session = await agentClient.buildSession("/workspace").start();
+      const session = await agentClient
+        .buildSession(absolutePath("/workspace"))
+        .start();
       try {
         await session.prompt("First");
         for (const update of [

--- a/src/v2/acp.ts
+++ b/src/v2/acp.ts
@@ -16,6 +16,7 @@ import * as validate from "./schema/zod.gen.js";
 import * as guards from "./schema/guards.gen.js";
 import { ndJsonStream as createJsonStream } from "../stream.js";
 export type * from "./schema/types.gen.js";
+export { absolutePath, isAbsolutePath } from "./absolute-path.js";
 // Runtime narrowing helpers for extensible unions, exposed as companion values
 // that merge (declaration merging) with the like-named types — e.g.
 // `CreateElicitationResponse.isAccept(response)`. See schema/guards.gen.ts.

--- a/src/v2/schema/types.gen.ts
+++ b/src/v2/schema/types.gen.ts
@@ -688,7 +688,9 @@ export type DiffFileType = "text" | "binary" | "directory" | "symlink" | string;
 /**
  * An absolute filesystem path used by the protocol.
  */
-export type AbsolutePath = string;
+export type AbsolutePath = string & {
+  readonly __brand: "AbsolutePath";
+};
 
 /**
  * Operation metadata for add, delete, and modify changes.

--- a/src/v2/schema/zod.gen.ts
+++ b/src/v2/schema/zod.gen.ts
@@ -7,6 +7,8 @@ import {
   requiredDefaultOnError,
   vecSkipError,
 } from "../../schema-deserialize.js";
+import { isAbsolutePath } from "../absolute-path.js";
+import type { AbsolutePath } from "./types.gen.js";
 import * as z from "zod/v4";
 
 /**
@@ -312,7 +314,12 @@ export const zDiffFileType = z.union([
 /**
  * An absolute filesystem path used by the protocol.
  */
-export const zAbsolutePath = z.string();
+export const zAbsolutePath = z
+  .string()
+  .refine(isAbsolutePath, {
+    message: "Expected an absolute filesystem path",
+  })
+  .transform((value) => value as AbsolutePath);
 
 /**
  * Operation metadata for add, delete, and modify changes.


### PR DESCRIPTION
## Summary

- brand generated experimental-v2 AbsolutePath values so raw strings cannot enter typed outbound calls or handler responses
- add a host-independent constructor and type guard for POSIX, Windows drive, and UNC paths
- validate inbound absolute paths in generated Zod schemas
- keep the generator authoritative for both the branded type and runtime validator

This changes only the existing experimental v2 surface. It should land after the generated-source gate PR because both update the generator.

## Testing

- npm run generate -- --skip-download
- npm run check (870 tests)